### PR TITLE
Miscellaneous tag additions

### DIFF
--- a/album/ancestral.yaml
+++ b/album/ancestral.yaml
@@ -305,7 +305,9 @@ Cover Artists:
 - Sigourney Martin
 Art Tags:
 - Dualscar
+- Alternia
 - 'cw: blood'
+- 'cw: corpse'
 Commentary: |-
     <i>Seijen:</i>
     So this is a re-hash of one of my first tracks from about 2 and a half years ago. The original title of the track was "Robot Pirate Island" and had a shift into a ravecore EDM as opposed to the constant high energy baroque sound we have here. This current edit is from april of 2016. I would create another, had it not been for the project crashing upon loading. It sounds incredibly rough in comparison to my current skill and I'm losing a little sleep over it. A damn shame since the amount of tools and knowledge I have now could make this sound night and day in quality, but what you hear is what you get.
@@ -481,6 +483,8 @@ Cover Artists:
 Art Tags:
 - Dualscar
 - Alternia
+- 'cw: blood'
+- 'cw: corpse'
 Referenced Tracks:
 - Eridan's Theme
 Commentary: |-
@@ -808,6 +812,7 @@ Cover Artists:
 Art Tags:
 - Mindfang
 - Dualscar
+- Alternia
 Referenced Tracks:
 - Wind-up Storm
 - Doctor

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -75,6 +75,7 @@ Art Tags:
 - Cronus
 - Meenah
 - Beforus
+- Frog Temple
 Commentary: |-
     <i>Blackhole:</i>
     The music here is one of three short bookend pieces I wrote for the start of each Disc, each a section of a longer piece, "Preludes to Beforus". They are not particularly exciting in and of themselves, so instead I'll speak a little about Disc 1 itself. Disc 1 is the part of the album initially designed to contain the twelve "principal tracks", invisaged as the main theme for each of the twelve Beforan trolls. At the start of the project, musicians could actually reserve these spots, but a lot of shuffling happened towards the end. Eventually, each troll ended up having multiple themes on the album, but Disc 1 still contains what can probably be considered their "main" theme, due to its location at the start of the album. With only twelve tracks and the short bookend piece, Disc 1 is far smaller than the longer Disc 2 section.
@@ -384,6 +385,7 @@ Art Tags:
 - Meenah
 - Horrorterrors
 - Dream Bubbles
+- Victory Platform
 Commentary: |-
     <i>Blackhole:</i>
     Disc 2 is the longest Disc in Beforus. Unlike Disc 1, which consists of individual themes for each of the trolls, Disc 2 is a narrative depiction of their story. Each song, be it a theme for a particular aspect of a character, a soundtrack for a particular event, or else a scene-setting piece, has been arranged so that Disc 2 roughly forms a narrative story in chronological order, which can hopefully be seen in the music and artwork.
@@ -659,6 +661,7 @@ Cover Artists:
 - JulietCee
 Art Tags:
 - Damara
+- LoQaM
 Commentary: |-
     <i>Ollie:</i>
     I did this track way back in 2013 I think? Maybe early 2014 back when my computer with my music program still worked. Hah. It all sort of originated with a wager, that I couldn't produce a better Tavros song than the one on the official album. And of course, being the huge procrastinator that I am, I never did. But I did however get the idea to do my own album for the songs of the Beforan Trolls. Again, procrastination got the better of me, but this project came along and almost took the workload I had give nmyself off my shoulders and still gave me an opportunity to showcase what I had done for Damara. It does have the traditional Eastern Asian sound to it with the pentatonic scale, and that's what the song was based upon. Also ghosts. Because spoopy.
@@ -867,6 +870,7 @@ Cover Artists:
 Art Tags:
 - Kankri
 - Meteor
+- Veil
 - 'cw: corpse (abstract)'
 Commentary: |-
     <i>Ducky Senpai:</i>
