### PR TITLE
Add Toby Fox's new (2022-10-31) website

### DIFF
--- a/artists.yaml
+++ b/artists.yaml
@@ -4123,6 +4123,7 @@ Artist: Toby Fox
 URLs:
 - https://tobyfox.bandcamp.com/
 - https://twitter.com/tobyfox
+- https://toby.fangamer.com/
 ---
 Artist: Toe
 ---


### PR DESCRIPTION
(it's https://toby.fangamer.com/)