### PR TITLE
Add directory to Bittersweet (Jamie Paige)

### DIFF
--- a/album/bittersweet.yaml
+++ b/album/bittersweet.yaml
@@ -604,6 +604,8 @@ Lyrics: |-
     And voices for the voiceless
 ---
 Track: Bittersweet
+Directory: bittersweet-jamie-paige
+Always Reference By Directory: true
 Duration: '4:16'
 URLs:
 - https://jamiepaige.bandcamp.com/track/bittersweet


### PR DESCRIPTION
Vast Error Volume 4 has a song also called Bittersweet, so preemptively resolve the conflict by adding a directory label to the Jamie Paige song of the same name.