### PR TITLE
add Ebichahan (Shrimp Miku song)

### DIFF
--- a/album/ebichahan.yaml
+++ b/album/ebichahan.yaml
@@ -1,4 +1,4 @@
-Album: エ​ビ​チ​ャ​ー​ハ​ン​! (You're Telling Me A SHRIMP Fried This Rice?!)
+Album: エビチャーハン! (You're Telling Me A SHRIMP Fried This Rice?!)
 Directory: ebichahan
 Artists:
 - Jamie Paige
@@ -14,16 +14,25 @@ Groups:
 - Beyond
 Cover Art File Extension: jpg
 Commentary: |-
-    <i>Jamie Paige:</i>
+    <i>Jamie Paige:</i> ([Bandcamp about blurb](https://jamiepaige.bandcamp.com/album/you-re-telling-me-a-shrimp-fried-this-rice))
+
     you're telling me a shrimp fried this rice? you're telling me a shrimp fell in love? you're telling me a shrimp can feel human emotions? you're telling me a shrimp can feel pain. you're telling me a shrimp could hurt me. i'm scared of you
 
-    CHECK OUT THE VIDEO ON YOUTUBE TOO!!! <a href="https://youtu.be/s742C0v5SFI">youtu.be/s742C0v5SFI</a>
+    CHECK OUT THE VIDEO ON YOUTUBE TOO!!! [youtu.be/s742C0v5SFI](https://youtu.be/s742C0v5SFI)
 
-    instrumental and vsq: <a href="https://app.box.com/s/23emvg4cett8hhno4e0q8ww8pca4dig8">app.box.com/s/23emvg4cett8hhno4e0q8ww8pca4dig8</a>
+    instrumental and vsq: [app.box.com/s/23emvg4cett8hhno4e0q8ww8pca4dig8](https://app.box.com/s/23emvg4cett8hhno4e0q8ww8pca4dig8)
+
+    <i>Jamie Paige:</i> ([Bandcamp credits blurb](https://jamiepaige.bandcamp.com/album/you-re-telling-me-a-shrimp-fried-this-rice))
+
+    vocals by hatsune miku v4 english<br>
+    manic seafood induced fever dream by shrimp miku<br>
+    shrimp miku by rice ( [ricedeity.neocities.org/shrimpku](https://ricedeity.neocities.org/shrimpku) )<br>
+    incredible dj voice tag by kowboat<br>
+    everything else by yours truly, Jamie Paige!
 ---
-Track: エ​ビ​チ​ャ​ー​ハ​ン​! (You're Telling Me A SHRIMP Fried This Rice?!)
+Track: エビチャーハン! (You're Telling Me A SHRIMP Fried This Rice?!)
 Contributors:
-- Hatsune Miku
+- Hatsune Miku (Vocaloid, starring role)
 Directory: ebichahan
 Duration: '3:19'
 URLs:

--- a/album/ebichahan.yaml
+++ b/album/ebichahan.yaml
@@ -1,0 +1,96 @@
+Album: エ​ビ​チ​ャ​ー​ハ​ン​! (You're Telling Me A SHRIMP Fried This Rice?!)
+Directory: ebichahan
+Artists:
+- Jamie Paige
+Date: December 12, 2023
+Date Added: December 23, 2023
+URLs:
+- https://jamiepaige.bandcamp.com/album/you-re-telling-me-a-shrimp-fried-this-rice
+Cover Artists:
+- Jamie Paige
+Color: '#73c2c9'
+Groups:
+- Jamie Paige
+- Beyond
+Cover Art File Extension: jpg
+Commentary: |-
+    <i>Jamie Paige:</i>
+    you're telling me a shrimp fried this rice? you're telling me a shrimp fell in love? you're telling me a shrimp can feel human emotions? you're telling me a shrimp can feel pain. you're telling me a shrimp could hurt me. i'm scared of you
+
+    CHECK OUT THE VIDEO ON YOUTUBE TOO!!! <a href="https://youtu.be/s742C0v5SFI">youtu.be/s742C0v5SFI</a>
+
+    instrumental and vsq: <a href="https://app.box.com/s/23emvg4cett8hhno4e0q8ww8pca4dig8">app.box.com/s/23emvg4cett8hhno4e0q8ww8pca4dig8</a>
+---
+Track: エ​ビ​チ​ャ​ー​ハ​ン​! (You're Telling Me A SHRIMP Fried This Rice?!)
+Contributors:
+- Hatsune Miku
+Directory: ebichahan
+Duration: '3:19'
+URLs:
+- https://jamiepaige.bandcamp.com/track/you-re-telling-me-a-shrimp-fried-this-rice
+- https://www.youtube.com/watch?v=s742C0v5SFI
+Lyrics: |-
+    I cook my dinners for an audience
+    At least that's what I'd like to do
+    Lately it's me and my irrelevance
+    Garnished with hopeless love for you
+
+    I cut these onions 'til I cry
+    Sear my heart on every side
+    Golden brown and lightly fried
+    I just don't know what I'm to do
+    With this meal I made for two...
+    Unless I cook for you!
+
+    I made a home-cooked meal
+    Full of everything I feel
+    And I send my love
+    Through the searing stainless steel
+    I hope you feel the heat
+    'Cause you're everything to me
+    Have this shrimp fried rice
+    No more talking, let's just eat!
+
+    You cook your dinners with no elegance
+    Nothing pretty, just some food
+    That might be why you're such a pessimist
+    Every day its plain white rice and chicken breast with protein powder, it's petulant!
+
+    Sous vide it slowly for a day
+    While the lonely hours away
+    Watch those colors turn to grey
+    Wouldn't your dinner feel complete
+    With some savory and sweet?
+    Just come and cook with me!
+
+    I made a home-cooked meal
+    Full of everything I feel
+    And I send my love
+    Through the searing stainless steel
+    I hope you come and eat
+    'Cause it's such a tasty treat
+    Have this shrimp fried rice
+    Grab a plate and take a seat!
+
+    Oh, Shrimp Miku in the place to be
+    You want a shrimp fajita or a shrimp scampi?
+    I got thirty-nine methods to prepare seafood
+    And I'd make up a million more for you
+    You make my heart beat wild and free
+    Now I'm seeing colors that I can't perceive
+    Baby don't back down, take a chance on me
+    And no, I don't give a shit about your shellfish allergy!
+
+    I don't care!
+    You're gonna eat this fried rice I made for you
+    Or... or there's gonna be problems!
+    You hear me?
+
+    I made a home-cooked meal
+    Full of everything I feel
+    And I send my love
+    Through the searing stainless steel
+    I hope you feel the heat
+    'Cause you're everything to me
+    Have this shrimp fried rice
+    No more talking, let's just eat!

--- a/artists.yaml
+++ b/artists.yaml
@@ -3241,6 +3241,8 @@ Artist: Hart
 Aliases:
 - realdeaal
 ---
+Artist: Hatsune Miku
+---
 Artist: Haunter
 Aliases:
 - HaunterDubstep


### PR DESCRIPTION
"Ebichahan" is a romanization of the primary title and is how the artist typically refers to it, so used that as the directory label. And indeed, at long last... Hatsune Miku in artists.yaml (in accordance with a previous tentative decision to credit vocal synths as track contributors).