### PR TITLE
Add Requiem for a Homestuck + per-track colors!

### DIFF
--- a/album/7th-gate-project.yaml
+++ b/album/7th-gate-project.yaml
@@ -35,6 +35,7 @@ Commentary: "<i>Catboss:</i>\nThe “Seventh Gate Project” - as I like to call
 ---
 Track: Through the Seventh Gate ~Land of Wind and Shade~
 Duration: '4:33'
+Color: '#00fcf8'
 URLs:
 - https://soundcloud.com/catbossstudio/through-the-seventh-gate-lowas?in=catbossstudio/sets/7th-gate-project
 Cover Artists:
@@ -66,6 +67,7 @@ Commentary: "<i>Catboss:</i>\n<i>(original commentary)</i>\n“Through the Seven
 ---
 Track: Through the Seventh Gate ~Land of Heat and Clockwork~
 Duration: '4:36'
+Color: '#fd0a0b'
 URLs:
 - https://soundcloud.com/catbossstudio/through-the-seventh-gate-lohac?in=catbossstudio/sets/7th-gate-project
 Cover Artists:
@@ -100,6 +102,7 @@ Commentary: |-
 ---
 Track: Through the Seventh Gate ~Land of Light and Rain~
 Duration: '4:36'
+Color: '#eb3fea'
 URLs:
 - https://soundcloud.com/catbossstudio/through-the-seventh-gate-lolar?in=catbossstudio/sets/7th-gate-project
 Cover Artists:
@@ -139,6 +142,7 @@ Commentary: |-
 ---
 Track: Through the Seventh Gate ~Land of Frost and Frogs~
 Duration: '5:43'
+Color: '#23fb2a'
 URLs:
 - https://soundcloud.com/catbossstudio/through-the-seventh-gate-lofaf?in=catbossstudio/sets/7th-gate-project
 Cover Artists:

--- a/album/ancestral.yaml
+++ b/album/ancestral.yaml
@@ -12,10 +12,10 @@ Groups:
 - Unofficial MSPA Fans
 - Fandom
 Art Tags:
-- The Signless
 - The Handmaid
 - The Summoner
 - The Psiioniic
+- The Signless
 - The Disciple
 - The Dolorosa
 - Redglare
@@ -90,6 +90,7 @@ Track: ♈Reality Theatre♈
 Artists:
 - Navochao
 Duration: '3:41'
+Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/reality-theatre
 - https://youtu.be/wfJJW5x1zo0
@@ -109,6 +110,7 @@ Track: ♉W1th W1ngs♉
 Artists:
 - irl-porrim-maryam
 Duration: '4:28'
+Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/w1th-w1ngs
 - https://youtu.be/xmTBPsfjtY8
@@ -127,6 +129,7 @@ Track: ♊Propulsion♊
 Artists:
 - Sean William Calhoun
 Duration: '3:02'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/propulsion
 - https://youtu.be/QHlaCcFXXwY
@@ -148,6 +151,7 @@ Track: ♋️A Peace Worth Fighting For♋️
 Artists:
 - Nate Tronerud
 Duration: '5:12'
+Color: '#7c7e81'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/a-peace-worth-fighting-for
 - https://youtu.be/sFhScGwOe00
@@ -168,6 +172,7 @@ Track: ♌On The Hunt For Something Unknown♌
 Artists:
 - The One Music Maniac
 Duration: '4:47'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/on-the-hunt-for-something-unknown
 - https://youtu.be/rNxOZggKOIM
@@ -186,6 +191,7 @@ Track: ♍Theotokos♍
 Artists:
 - SerialSymphony
 Duration: '4:34'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/theotokos
 - https://youtu.be/4X00kfRnmcc
@@ -207,6 +213,7 @@ Track: ♎H3R HONOR4BL3 V3NG34NC3♎
 Artists:
 - Seren Mist
 Duration: '2:49'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/h3r-honor4bl3-v3ng34nc3
 - https://youtu.be/IusAe6XHzws
@@ -226,6 +233,7 @@ Artists:
 Contributors:
 - magnoliajades (vocals)
 Duration: '10:00'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/spiders-eclipse
 - https://youtu.be/LtLE_T53p_A
@@ -250,6 +258,7 @@ Track: ♐Broken Strings♐
 Artists:
 - psithurist
 Duration: '3:17'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/broken-strings
 - https://youtu.be/oje4ziyMcy0
@@ -267,6 +276,7 @@ Track: ♑His Demented Mural♑
 Artists:
 - Zan Beaver
 Duration: '3:51'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/his-demented-mural
 - https://youtu.be/8oNF8p_6Q84
@@ -285,6 +295,7 @@ Track: ♒Tumescent♒
 Artists:
 - Seijen
 Duration: '3:51'
+Color: '#db00db'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/tumescent
 - https://youtu.be/5VKSoP22sIg
@@ -303,6 +314,7 @@ Track: ♓Greatest -Empress♓
 Artists:
 - Mathias Ramalho
 Duration: '5:52'
+Color: '#e30072'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/greatest-empress
 - https://youtu.be/Y_pWa2CA2x0

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -12,10 +12,10 @@ Groups:
 - Unofficial MSPA Fans
 - Fandom
 Art Tags:
-- Kankri
 - Damara
 - Rufioh
 - Mituna
+- Kankri
 - Meulin
 - Porrim
 - Latula
@@ -83,6 +83,7 @@ Track: ♈ - Fatalism
 Artists:
 - NEON SYSTEM 95
 Duration: '4:28'
+Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/fatalism-2
 - https://youtu.be/tliId-rVINE
@@ -112,6 +113,7 @@ Track: ♉ - Breathtak1ng
 Artists:
 - Rhyselinn
 Duration: '5:30'
+Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/breathtak1ng
 - https://youtu.be/3uDVyljVSC4