@@ -928,6 +932,7 @@ Art Tags:
 - Meulin
 - Latula
 - Horuss
+- Gate
 Commentary: |-
     <i>Willow Ascenzo:</i>
     Dan (also known as aradia-symmetry, author of <a href="https://aradiawheresheshouldbe.tumblr.com/">aradiawheresheshouldbe</a> and <a href="https://rosewheresheshouldbe.tumblr.com/">rosewheresheshouldbe.tumblr.com</a>) commissioned me back in October 2013 for a song about Damara Megido. The song ended up quite spooky, because after all, he did commission it on October 31. I relied on the shakuhachi and cello and, per Dan's request, a pulsing synth bass to create the brooding, melancholy atmosphere I felt best reflected Damara's inner coldness and despesrate nihilism.
@@ -981,6 +986,7 @@ Cover Artists:
 Art Tags:
 - Damara
 - Rufioh
+- Beforus
 Referenced Tracks:
 - Rust Maid
 - psych0ruins
@@ -1006,6 +1012,7 @@ Art Tags:
 - Damara
 - Rufioh
 - Horuss
+- Beforus
 Commentary: |-
     <i>rest✩taurus:</i>
     Parsing this one out makes "Damn" "Iterations" + a horse pun. This track was the one that hung around in concept the longest of any of my tracks, but came together the last of them. The original idea was to explore Horuss' own introspections, but that alone wsn't compelling me nearly enough. In the end, connecting Damara's and Horuss' struggles in one musical trainwreck was what propelled me forward. Rufioh takes a back seat to the insecurities and raw emotion of his past and present lovers, existing in tandem. I get the feeling that the session itself weighed heaviest on these two, one doomed to undo it at every turn, and the other to be swallowed up whole in pieces of hismelf. I aimed to convey this through the uncanny, grating musical landscape of the track. It is probably my favorite of the bunch.
@@ -1087,6 +1094,7 @@ Art Tags:
 - Kurloz
 - Cronus
 - Meenah
+- Tumor
 Commentary: |-
     <i>Sean William Calhoun:</i>
     <code style="color: #3796c6">ARANEA: You look into the future and see a life lasting for may8e thousands of sweeps, with nothing to look forward to,"</code>
@@ -1107,6 +1115,7 @@ Cover Artists:
 - oxfordroulette
 Art Tags:
 - Damara
+- LoQaM
 Referenced Tracks:
 - Hate You
 - Theme
@@ -1127,6 +1136,8 @@ URLs:
 - https://youtu.be/gS0IKk1MVO0
 Cover Artists:
 - Scarodactyl
+Art Tags:
+- LoQaM
 Commentary: |-
     <i>Laurent Désautels-Séguin:</i>
     This song is divided in 3 parts: everything is sad and not going well - They enter the palace for the Scratch and it's mysterious - The Scratch begins and it's intense. For the sad part, it's just sad chords. For the mysterious parts, I used a lot of mysterious arpeggios and delay effects. For the Scratch, I used a lot of bitcrush, dramatic arpeggios, and I reused chords from the sad part and arpeggios from the mysterious parts because the Scratch is mixing things. I was inspired by the music of Steven Universe for the style of mysterious arpeggios. I think the music of the series did a great job with how they represent dangerous mystical stuff. I created all the sounds with NI Massive, used Replika for delay and Decimort for bitcrush. I had a lot of fun doing these songs and I hope that you liked it!
@@ -1216,6 +1227,7 @@ Cover Artists:
 - YoItsCro
 Art Tags:
 - Cronus
+- Dream Bubbles
 Commentary: |-
     <i>Dallas Ross Hicks:</i>
     Cronus Ampora is in love with the 1950's era of Earth but wishes he could be in love with somebody. Anybody. This song captures the style of music from that time, starting with Cronus's generally pleasant mood but giving way to his overbearing on-the-make obnoxiousness that invariably drives people away. This doesn't make his loneliness any less real, which is illustrated at the end of the tune by a slow, sad finale. I grew up listening to this kind of music on my parents' radio so I really enjoyed bringing elements of my favourites from the Fifties to life in this song!
