### PR TITLE
Quick media filename fixes

### DIFF
--- a/album/diverging-delicacies.yaml
+++ b/album/diverging-delicacies.yaml
@@ -301,7 +301,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Mikkynga:</i>
     Also bonus art because i read the wrong part of the epilogues at first but i liked it anyway and i couldn't just let it die:
-    <img src="media/misc/kamina-burana-bonus.jpeg" width="300">
+    <img src="media/misc/kamina-burana-bonus.jpg" width="300">
 ---
 Track: Giving Up the Ghost
 Artists:

--- a/album/prospit-and-derse.yaml
+++ b/album/prospit-and-derse.yaml
@@ -73,7 +73,7 @@ Commentary: |-
     Thanks for helping me out, Bea. And keep up the good work.
     I have to say I'm pleased overall with this song, but, like any artist, it's difficult to look back at my works. They never seem completed. Especially the Prospit half for me.
     (<i>original track art</i>)
-    <img src="media/misc/hallowed-halls-original.jpg" width="350">
+    <img src="media/misc/hallowed-halls-original.png" width="350">
 ---
 Track: The Golden Towers
 Duration: '3:22'

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -61,6 +61,9 @@ Content: |-
         - fixed [[track:memories-of-home]] not referencing [[track:rosen-wings]] or [[track:restful-wings]]
         - fixed [[track:living-will]] not referencing [[track:the-fifth-flower]]
         - fixed [[track:purge-destiny]] not referencing [[track:corona]]
+    - fixed a variety of filename issues for track artwork and other images
+        - fixed original art for [[track:hallowed-halls]] being a 404 when viewing its source file
+        - fixed bonus art for [[track:kamina-burana]] displaying source file instead of thumbnail
 
     <h2 id="18-aug-2023" class="major-release"><a href="#18-aug-2023">[[date:18 August 2023]] - Iridescent Noon</a></h2>
     (news entry: [[news-entry:iridescent-noon]])


### PR DESCRIPTION
Truly incredible stuff:

* Fixes buy-NAK-sell-DOOF filename capitalization (media PR only)
* Fixes kamina-burana-bonus being jpeg instead of jpg (media PR also)
* Fixes hallowed-halls-original being really png, not jpg

Thanks to everyone for pointing out Buy NAK Sell DOOF, and to hsmusic/hsmusic-wiki#264 for catching the others.

Merge alongside hsmusic/hsmusic-media#5.