@@ -139,6 +141,7 @@ Track: ♊ - The Mituna Method
 Artists:
 - psithurist
 Duration: '2:46'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-mituna-method
 - https://youtu.be/yXB8fYZFRq0
@@ -156,6 +159,7 @@ Track: ♋ - Civil Discussi9n
 Artists:
 - Blackhole
 Duration: '4:29'
+Color: '#ff0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/civil-discussi9n
 - https://youtu.be/32gksvECBEQ
@@ -174,6 +178,7 @@ Track: ♌ - MOG^3
 Artists:
 - Dallas Ross Hicks
 Duration: '7:01'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/mog-3
 - https://youtu.be/4GqkApgXiQU
@@ -194,6 +199,7 @@ Track: ♍ - Let Me Dance, Let Me Glisten
 Artists:
 - Flutterwhat
 Duration: '3:53'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/let-me-dance-let-me-glisten
 - https://youtu.be/mjU2WowinYw
@@ -219,6 +225,7 @@ Track: ♎ - R4d1c4l!
 Artists:
 - SerialSymphony
 Duration: '2:40'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/r4d1c4l
 - https://youtu.be/7N-V9TM83es
@@ -236,6 +243,7 @@ Track: ♏ - Salv8tion
 Artists:
 - Charles Neudorf
 Duration: '2:21'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/salv8tion
 - https://youtu.be/sdFRBgYqcN4
@@ -259,6 +267,7 @@ Track: ♐ - Creeping Blue
 Artists:
 - smear
 Duration: '2:38'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/creeping-blue
 - https://youtu.be/KaK8z8buRhA
@@ -276,6 +285,7 @@ Track: ♑ - Pious Noise
 Artists:
 - ndividedbyzero
 Duration: '3:11'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/pious-noise
 - https://youtu.be/0qnFucqWf3Q
@@ -296,6 +306,7 @@ Track: ♒ - Aquasex Renegade
 Artists:
 - theh0nestman
 Duration: '2:49'
+Color: '#db00db'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/aquasex-renegade
 - https://youtu.be/Epc3nlKAenU
@@ -323,6 +334,7 @@ Track: ♓ - Killer Beach
 Artists:
 - Veritas Unae
 Duration: '3:19'
+Color: '#e30072'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/killer-beach
 - https://youtu.be/c_F4NGUgG3o

--- a/album/cherubim.yaml
+++ b/album/cherubim.yaml
@@ -8,7 +8,7 @@ URLs:
 Cover Artists:
 - Kait Linney (lines)
 - Shelby Cragg (coloring & logo)
-Color: '#ff7600'
+Color: '#e57600'
 Groups:
 - group:official
 Art Tags:
@@ -34,6 +34,7 @@ Track: Reverie
 Artists:
 - Alex Rosetti
 Duration: '4:17'
+Color: '#00e500'
 URLs:
 - https://homestuck.bandcamp.com/track/reverie-2
 - https://youtu.be/WkpYnDz-Y1w
@@ -59,6 +60,7 @@ Duration: '4:22'
 URLs:
 - https://homestuck.bandcamp.com/track/power-fantasy-2
 - https://youtu.be/5adGTghTECM
+Color: '#e50000'
 Cover Artists:
 - Indolentjellyfish
 Art Tags:
@@ -75,6 +77,7 @@ Track: Stellarum Salve
 Artists:
 - Robert J! Lake
 Duration: '3:23'
+Color: '#00e500'
 URLs:
 - https://homestuck.bandcamp.com/track/stellarum-salve-2
 - https://youtu.be/J2Vc2JIWPaY
@@ -94,6 +97,7 @@ Duration: '4:23'
 URLs:
 - https://homestuck.bandcamp.com/track/carne-vale-2
 - https://youtu.be/AdPU0emEeUg
+Color: '#e50000'
 Cover Artists:
 - Leslie Hung
 Art Tags:
@@ -144,6 +148,7 @@ Track: Green Lolly
 Artists:
 - Robert J! Lake
 Duration: '4:11'
+Color: '#00e500'
 URLs:
 - https://homestuck.bandcamp.com/track/green-lolly-2
 - https://youtu.be/oWC2oXU_hP4
@@ -161,6 +166,7 @@ Duration: '3:44'
 URLs:
 - https://homestuck.bandcamp.com/track/red-sucker-2
 - https://youtu.be/lp7kDAHaWIc
+Color: '#e50000'
 Cover Artists:
 - Dana Smart
 Art Tags:
@@ -172,6 +178,7 @@ Track: Constant Confinement
 Artists:
 - Erik Scheele
 Duration: '3:54'
+Color: '#00e500'
 URLs:
 - https://homestuck.bandcamp.com/track/constant-confinement-2
 - https://youtu.be/1pp7UpsuTa4
@@ -195,6 +202,7 @@ Duration: '4:46'
 URLs:
 - https://homestuck.bandcamp.com/track/constant-conquest-2
 - https://www.youtube.com/watch?v=BKPUXLOEcqY
+Color: '#e50000'
 Cover Artists:
 - Elly Beck
 Art Tags:
@@ -217,6 +225,7 @@ Duration: '3:35'
 URLs:
 - https://homestuck.bandcamp.com/track/the-lyrist-2
 - https://youtu.be/Tybj0RZoGks
+Color: '#00e500'
 Cover Artists:
 - rumminov
 Art Tags:
@@ -234,6 +243,7 @@ Duration: '2:51'
 URLs:
 - https://homestuck.bandcamp.com/track/the-lordling-2
 - https://youtu.be/nLrChSME0T8
+Color: '#e50000'
 Cover Artists:
 - rumminov
 Art Tags:
@@ -249,6 +259,7 @@ Duration: '8:20'
 URLs:
 - https://homestuck.bandcamp.com/track/eternity-served-cold-2
 - https://youtu.be/wg9jows9Yfo