@@ -1620,6 +1632,7 @@ Cover Artists:
 - Quietserval
 Art Tags:
 - Rufioh
+- Beforus
 Commentary: |-
     <i>MariEaster:</i>
     Tree Dwellers is about the Lost Weeaboos; a group of Beforan otaku trolls living in a secret forest village far away from normal troll society. The track was originally made to be a fan track for Nepeta, but I found the track to fit surprisingly well with the whole concept about the Lost Weeaboos.
@@ -1758,6 +1771,7 @@ Cover Artists:
 Art Tags:
 - Rufioh
 - Damara
+- Beforus
 Referenced Tracks:
 - Uptown Funk
 Lyrics: |-
@@ -1858,6 +1872,7 @@ Art Tags:
 - Horrorterrors
 - Gate
 - Tumor
+- LoQaM
 Commentary: |-
     <i>Toris Crow:</i>
     This song can be interpreted as being about the Scratch from the Beforus trolls' point of view. I wanted to write a song that had a suspenseful single-note intro, similar to in the song [[English]] from the Homestuck album The Felt. I wrote the song to be dramatic because the Scratch, for them, signifies the end of their roles as players in their session.

--- a/album/cool-and-new-homestuck-2.yaml
+++ b/album/cool-and-new-homestuck-2.yaml
@@ -890,6 +890,7 @@ Art Tags:
 - Jasprose
 - John
 - Roxy
+- The Condesce
 - Ace Dick
 - Lord English
 - Meenah
@@ -920,7 +921,10 @@ Art Tags:
 - Sans
 - Dabe
 - Fresh Jimmy
+- Consorts
+- Battlefield
 - Derse
+- Earth
 - Ruined Earth
 - LoCaH
 - Skaia

--- a/album/lofam.yaml
+++ b/album/lofam.yaml
@@ -1356,6 +1356,7 @@ Art Tags:
 - John
 - Karkat
 - Terezi
+- Victory Platform
 Referenced Tracks:
 - Showtime (Piano Refrain)
 Commentary: |-

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -445,6 +445,7 @@ Cover Artists:
 - Maddie Haines
 Art Tags:
 - Kanaya
+- Matriorb
 - 'cw: blood (abstract)'
 Referenced Tracks:
 - Savior of the Waking World

--- a/album/lofam4.yaml
+++ b/album/lofam4.yaml
@@ -2565,6 +2565,7 @@ Art Tags:
 - Kanaya
 - Terezi
 - Calliope
+- Victory Platform
 - Skaia
 Referenced Tracks:
 - Black Rose / Green Sun

--- a/album/lofam5.yaml
+++ b/album/lofam5.yaml
@@ -1310,6 +1310,7 @@ Cover Artists:
 Art Tags:
 - John
 - John's dad
+- Victory Platform
 - Skaia
 Commentary: |-
     <i>Not Eno:</i>

--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -245,6 +245,7 @@ URLs:
 Cover Artists:
 - Fender_Jess
 Art Tags:
+- June
 - John
 - Vriska
 Referenced Tracks:

--- a/album/sburb-ost.yaml
+++ b/album/sburb-ost.yaml
@@ -1096,6 +1096,8 @@ URLs:
 - https://youtu.be/UuxoqLL5Yvs
 Cover Artists:
 - Mixt
+Art Tags:
+- Victory Platform
 Commentary: |-
     <i>Tarranon:</i>
     <i>The cusp of victory, at a moment when it seems that it will be snatched away forever - the heroes stand proudly at the crest, knowing that they have succeeded beyond all hope or expectation.</i>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -41,7 +41,7 @@ Content: |-
         - added [[tag:matriorb]] to [[track:rainbow-rebirth]]
         - added [[tag:tumor]] to [[track:game-lost]]
         - added [[tag:veil]] to [[track:cosmic-malfunction]]
