### PR TITLE
Move Kate Mitchell's twitter to dead URLs

### DIFF
--- a/artists.yaml
+++ b/artists.yaml
@@ -3671,9 +3671,9 @@ Artist: Kate Griffith
 Artist: Kate Mitchell
 URLs:
 - https://katemitchell.bandcamp.com/
-- https://twitter.com/gamblignant8
 Dead URLs:
 - https://www.ssstudio.org/kate
+- https://twitter.com/gamblignant8
 ---
 Artist: Katharine Lee Bates
 ---


### PR DESCRIPTION
Kate deleted her twitter years ago; the current account with that handle belongs to someone else.