+Color: '#e50000'
 Cover Artists:
 - rennerei
 Art Tags:

--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -62,6 +62,7 @@ Track: Rust Servant
 Artists:
 - Willow Ascenzo
 Duration: '4:48'
+Color: '#eb0000'
 URLs:
 - https://homestuck.bandcamp.com/track/rust-servant
 - https://youtu.be/ZbVCaNBeEpA
@@ -81,6 +82,7 @@ Track: Bronze Rebel
 Artists:
 - Yan Rodriguez
 Duration: '4:13'
+Color: '#c36100'
 URLs:
 - https://homestuck.bandcamp.com/track/bronze-rebel
 - https://youtu.be/5z4ctxDKCVM
@@ -99,6 +101,7 @@ Track: Gold Pilot
 Artists:
 - First Turn Fold
 Duration: '5:23'
+Color: '#a1a100'
 URLs:
 - https://homestuck.bandcamp.com/track/gold-pilot
 - https://youtu.be/QZqYLuCH62Q
@@ -150,6 +153,7 @@ Contributors:
 - ari
 - Pippin
 Duration: '2:43'
+Color: '#7c7e81'
 URLs:
 - https://homestuck.bandcamp.com/track/iron-infidel
 - https://youtu.be/pIplxQdLgA4
@@ -190,6 +194,7 @@ Track: Olive Scribe
 Artists:
 - Bleed Binary
 Duration: '2:27'
+Color: '#588a00'
 URLs:
 - https://homestuck.bandcamp.com/track/olive-scribe
 - https://youtu.be/FpC98dlKX4s
@@ -204,6 +209,7 @@ Track: Jade Mother
 Artists:
 - Nathan H.
 Duration: '2:15'
+Color: '#008f48'
 URLs:
 - https://homestuck.bandcamp.com/track/jade-mother
 - https://youtu.be/OKQqQ3152QQ
@@ -220,6 +226,7 @@ Track: Teal Hunter
 Artists:
 - Willow Ascenzo
 Duration: '2:31'
+Color: '#008b8b'
 URLs:
 - https://homestuck.bandcamp.com/track/teal-hunter
 - https://youtu.be/i_ehVzmj7dM
@@ -238,6 +245,7 @@ Track: Cobalt Corsair
 Artists:
 - Max Wright
 Duration: '4:14'
+Color: '#3796c6'
 URLs:
 - https://homestuck.bandcamp.com/track/cobalt-corsair
 - https://youtu.be/FhFw9mhGf84
@@ -265,6 +273,7 @@ Track: Indigo Archer
 Artists:
 - Rachel Rose Mitchell
 Duration: '4:42'
+Color: '#c6c6f0'
 URLs:
 - https://youtu.be/3F0S20HUuNA
 Cover Artists:
@@ -276,6 +285,7 @@ Track: Purple Tyrant
 Artists:
 - Kevin Grant
 Duration: '3:50'
+Color: '#a34bff'
 URLs:
 - https://homestuck.bandcamp.com/track/purple-tyrant
 - https://youtu.be/DfbLS-W0V9A
@@ -300,6 +310,7 @@ Track: Violet Mariner
 Artists:
 - Willow Ascenzo
 Duration: '2:45'
+Color: '#db00db'
 URLs:
 - https://homestuck.bandcamp.com/track/violet-mariner
 - https://youtu.be/aXpnjMsqC6k
@@ -320,6 +331,7 @@ Track: Fuchsia Ruler
 Artists:
 - Kezinox
 Duration: '4:07'
+Color: '#e30072'
 URLs:
 - https://homestuck.bandcamp.com/track/fuchsia-ruler
 - https://youtu.be/AgOGQVszHbY
@@ -355,6 +367,7 @@ Track: Rust Maid
 Artists:
 - Plumegeist
 Duration: '2:54'
+Color: '#eb0000'
 URLs:
 - https://homestuck.bandcamp.com/track/rust-maid
 - https://youtu.be/ekWCjAjetZA
@@ -378,6 +391,7 @@ Artists:
 Contributors:
 - Ally Clark (vocals)
 Duration: 0:57
+Color: '#c36100'
 URLs:
 - https://homestuck.bandcamp.com/track/bronze-page
 - https://youtu.be/2ZmG8q5z1XE
@@ -402,6 +416,7 @@ Track: Gold Mage
 Artists:
 - repeatedScales
 Duration: '3:30'
+Color: '#a1a100'
 URLs:
 - https://homestuck.bandcamp.com/track/gold-mage
 - https://youtu.be/IY9mF06ZVFI
@@ -423,6 +438,7 @@ Track: Iron Knight
 Artists:
 - DJ最テー
 Duration: '4:07'
+Color: '#7c7e81'
 URLs:
 - https://homestuck.bandcamp.com/track/iron-knight
 - https://youtu.be/Nv6hGW8cou4
@@ -438,6 +454,7 @@ Artists:
 Contributors:
 - Alex Amlie-Wolf (bass)
 Duration: '4:57'
+Color: '#588a00'
 URLs:
 - https://homestuck.bandcamp.com/track/olive-rogue
 - https://youtu.be/L2BLUyv7UT0
@@ -466,6 +483,7 @@ Track: Jade Sylph
 Artists:
 - Frank Haught
 Duration: '3:50'
+Color: '#008f48'
 URLs:
 - https://homestuck.bandcamp.com/track/jade-sylph
 - https://youtu.be/oT-iHcyEjGQ
@@ -479,6 +497,7 @@ Track: Teal Seer
 Artists:
 - Kera Jones
 Duration: '2:32'
+Color: '#008b8b'
 URLs:
 - https://homestuck.bandcamp.com/track/teal-seer
 - https://youtu.be/Dwcn4q4X0OQ
@@ -495,6 +514,7 @@ Track: Cobalt Thief
 Artists:
 - Ray McDougall
 Duration: '3:22'
