### PR TITLE
Add additional files!

### DIFF
--- a/album/ancestral.yaml
+++ b/album/ancestral.yaml
@@ -45,6 +45,9 @@ Banner Artists:
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Ancestral Album Booklet.pdf
 - Title: Bandcamp Banner
   Files:
   - banner_anc.png

--- a/album/bee-forus-seatbelt-safebee.yaml
+++ b/album/bee-forus-seatbelt-safebee.yaml
@@ -25,6 +25,15 @@ Art Tags:
 - Bees
 - Beforus
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Seatbelt Safebee -OFFICIAL- Booklet.pdf
+- Title: Alternate Artwork (DLC)
+  Files:
+  - 00 (cover alt).png
+  - 00 (cover alt 2).png
+  - 00 (banner).png
+  - 05 (old).png  
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -40,6 +40,9 @@ Banner Artists:
 Banner Dimensions: 1100x203
 Banner File Extension: png
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Beforus Official Commentary Booklet.pdf
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/cool-and-new-volume-2.yaml
+++ b/album/cool-and-new-volume-2.yaml
@@ -20,6 +20,10 @@ Color: '#fa6006'
 Groups:
 - Cool and New Music Team
 - Fandom
+Additional Files:
+- Title: Album Booklet
+  Files:
+  - Cool and New Volume 2.pdf
 Commentary: |-
     <i>Cool and New Music Team:</i>
     i'ts album fro cool and new web comic................................................agian!?!

--- a/album/cool-and-new-volume-ii.yaml
+++ b/album/cool-and-new-volume-ii.yaml
@@ -49,6 +49,10 @@ Color: '#ff8a84'
 Groups:
 - Cool and New Music Team
 - Fandom
+Additional Files:
+- Title: Album Booklet
+  Files:
+  - Cool and New Volume II.pdf
 Commentary: |-
     <i>Cool and New Music Team:</i>
     i'ts album fro cool and new web comic

--- a/album/cosmic-caretakers.yaml
+++ b/album/cosmic-caretakers.yaml
@@ -55,6 +55,9 @@ Banner File Extension: png
 Wallpaper Artists:
 - Elanor Pam
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Cosmic_Caretakers_Booklet.pdf
 - Title: Bandcamp Banner and Background
   Files:
   - banner.png

--- a/album/friendsymphony.yaml
+++ b/album/friendsymphony.yaml
@@ -22,8 +22,11 @@ Wallpaper Style: 'opacity: 0.8;'
 Additional Files:
 - Title: Bandcamp Banner and Background
   Files:
-  - banner.png
-  - bg.jpg
+  - bcbanner.png
+  - bctheme.png
+- Title: Credits
+  Files:
+  - additional_credits.txt
 ---
 Group: Disc 1
 ---

--- a/album/gristmas-carols.yaml
+++ b/album/gristmas-carols.yaml
@@ -34,6 +34,9 @@ Wallpaper Style: 'opacity: 0.65;'
 Wallpaper Artists:
 - Ephemerald
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Gristmas Carols.pdf
 - Title: Bandcamp Banner and Background
   Files:
   - banner.png

--- a/album/jailbreak-vol-1.yaml
+++ b/album/jailbreak-vol-1.yaml
@@ -19,6 +19,13 @@ Banner Style: |-
     image-rendering: pixelated;
     image-rendering: crisp-edges;
 Additional Files:
+- Title: NES Sound Format Files
+  Files:
+  - Logorg.nsf
+  - Bars.nsf
+  - Drillgorg.nsf
+  - Nick Smalley - Retrobution.nsf
+  - aboutthosethings.txt
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/lofam.yaml
+++ b/album/lofam.yaml
@@ -54,9 +54,15 @@ Banner Artists:
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Commentary Booklet.pdf
 - Title: Bandcamp Banner
   Files:
   - banner.png