-        - added [[tag:victory-platform]] (new tag) to [[track:disc2-beforus]]
+        - added [[tag:victory-platform]] (new tag) to [[track:farewell]], [[track:higher-hopes]], [[track:disc2-beforus]], [[track:black-hole-white-door]], [[track:reunion]]
         - [[track:720x-showdown-combo]]: added [[tag:the-condesce]], [[tag:consorts]], [[tag:battlefield]], [[tag:earth]]
 
     <h2 id="20-sep-2023"><a href="#20-sep-2023">[[date:20 September 2023]] - after<sup>2</sup>party cleanup</a></h2>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -28,6 +28,22 @@ Style: |-
         margin-bottom: 0.6em;
     }
 Content: |-
+    <h2 id="23-sep-2023"><a href="#23-sep-2023">[[date:23 September 2023]] - jerry's theme for deltarune ch. 7</a></h2>
+    <h3>data fixes</h3>
+    - added various missing art tags
+        - added [[tag:alternia]] to [[track:tumescent]], [[track:vwigor8us]]
+        - added [[tag:beforus]] to [[track:cheater-pan]], [[track:damiterneightions]], [[track:tree-dwellers]], [[track:east-beforan-funk]]
+        - added [[tag:dream-bubbles]] to [[track:vwiolet-vwelvwet]]
+        - added [[tag:frog-temple]] to [[track:disc1-beforus]]
+        - added [[tag:gate]] to [[track:times-apostate]]
+        - added [[tag:june]] to [[track:vriskafic8ion]]
+        - added [[tag:loqam]] to [[track:rust-witch]], [[track:press-a-to-reset]], [[track:the-scratch-before-the-calm]], [[track:motions-of-infinity]]
+        - added [[tag:matriorb]] to [[track:rainbow-rebirth]]
+        - added [[tag:tumor]] to [[track:game-lost]]
+        - added [[tag:veil]] to [[track:cosmic-malfunction]]
+        - added [[tag:victory-platform]] (new tag) to [[track:disc2-beforus]]
+        - [[track:720x-showdown-combo]]: added [[tag:the-condesce]], [[tag:consorts]], [[tag:battlefield]], [[tag:earth]]
+
     <h2 id="20-sep-2023"><a href="#20-sep-2023">[[date:20 September 2023]] - after<sup>2</sup>party cleanup</a></h2>
     <h3>bug fixes</h3>
     - fixed <a href="https://github.com/hsmusic/hsmusic-wiki/issues/277">some links</a> stripping "&lt;", such as in [[album:exile]]

--- a/tags.yaml
+++ b/tags.yaml
@@ -625,6 +625,9 @@ Tag: Felt Manor
 Color: '#c1dd58'
 Tag: Frog Temple
 ---
+Color: '#90dd58'
+Tag: Victory Platform
+---
 Color: '#f2a400'
 Tag: The Theseus
 ---


### PR DESCRIPTION
See updated changelog (or just the diff) for details.

Notably, this adds a "Victory Platform" tag, but it's only so far used in one track. I'd like to go over at least some fandom music (apart from Beforus and Ancestral, which are already done) to see if it's really not used anywhere - went over the whole official discography and it wasn't featured there at all.

Other from that, this PR is good to go.

LoQaM additions (for any instance of the music box + quartz platform) may be somewhat controversial - it's more associated with the scratch than Damara's land, necessarily. But it is an existing tag and that's the major defining feature of LoQaM, so figured it should be okay.

Most other tag additions were reviewed [in #art-tag-review](https://discord.com/channels/749042497610842152/954144431051788370/1154872028281712700). (Linked discussion starts with [BeforusBound review](https://github.com/hsmusic/hsmusic-data/pull/280).)