+Color: '#3796c6'
 URLs:
 - https://homestuck.bandcamp.com/track/cobalt-thief
 - https://youtu.be/44un1ADquPA
@@ -521,6 +541,7 @@ Track: Indigo Heir
 Artists:
 - Paul Tuttle Starr
 Duration: '5:00'
+Color: '#c6c6f0'
 URLs:
 - https://homestuck.bandcamp.com/track/indigo-heir
 - https://youtu.be/tdzG9kkxGt8
@@ -537,6 +558,7 @@ Track: Purple Bard
 Artists:
 - Eligecos
 Duration: '3:08'
+Color: '#a34bff'
 URLs:
 - https://homestuck.bandcamp.com/track/purple-bard
 - https://youtu.be/H9PK2xF_b3I
@@ -555,6 +577,7 @@ Track: Violet Prince
 Artists:
 - DJ最テー
 Duration: '3:02'
+Color: '#db00db'
 URLs:
 - https://homestuck.bandcamp.com/track/violet-prince
 - https://youtu.be/o0W_22WQjZ0
@@ -584,6 +607,7 @@ Track: Fuchsia Witch
 Artists:
 - David Dycus
 Duration: '1:36'
+Color: '#e30072'
 URLs:
 - https://homestuck.bandcamp.com/track/fuchsia-witch
 - https://youtu.be/FApClQH9MrE

--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -157,7 +157,7 @@ Contributors:
 - ari
 - Pippin
 Duration: '2:43'
-Color: '#7c7e81'
+Color: '#ff2400'
 URLs:
 - https://homestuck.bandcamp.com/track/iron-infidel
 - https://youtu.be/pIplxQdLgA4
@@ -281,7 +281,7 @@ Track: Indigo Archer
 Artists:
 - Rachel Rose Mitchell
 Duration: '4:42'
-Color: '#c6c6f0'
+Color: '#487aef'
 URLs:
 - https://youtu.be/3F0S20HUuNA
 Cover Artists:
@@ -559,7 +559,7 @@ Track: Indigo Heir
 Artists:
 - Paul Tuttle Starr
 Duration: '5:00'
-Color: '#c6c6f0'
+Color: '#487aef'
 URLs:
 - https://homestuck.bandcamp.com/track/indigo-heir
 - https://youtu.be/tdzG9kkxGt8

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -55,6 +55,7 @@ Track: Green Ghost
 Artists:
 - Monobrow
 Duration: '5:58'
+Color: '#4ac925'
 URLs:
 - https://homestuck.bandcamp.com/track/green-ghost-2
 - https://youtu.be/nx2CqNp16IA
@@ -88,6 +89,7 @@ Track: Orchid Horror
 Artists:
 - David DeCou
 Duration: '4:07'
+Color: '#b536da'
 URLs:
 - https://homestuck.bandcamp.com/track/orchid-horror-2
 - https://youtu.be/ZOVhMJgdIX0
@@ -112,6 +114,7 @@ Track: Red Disc
 Artists:
 - Nathan H.
 Duration: '2:52'
+Color: '#e00707'
 URLs:
 - https://homestuck.bandcamp.com/track/red-disc-2
 - https://youtu.be/Y4lJcMpYGZk
@@ -132,6 +135,7 @@ Artists:
 Contributors:
 - Malik Refaat (alto saxophone)
 Duration: '4:46'
+Color: '#5c66e8'
 URLs:
 - https://homestuck.bandcamp.com/track/blue-atom-2
 - https://youtu.be/QrB8PrwBIY0
@@ -176,6 +180,7 @@ Track: Cyan Beast
 Artists:
 - David Ellis
 Duration: '3:44'
+Color: '#00d5f2'
 URLs:
 - https://homestuck.bandcamp.com/track/cyan-beast-2
 - https://youtu.be/qhP_QTvAeQg
@@ -195,6 +200,7 @@ Track: Pink Cat
 Artists:
 - Ryan Ames
 Duration: '3:52'
+Color: '#ff6ff2'
 URLs:
 - https://homestuck.bandcamp.com/track/pink-cat-2
 - https://youtu.be/mF7WdQcSkHI
@@ -227,6 +233,7 @@ Track: Orange Hat
 Artists:
 - Plumegeist
 Duration: '2:36'
+Color: '#f2a400'
 URLs:
 - https://homestuck.bandcamp.com/track/orange-hat-2
 - https://youtu.be/sMkNFjy8xcU
@@ -239,6 +246,7 @@ Track: Emerald Terror
 Artists:
 - Elisa McCabe
 Duration: '2:31'
+Color: '#1f9400'
 URLs:
 - https://homestuck.bandcamp.com/track/emerald-terror-2
 - https://youtu.be/CWDbNoGgGyQ

--- a/album/diverging-delicacies.yaml
+++ b/album/diverging-delicacies.yaml
@@ -75,6 +75,7 @@ Art Tags:
 Referenced Tracks:
 - The Paradox Paradigm
 ---
+Color: '#e50000'
 Section: Meat Epilogue
 ---
 Track: '[MEAT EPILOGUE | 🥩]'
@@ -329,6 +330,7 @@ Art Tags:
 - Rose
 - Dirk
 ---
+Color: '#00e500'
 Section: Candy Epilogue
 ---
 Track: '[CANDY EPILOGUE | 🍭]'

--- a/album/friendsymphony.yaml
+++ b/album/friendsymphony.yaml
@@ -84,6 +84,7 @@ Track: today i put......... JELLY on this hot god
 Artists:
 - Tee-vee
 Duration: '2:01'
+Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/today-i-put-jelly-on-this-hot-god
 Cover Artists:
@@ -98,6 +99,7 @@ Track: Scrubbing Until Morning
 Artists:
 - JulieTunes
 Duration: '3:20'
+Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/scrubbing-until-morning
 Cover Artists:
@@ -110,6 +112,7 @@ Track: Gravedigger's Dirge
 Artists:
 - JulieTunes
 Duration: '1:41'
+Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/gravediggers-dirge
 Cover Artists:
@@ -122,6 +125,7 @@ Track: Dreams of Flight
 Artists:
 - JulieTunes
 Duration: '2:21'
+Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dreams-of-flight
 Cover Artists:
@@ -131,6 +135,7 @@ Track: Desert Daring
 Artists:
 - heir-of-puns
 Duration: '2:36'
+Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/desert-daring
 Cover Artists:
@@ -144,6 +149,7 @@ Track: Beneath the Night Sky So Dark
 Artists:
 - JulieTunes
 Duration: '3:29'
+Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/beneath-the-night-sky-so-dark
 Cover Artists:
@@ -158,6 +164,7 @@ Track: >-
 Artists:
 - Tee-vee
 Duration: '3:06'
+Color: '#c36100'
 URLs:
 - >-
     https://unofficialmspafans.bandcamp.com/track/hi-everyone-antony-fntano-here-alternias-busiest-music-nerd-and-its-time-for-a-review-of-the-new-chixie-roixmr-album
@@ -177,6 +184,7 @@ Directory: its-hard-being-famous
 Artists:
 - astropod
 Duration: '2:15'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/its-hard-being-famous-its-hard-and-nobody-understands
 Cover Artists:
@@ -190,6 +198,7 @@ Track: leech
 Artists:
 - Gryotharian
 Duration: '2:51'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/leech
 Cover Artists:
@@ -202,6 +211,7 @@ Track: assault and battery
 Artists:
 - Gryotharian
 Duration: '2:18'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/assault-and-battery
 Cover Artists:
@@ -216,6 +226,7 @@ Track: Carefree Consternation
 Artists:
 - JulieTunes
 Duration: '2:05'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/carefree-consternation
 Cover Artists:
@@ -230,6 +241,7 @@ Track: '|||Optic Duelist|||'
 Artists:
 - Rainy
 Duration: '4:00'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/optic-duelist
 Cover Artists:
@@ -256,6 +268,7 @@ Artists:
 - Rainy
 - Tee-vee
 Duration: '3:45'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/marvelous-marauder
 Cover Artists:
@@ -269,6 +282,7 @@ Track: no *kills you*
 Artists:
 - astropod
 Duration: '1:37'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/no-kills-you
 Cover Artists:
@@ -281,6 +295,7 @@ Track: Caught in the Facts
 Artists:
 - Panfex
 Duration: '2:29'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/caught-in-the-facts
 Cover Artists:
@@ -294,6 +309,7 @@ Track: Paradox Pariah
 Artists:
 - Baleish
 Duration: '2:33'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/paradox-pariah
 Cover Artists:
@@ -308,6 +324,7 @@ Track: Mother To Many
 Artists:
 - JulieTunes
 Duration: '3:02'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/mother-to-many
 Cover Artists:
@@ -321,6 +338,7 @@ Track: Improved Acumen
 Artists:
 - JulieTunes
 Duration: '3:10'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/improved-acumen
 Cover Artists:
@@ -332,6 +350,7 @@ Track: oWo
 Artists:
 - Chesswanderlust-sama
 Duration: '2:30'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/owo
 Cover Artists:
@@ -344,6 +363,7 @@ Track: we waste time JADED
 Artists:
 - Tee-vee
 Duration: '3:46'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/we-waste-time-jaded
 Cover Artists:
@@ -368,6 +388,7 @@ Track: Naive Harmony
 Artists:
 - JulieTunes
 Duration: '3:13'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/naive-harmony
 Cover Artists:
@@ -379,6 +400,7 @@ Track: '*Legal Fees Pending'
 Artists:
 - Scorpyus
 Duration: '3:28'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/legal-fees-pending
 Cover Artists:
@@ -391,6 +413,7 @@ Track: Exhausted Hope
 Artists:
 - Gryotharian
 Duration: '3:37'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/exhausted-hope
 Cover Artists:
@@ -405,6 +428,7 @@ Track: Bullet Brain
 Artists:
 - JulieTunes
 Duration: '3:50'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/bullet-brain
 Cover Artists:
@@ -417,6 +441,7 @@ Track: '*teleports behind you*'
 Artists:
 - Gryotharian
 Duration: '3:32'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/teleports-behind-you
 Cover Artists:
@@ -428,6 +453,7 @@ Track: Lonely Little Gremlin Girl
 Artists:
 - JulieTunes
 Duration: '3:09'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/lonely-little-gremlin-girl
 Cover Artists:
@@ -437,6 +463,7 @@ Track: Middleclass Daydream
 Artists:
 - heir-of-puns
 Duration: '2:18'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/middleclass-daydream
 Cover Artists:
@@ -461,6 +488,7 @@ Track: Zillow for Evil Lairs
 Artists:
 - JulieTunes
 Duration: '2:55'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/zillow-for-evil-lairs
 Cover Artists:
@@ -473,6 +501,7 @@ Track: Chelicerae
 Artists:
 - heir-of-puns
 Duration: '2:32'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/chelicerae
 Cover Artists:
@@ -484,6 +513,7 @@ Track: Pop Pills Get Girls
 Artists:
 - Scorpyus
 Duration: '3:29'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/pop-pills-get-girls
 Cover Artists:
@@ -497,6 +527,7 @@ Track: Blatant Plagiarism
 Artists:
 - Scorpyus
 Duration: '2:46'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/blatant-plagiarism
 Cover Artists:
@@ -510,6 +541,7 @@ Track: Dumbass Terminal
 Artists:
 - Tee-vee
 Duration: '6:01'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dumbass-terminal
 Cover Artists:
@@ -529,6 +561,7 @@ Directory: growing-up-friendsymphony
 Artists:
 - JulieTunes
 Duration: '1:13'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/growing-up
 Cover Artists:
@@ -539,6 +572,7 @@ Directory: worst-friend
 Artists:
 - Gryotharian
 Duration: '1:59'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/worst-fri-end
 Cover Artists:
@@ -551,6 +585,7 @@ Track: Sesquipedalian Loquaciousness
 Artists:
 - Tee-vee
 Duration: '2:56'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sesquipedalian-loquaciousness
 Cover Artists:
@@ -563,6 +598,7 @@ Track: '*Suplexes piano*'
 Artists:
 - Scorpyus
 Duration: '2:26'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/suplexes-piano
 Cover Artists:
@@ -572,6 +608,7 @@ Track: Sleeping in the cheerful sis's hair
 Artists:
 - Chesswanderlust-sama
 Duration: '2:31'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sleeping-in-the-cheerful-siss-hair
 Cover Artists:
@@ -583,6 +620,7 @@ Track: General Clownery
 Artists:
 - astropod
 Duration: '2:18'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/general-clownery
 Cover Artists:
@@ -594,6 +632,7 @@ Track: Phantasmagoria
 Artists:
 - Scorpyus
 Duration: '3:00'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/phantasmagoria
 Cover Artists:
@@ -609,6 +648,7 @@ Track: The Show Must Go On
 Artists:
 - Scorpyus
 Duration: '4:02'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-show-must-go-on
 Cover Artists:
@@ -621,6 +661,7 @@ Track: You're the Whole Circus
 Artists:
 - Tee-vee
 Duration: '3:36'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/youre-the-whole-circus
 Cover Artists:

--- a/album/of-troles-and-chiptumes.yaml
+++ b/album/of-troles-and-chiptumes.yaml
@@ -39,6 +39,7 @@ Track: A Ghost Then a Frog Then a Robot Then a Fairy
 Duration: '02:59'
 Cover Artists:
 - DrWorm
+Color: '#eb0000'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/a-ghost-then-a-frog-then-a-robot-then-a-fairy
 - https://www.youtube.com/watch?v=vzCFgF9zJKM
@@ -56,6 +57,7 @@ Track: Mexican But Not Really
 Duration: '02:06'
 Cover Artists:
 - wank_wank
+Color: '#c36100'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/mexican-but-not-really
 - https://www.youtube.com/watch?v=rUH5yZlojL8
@@ -74,6 +76,7 @@ Track: The Gemoni Mustard Blood
 Cover Artists:
 - Bambosh
 Duration: '02:04'
+Color: '#a1a100'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-gemoni-mustard-blood
 - https://www.youtube.com/watch?v=bRcjZBb7nKk
@@ -87,6 +90,7 @@ Track: The Not-Fuckass Not-Waltz
 Cover Artists:
 - daXfactorz
 Duration: '02:41'
+Color: '#7c7e81'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-not-fuckass-not-waltz
 - https://www.youtube.com/watch?v=EZv9Pi70n3Q
@@ -101,6 +105,7 @@ Track: Everyone Forgets She Kills Animals
 Cover Artists:
 - Sbahjsic
 Duration: '02:15'
+Color: '#588a00'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/everyone-forgets-she-kills-animals
 - https://www.youtube.com/watch?v=UWkHkExbv2w
@@ -117,6 +122,7 @@ Track: The Ascended Twilight Fangirl
 Cover Artists:
 - NyashAlex
 Duration: '02:28'
+Color: '#008f48'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-ascended-twilight-fangirl
 - https://www.youtube.com/watch?v=LSyfDp8Ibew
@@ -133,6 +139,7 @@ Cover Artists:
 - XenoZane
 Cover Art File Extension: jpg
 Duration: '02:50'
+Color: '#008b8b'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/detective-cherry-inspector
 - https://www.youtube.com/watch?v=kkC-nJI0K7o
@@ -154,6 +161,7 @@ Cover Artists:
 - cookiefonster
 Cover Art File Extension: jpg
 Duration: '2:50'
+Color: '#3796c6'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/madame-controversielle
 - https://www.youtube.com/watch?v=5Mlwm5FhgWc
@@ -172,6 +180,7 @@ Track: Yes, So Good
 Cover Artists:
 - Makin
 Duration: '02:35'
+Color: '#c6c6f0'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/yes-so-good
 - https://www.youtube.com/watch?v=xTQBoUmVkxE
@@ -189,6 +198,7 @@ Track: The March of the One True Juggalo
 Cover Artists:
 - Toast
 Duration: '02:09'
+Color: '#a34bff'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-march-of-the-one-true-juggalo
 - https://www.youtube.com/watch?v=On0bJaZfGKw
@@ -209,6 +219,7 @@ Track: The Ridiculous Wwizard of Stupidity
 Cover Artists:
 - miraculousAvantgarde
 Duration: '02:07'
+Color: '#db00db'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-ridiculous-wwizard-of-stupidity
 - https://www.youtube.com/watch?v=Vga9wpQin5A
@@ -228,6 +239,7 @@ Track: The Heiress Without a Role
 Cover Artists:
 - yazshu
 Duration: '01:43'
+Color: '#e30072'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-heiress-without-a-role
 - https://www.youtube.com/watch?v=-QGamX8zw3Y