+- Title: Site Banner
+  Files:
+  - banner_alt.png
 ---
 Track: Beginnings (Press Start to Play)
 Artists:

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -14,6 +14,12 @@ Groups:
 - Unofficial MSPA Fans
 - Fandom
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - LOFAM2_Commentary_Booklet.pdf
+- Title: Art for the Project (DLC) (bonus art only)
+  Files:
+  - lofam2_artwork.zip
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/lofam3.yaml
+++ b/album/lofam3.yaml
@@ -36,6 +36,20 @@ Banner Artists:
 Banner Dimensions: 1100x203
 Banner File Extension: png
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - LoFaM 3 - Commentary Booklet.pdf
+- Title: Garden of Eden Full Version & Sheet Music (DLC)
+  Files:
+  - Garden of Eden (FULL Version) [Lofam3].mp3
+  - Garden of Eden - Full Score.pdf
+- Title: Disc 2 Cover Wallpaper (DLC)
+  Files:
+  - Together_at_last_1900_x_1200.png
+  - Together_at_last_1024_x_768.png
+- Title: sord... NEWF AND IMPROVD (DLC)
+  Files:
+  - sord.mp3
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/lofam4.yaml
+++ b/album/lofam4.yaml
@@ -45,6 +45,19 @@ Wallpaper Artists:
 - Sozzay
 Wallpaper Style: 'opacity: 0.65;'
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - LOFAM 4 Booklet.pdf
+- Title: Bonus Artwork (DLC)
+  Files:
+  - '[Circlejourney] Bonus.png'
+  - '[Circlejourney] Bonus 2.png'
+  - '[Facetious & Friends] Bonus.jpg'
+  - '[Griever] Bonus 2.png'
+  - '[insecureIllustrator] Bonus.png'
+  - '[Shadok123] Bonus.png'
+  - '[Trufflemeep] Bonus.png'
+  - '[tti] Bonus.png'
 - Title: Bandcamp Banner and Background
   Files:
   - banner.png

--- a/album/lofam5.yaml
+++ b/album/lofam5.yaml
@@ -35,6 +35,9 @@ Wallpaper Style: 'opacity: 0.9;'
 Wallpaper File Extension: png
 Track Art File Extension: png
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - LOFAM 5 Booklet.pdf
 - Title: Bandcamp Banner and Background
   Files:
   - banner.png

--- a/album/moons-of-theseus.yaml
+++ b/album/moons-of-theseus.yaml
@@ -24,6 +24,9 @@ Wallpaper Style: |-
     opacity: 0.4;
     background-position: center 30%;
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Moons of Theseus Booklet.pdf
 - Title: Bandcamp Banner and Background
   Files:
   - banner.png

--- a/album/sburb-ost.yaml
+++ b/album/sburb-ost.yaml
@@ -21,6 +21,16 @@ Banner Artists:
 Banner Dimensions: 1100x203
 Banner File Extension: png
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Sburb OST - Commentary Booklet.pdf
+- Title: Audio Commentary (DLC)
+  Files:
+  - commentary1.mp3
+  - commentary2.mp3
+- Title: Layers Upon Layers Remix by Jamie Paige Stanley, Lyrics/Vocals by VeritasUnae (DLC)
+  Files:
+  - 57 Build Gate (Swag Gate) ft VeritasUnae -DLC-.mp3
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/team-paradox.yaml
+++ b/album/team-paradox.yaml
@@ -15,6 +15,9 @@ Color: '#c25b6d'
 Groups:
 - Fandom
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - Commentary.pdf
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/album/the-baby-is-you.yaml
+++ b/album/the-baby-is-you.yaml
@@ -18,6 +18,10 @@ Art Tags:
 - John
 - Karkat
 - Dave
+Additional Files:
+- Title: Official Lyrics
+  Files:
+  - lyrics for queer dicks.txt
 Commentary: |-
     <i>Sanctferum:</i>
     (<i>From the Homestuck Sound Test 4/13/2017 Edition release notes:</i>)