--- a/album/requiem-for-a-homestuck.yaml
+++ b/album/requiem-for-a-homestuck.yaml
@@ -1,0 +1,37 @@
+Album: Requiem for a Homestuck
+Artists:
+- James Roach
+Date: March 3, 2023
+Date Added: March 3, 2023
+URLs:
+- https://music.wixstatic.com/preview/092df5_c949c89f59a842ac973e8c3381cce490-128.mp3
+- https://www.youtube.com/watch?v=pbkqM8L1AWI
+Has Track Art: false
+Cover Artists:
+- Heather Hermann
+Cover Art File Extension: png
+Wallpaper Artists:
+- Heather Hermann
+Wallpaper Style: |-
+    opacity: 1;
+    background-repeat: repeat;
+    background-size: auto;
+Color: '#62c700'
+Groups:
+- group:official
+Art Tags:
+- Gate
+Commentary: |-
+    <i>Requiem Cafe:</i>
+    <b><u>Remember Your Roots</b></u><br>
+    Step back in time 10 years. Obama has started his second term, Snoop Dogg just shared some <i>interesting</i> fan art, and Homestuck is breaking the internet with fans eagerly awaiting an update. Feeling nostalgic yet?
+
+    Break out the gray paint because this 4/13 Homestuck and VIZ Media are teaming up with Requiem Cafe to bring you back in time for a 4/13 party unlike any other. You're invited to come to Requiem cafe, located in Anaheim CA, to experience themed drinks, treats, cosplay photo ops, and new licensed merch with official never-before-seen art. Measure up to your favorite characters in our photo room with a life-size height chart and experience Homestuck all over again in way you only can at Requiem.
+---
+Track: Requiem for a Homestuck
+Duration: '2:07'
+Art Tags:
+- Gate
+URLs:
+- https://music.wixstatic.com/preview/092df5_c949c89f59a842ac973e8c3381cce490-128.mp3
+- https://www.youtube.com/watch?v=pbkqM8L1AWI

--- a/album/xenoplanetarium.yaml
+++ b/album/xenoplanetarium.yaml
@@ -66,6 +66,7 @@ Track: Calming Quartz
 Artists:
 - PoisonedElite
 Duration: '2:05'
+Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/calming-quartz
 - https://youtu.be/i_rH12hll8A
@@ -93,6 +94,7 @@ Track: Sandy Skyline
 Artists:
 - Aris Martinian
 Duration: '2:53'
+Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sandy-skyline
 - https://youtu.be/vjMeokNP2E4
@@ -112,6 +114,7 @@ Track: Deep Fried
 Artists:
 - Kanishka
 Duration: '4:00'
+Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/deep-fried
 - https://youtu.be/VL-k3TDTxSA
@@ -137,6 +140,7 @@ Track: Red Pulse
 Artists:
 - ehlsea
 Duration: '3:25'
+Color: '#7c7e81'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/red-pulse
 - https://youtu.be/uZrnoad2yUQ
@@ -157,6 +161,7 @@ Track: Oolongcat
 Artists:
 - Ucklin
 Duration: '2:43'
+Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/oolongcat
 - https://youtu.be/bQBkjUo9q10
@@ -181,6 +186,7 @@ Track: Light Like Raindrops
 Artists:
 - Grace Medley
 Duration: '3:15'
+Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/light-like-raindrops
 - https://youtu.be/7at_By7l078
@@ -203,6 +209,7 @@ Track: Delta Divination
 Artists:
 - ndividedbyzero
 Duration: '3:27'
+Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/delta-divination
 - https://youtu.be/GcXi5JoU_94
@@ -226,6 +233,7 @@ Track: Acquiesce
 Artists:
 - psithurist
 Duration: '4:25'
+Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/acquiesce
 - https://youtu.be/TS5ibctqo5U
@@ -252,6 +260,7 @@ Track: Depths and Water
 Artists:
 - Blackhole
 Duration: '7:15'
+Color: '#c6c6f0'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/depths-and-water
 - https://youtu.be/Y6N6qPUberY
@@ -271,6 +280,7 @@ Track: Carnival of Nescience
 Artists:
 - WHATISLOSTINTHEMINES
 Duration: '2:05'
+Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/carnival-of-nescience
 - https://youtu.be/Bjwg6RjvTzI
@@ -295,6 +305,7 @@ Track: Round Perdition's Flames
 Artists:
 - Kal-la-kal-la
 Duration: '3:44'
+Color: '#db00db'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/round-perditions-flames
 - https://youtu.be/331ZPNLIdZo
@@ -316,6 +327,7 @@ Track: The Hyaline
 Artists:
 - Circlejourney
 Duration: '4:13'
+Color: '#e30072'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-hyaline
 - https://youtu.be/dDbC9VpsMtc

--- a/artists.yaml
+++ b/artists.yaml
@@ -1862,6 +1862,16 @@ Artist: Haven Gillespie
 ---
 Artist: Hazel M.
 ---
+Artist: Heather Hermann
+Aliases:
+- The Duchess of Deco
+- Duchess of Deco
+- duchessofdeco
+URLs:
+- https://www.heatherhermann.com/
+- https://beacons.ai/duchessofdeco
+- https://www.instagram.com/duchess.of.deco/
+---
 Artist: heinousdave
 Dead URLs:
 - https://heinousdave.tumblr.com/

--- a/homepage.yaml
+++ b/homepage.yaml
@@ -48,5 +48,6 @@ Albums:
 - album:the-consuming-shadow-ost
 - album:the-raddest
 
+- album:requiem-for-a-homestuck
 - album:dialed-to-11
 - album:retcon-2018

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -56,7 +56,7 @@ Content: |-
     - added backgrounds to [[album:homestuck-vol-1]], [[album:homestuck-vol-2]], [[album:homestuck-vol-3]], [[album:homestuck-vol-4]], and [[album:homestuck-vol-1-4]]
     - added links to album premiere stream recordings to [[album:ancestral]], [[album:cosmic-caretakers]], [[album:moons-of-theseus]], [[album:strife-2]], and [[album:oceanfalls-vol-1]] (thanks for these, Ngame!)
     - added commentary to the [[album:friendsymphony]] album page