--- a/album/weird-puzzle-tunes.yaml
+++ b/album/weird-puzzle-tunes.yaml
@@ -21,6 +21,9 @@ Banner Artists:
 Banner Dimensions: 1100x203
 Banner File Extension: png
 Additional Files:
+- Title: Bonus Artwork (DLC)
+  Files:
+  - Bonus by OpsCat.png
 - Title: Bandcamp Banner
   Files:
   - banner-wps.png

--- a/album/xenoplanetarium.yaml
+++ b/album/xenoplanetarium.yaml
@@ -38,6 +38,9 @@ Art Tags:
 - LoWaA
 - LoDaG
 Additional Files:
+- Title: Album Booklet
+  Files:
+  - xenoplanetarium.pdf
 - Title: Bandcamp Banner
   Files:
   - banner.png

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -25,7 +25,7 @@ Style: |-
 Content: |-
     <h2 id="12-jun-2077" class="major-release"><a href="#12-jun-2077">[[date:12 June 2077]] - (Preview changelog!)</a></h2>
     <h3>other additions</h3>
-    - added additional files to [[album:lofam]], [[album:jailbreak-vol-1]], [[album:the-baby-is-you]], [[album:cool-and-new-volume-2]], [[album:cool-and-new-volume-ii]], [[album:team-paradox]]
+    - added additional files to [[album:lofam]], [[album:lofam2]], [[album:lofam3]], [[album:lofam4]], [[album:lofam5]], [[album:jailbreak-vol-1]], [[album:sburb-ost]], [[album:beforus]], [[album:bee-forus-seatbelt-safebee]], [[album:weird-puzzle-tunes]], [[album:ancestral]], [[album:xenoplanetarium]], [[album:gristmas-carols]], [[album:cosmic-caretakers]], [[album:moons-of-theseus]], [[album:friendsymphony]], [[album:the-baby-is-you]], [[album:cool-and-new-volume-2]], [[album:cool-and-new-volume-ii]], and [[album:team-paradox]]
     <h2 id="05-jan-2023"><a href="#05-jan-2023">[[date:05 January 2023]] - picking up the ball</a></h2>
     <h3>site changes</h3>
     - slightly tweaked the homepage album selection

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -23,6 +23,9 @@ Style: |-
         margin-bottom: 0.6em;
     }
 Content: |-
+    <h2 id="12-jun-2077" class="major-release"><a href="#12-jun-2077">[[date:12 June 2077]] - (Preview changelog!)</a></h2>
+    <h3>other additions</h3>
+    - added additional files to [[album:lofam]], [[album:jailbreak-vol-1]], [[album:the-baby-is-you]], [[album:cool-and-new-volume-2]], [[album:cool-and-new-volume-ii]], [[album:team-paradox]]
     <h2 id="05-jan-2023"><a href="#05-jan-2023">[[date:05 January 2023]] - picking up the ball</a></h2>
     <h3>site changes</h3>
     - slightly tweaked the homepage album selection


### PR DESCRIPTION
- #105

*Partial* media update: https://mega.nz/folder/nFE02ZLR#BVauYA_ORSn_pyrqcduRlw
(This patch builds off the media patch for PR #92 that hasn't been merged yet, if that's an issue let me know and I can upload one that builds off upstream instead.)

Remember that https://github.com/hsmusic/hsmusic-wiki/issues/147 may cause apparent issues while testing.

Missing files for you to add:
-
- Album booklets: SBURB OST, LOFAM2, LOFAM3, Beforus, Ancestral, LOFAM4
    - These are all included in their respective album downloads but must be renamed to remove the leading `[artist name] - [album name] - [filename]` to just the actual filenames
- SBURB OST audio commentary
    - https://www.dropbox.com/s/eh8m3ssvwd4beb9/commentary1.mp3?dl=0
    - https://www.dropbox.com/s/co1zy51e3x301md/commentary2.mp3?dl=0