-    - added per-track colors to tracks in [[album:coloUrs-and-mayhem-universe-a]], [[album:coloUrs-and-mayhem-universe-b]], [[album:cherubim]], [[album:diverging-delicacies]], [[album:friendsymphony]], [[album:7th-gate-project]], and [[album:of-troles-and-chiptumes]]
+    - added per-track colors to tracks in [[album:coloUrs-and-mayhem-universe-a]], [[album:coloUrs-and-mayhem-universe-b]], [[album:cherubim]], [[album:beforus]], [[album:ancestral]], [[album:xenoplanetarium]], [[album:diverging-delicacies]], [[album:friendsymphony]], [[album:7th-gate-project]], and [[album:of-troles-and-chiptumes]]
     <h3>data changes</h3>
     - [[track:outrun]] moved out of [[album:more-homestuck-fandom]] (now in [[album:a-shade-of-blue]])
     <h3>data fixes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -56,6 +56,7 @@ Content: |-
     - added backgrounds to [[album:homestuck-vol-1]], [[album:homestuck-vol-2]], [[album:homestuck-vol-3]], [[album:homestuck-vol-4]], and [[album:homestuck-vol-1-4]]
     - added links to album premiere stream recordings to [[album:ancestral]], [[album:cosmic-caretakers]], [[album:moons-of-theseus]], [[album:strife-2]], and [[album:oceanfalls-vol-1]] (thanks for these, Ngame!)
     - added commentary to the [[album:friendsymphony]] album page
+    - added per-track colors to tracks in [[album:coloUrs-and-mayhem-universe-a]], [[album:coloUrs-and-mayhem-universe-b]], [[album:cherubim]], [[album:diverging-delicacies]], [[album:friendsymphony]], [[album:7th-gate-project]], and [[album:of-troles-and-chiptumes]]
     <h3>data changes</h3>
     - [[track:outrun]] moved out of [[album:more-homestuck-fandom]] (now in [[album:a-shade-of-blue]])
     <h3>data fixes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -50,6 +50,7 @@ Content: |-
         - added [[album:a-shade-of-blue]] by [[artist:cerulean]]!
     - added [[album:dialed-to-11]] by [[artist:ludicrousfalcon]]!
     - added [[album:retcon-2018]] by [[artist:the-cat-herd]]!
+    - added [[album:requiem-for-a-homestuck]] by [[artist:james-roach]]!
     <h3>other additions</h3>
     - added additional files to [[album:lofam]], [[album:lofam2]], [[album:lofam3]], [[album:lofam4]], [[album:lofam5]], [[album:jailbreak-vol-1]], [[album:sburb-ost]], [[album:beforus]], [[album:bee-forus-seatbelt-safebee]], [[album:weird-puzzle-tunes]], [[album:ancestral]], [[album:xenoplanetarium]], [[album:gristmas-carols]], [[album:cosmic-caretakers]], [[album:moons-of-theseus]], [[album:friendsymphony]], [[album:the-baby-is-you]], [[album:cool-and-new-volume-2]], [[album:cool-and-new-volume-ii]], and [[album:team-paradox]]
     - added backgrounds to [[album:homestuck-vol-1]], [[album:homestuck-vol-2]], [[album:homestuck-vol-3]], [[album:homestuck-vol-4]], and [[album:homestuck-vol-1-4]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -61,6 +61,7 @@ Content: |-
     <h3>data changes</h3>
     - [[track:outrun]] moved out of [[album:more-homestuck-fandom]] (now in [[album:a-shade-of-blue]])
     - added art anthology booklet to [[album:beyond-canon]] as additional file
+    - matching per-track colors, updated the colors for a few tags, including [[tag:caliborn]] nad [[tag:calliope]], as well as [[tag:equius]] and other indigo tags
     <h3>data fixes</h3>
     - fixed typos in commentary citation for [[track:pumpkin-tide-tvs-i-can-barely-sleep-i-have-to-quickly-finish-this-rock-cover]] and [[track:lapis-lazuli-extended]], making these listed properly on their artists' wiki pages
     - fixed [[track:frustracean]] not referencing [[track:hardlyquin]] (thanks, OneOfTheChips!)

--- a/tags.yaml
+++ b/tags.yaml
@@ -145,19 +145,19 @@ Tag: Aranea
 Color: '#3796c6'
 Tag: Vriska's lusus
 ---
-Color: '#c6c6f0'
+Color: '#487aef'
 Tag: Equius
 ---
-Color: '#c6c6f0'
+Color: '#487aef'
 Tag: Equihorse
 ---
-Color: '#c6c6f0'
+Color: '#487aef'
 Tag: The Expatriate
 ---
-Color: '#c6c6f0'
+Color: '#487aef'
 Tag: Horuss
 ---
-Color: '#c6c6f0'
+Color: '#487aef'
 Tag: Equius's lusus
 ---
 Color: '#a34bff'
@@ -199,10 +199,10 @@ Tag: Meenah
 Color: '#e30072'
 Tag: Feferi's lusus
 ---
-Color: '#a1a3a6'
+Color: '#00e500'
 Tag: Calliope
 ---
-Color: '#009c68'
+Color: '#e50000'
 Tag: Caliborn
 ---
 Color: '#929292'
@@ -616,7 +616,7 @@ Tag: LoBaF
 Color: '#00d5f2'
 Tag: LoCaH
 ---
-Color: '#c6c6f0'
+Color: '#487aef'
 Tag: LoCaS
 ---
 Color: '#e30072'


### PR DESCRIPTION
Albums affected: c&m A&B, Cherubim, Friendsymphony, Diverging Delicacies, Friendsymphony, 7th Gate Project, Of Troles and Chiptumes, Ancestral, Beforus, Xenoplanetarium.

TODO: Review tag colors (and therefore track colors) for Equius.

Since I haven't been able to sync `hsmusic-media`, here are the two new art files for Requiem:

`cover.png`
![cover](https://user-images.githubusercontent.com/25875275/222939529-33d58410-820c-40ea-a1e3-37b585391428.png)

`bg.jpg`
![bg](https://user-images.githubusercontent.com/25875275/222939552-221296e1-10e8-4c5e-8419-3f6602925e19.jpg)
