### PR TITLE
Land more details from Jebb's flashes

### DIFF
--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -262,6 +262,7 @@ Cover Artists:
 Art Tags:
 - Meenah
 Referenced Tracks:
+- Condescescion
 - Love You (Feferi's Theme)
 ---
 Track: Pumpkin Party in Sea Hitler's Water Apocalypse
@@ -374,18 +375,84 @@ Referenced Tracks:
 - Airtime
 - Afraid of the Darko
 Lyrics: |-
-    Aw yeah! What's up gamers?<br>I'm GameGrl, and I'm here to show you that girls can game too!<br>Don't go easy on me, guys - unless you want to get beat by a GIRL<br>Are you ready? Let's DO THIS!
-    Yo I'm the GameGrl, and I've got the scores<br>'Cause I woop butt and game hardcore<br>I might look cute but I play to win<br>So get your head in the game, 'cause we're about to begin
-    I got sweet moves and secret skills<br>To pull off the codes, the combos, and kills<br>Tapping my fingers like a maniac<br>This girl's gone bad on a game attack!
-    GAME ATTACK! GAME ATTACK!<br>When I'm on the scoreboard, you sure can tell!<br>GAME ATTACK! GAME ATTACK!<br>Cause I spell my scores "G-R-L!"<br>GAME ATTACK! GAME ATTACK!<br>You gamer guys better take it like a man!<br>GAME ATTACK! GAME ATTACK!<br>If you can't keep up then talk to the hand!
-    (She's a GameGrl) I'm the GameGrl!<br>(She's a GameGrl) The best in the world!<br>(She's a GameGrl) Girls rule!<br>(She's a GameGrl) And boys drool!<br>(She's a GameGrl) I'm kickin' rad!<br>(She's a GameGrl) You're super bad!<br>(She's a GameGrl) Better than the rest<br>When you're gaming with the GameGrl you're gaming with the best!
-    When I say "game", you say "girl!"<br>GAME! GRL! GAME! GRL!<br>When I say "best", you say "the world!"<br>BEST IN! THE WORLD! BEST IN! THE WORLD!<br>When I say girls, you say rule!<br>GIRLS! RULE! GIRLS! RULE!<br>When I say boys, you say drool!<br>BOYS! DROOL! BOYS! DROOL!
+    Aw yeah! What's up gamers?
+    I'm GameGrl, and I'm here to show you that girls can game too!
+    Don't go easy on me, guys - unless you want to get beat by a GIRL
+    Are you ready? Let's DO THIS!
+
+    Yo I'm the GameGrl, and I've got the scores
+    'Cause I woop butt and game hardcore
+    I might look cute but I play to win
+    So get your head in the game, 'cause we're about to begin
+
+    I got sweet moves and secret skills
+    To pull off the codes, the combos, and kills
+    Tapping my fingers like a maniac
+    This girl's gone bad on a game attack!
+    GAME ATTACK! GAME ATTACK!
+    When I'm on the scoreboard, you sure can tell!
+    GAME ATTACK! GAME ATTACK!C
+    ause I spell my scores "G-R-L!"
+    GAME ATTACK! GAME ATTACK!
+    You gamer guys better take it like a man!
+    GAME ATTACK! GAME ATTACK!
+    If you can't keep up then talk to the hand!
+
+    (She's a GameGrl) I'm the GameGrl!
+    (She's a GameGrl) The best in the world!
+    (She's a GameGrl) Girls rule!
+    (She's a GameGrl) And boys drool!
+    (She's a GameGrl) I'm kickin' rad!
+    (She's a GameGrl) You're super bad!
+    (She's a GameGrl) Better than the rest
+    When you're gaming with the GameGrl you're gaming with the best!
+
+    When I say "game", you say "girl!"
+    GAME! GRL! GAME! GRL!
+    When I say "best", you say "the world!"
+    BEST IN! THE WORLD! BEST IN! THE WORLD!
+    When I say girls, you say rule!
+    GIRLS! RULE! GIRLS! RULE!
+    When I say boys, you say drool!
+    BOYS! DROOL! BOYS! DROOL!
+
     (Let's have a dance party RIGHT NOW. Everybody do the wave! Yeah, that's pretty good. Check it out! I'm dancing! I'm dancing! Check this move out! Oh man, oh yeah!)
     (Aw yeah. I'm having SO MUCH FUN. This is like a slumber party where there's nothing to do but play games ALL NIGHT LONG. Oh yeah, and NO BOYS ALLOWED. Not that I care - I can beat any boy at any game, any time, anywhere!)
-    Puzzle games, fighting games, action, rpg<br>Shoot 'em ups, beat 'em ups, virtual reality<br>Dating sims, flight sims, CD-rom or console<br>Handheld, arcade, tabletopping oldschool<br>Turn-based, card-based, tactical, strategy<br>Text-based adventure, point-and-click mystery<br>FPS, racers, platforms, rhythm games<br>She's the bomb at anything you can name!
-    GAME ATTACK! GAME ATTACK!<br>Gamer guys better run and hide!<br>GAME ATTACK! GAME ATTACK!<br>'Cause I'm the baddest, so step aside!<br>GAME ATTACK! GAME ATTACK!<br>I got the stats, and that's my proof!<br>GAME ATTACK! GAME ATTACK!<br>So come on and RAISE THE ROOF!
-    (She's a GameGrl) I'm the GameGrl!<br>(She's a GameGrl) The best in the world!<br>(She's a GameGrl) Girls rule!<br>(She's a GameGrl) And boys drool!<br>(She's a GameGrl) I'm kickin' rad!<br>(She's a GameGrl) You're super bad!<br>(She's a GameGrl) 'Cause I've got the moves<br>So step into my GAMER GROOVE.
-    (She's a GameGrl) Don't be a wimp!<br>(She's a GameGrl) Unless you're a shrimp!<br>(She's a GameGrl) I'm the new cool!<br>(She's a GameGrl) You're old school!<br>(She's a GameGrl) Gaming like a pro!<br>(She's a GameGrl) Come on, let's go!<br>(She's a GameGrl) Better than the rest<br>When you're gaming with the GameGrl you're gaming with the best!
+    Puzzle games, fighting games, action, rpg
+    Shoot 'em ups, beat 'em ups, virtual reality
+    Dating sims, flight sims, CD-rom or console
+    Handheld, arcade, tabletopping oldschool
+    Turn-based, card-based, tactical, strategy
+    Text-based adventure, point-and-click mystery
+    FPS, racers, platforms, rhythm games
+    She's the bomb at anything you can name!
+
+    GAME ATTACK! GAME ATTACK!
+    Gamer guys better run and hide!
+    GAME ATTACK! GAME ATTACK!
+    'Cause I'm the baddest, so step aside!
+    GAME ATTACK! GAME ATTACK!
+    I got the stats, and that's my proof!
+    GAME ATTACK! GAME ATTACK!
+    So come on and RAISE THE ROOF!
+    (She's a GameGrl) I'm the GameGrl!
+    (She's a GameGrl) The best in the world!
+    (She's a GameGrl) Girls rule!
+    (She's a GameGrl) And boys drool!
+    (She's a GameGrl) I'm kickin' rad!
+    (She's a GameGrl) You're super bad!
+    (She's a GameGrl) 'Cause I've got the moves
+    So step into my GAMER GROOVE.
+
+    (She's a GameGrl) Don't be a wimp!
+    (She's a GameGrl) Unless you're a shrimp!
+    (She's a GameGrl) I'm the new cool!
+    (She's a GameGrl) You're old school!
+    (She's a GameGrl) Gaming like a pro!
+    (She's a GameGrl) Come on, let's go!
+    (She's a GameGrl) Better than the rest
+    When you're gaming with the GameGrl you're gaming with the best!
+
     (Awesome! That was totally rad to the max! I could just keep doing this all day... NOT! I've got games to play, and if you think I'm gonna slow down just to talk to a bunch of amateurs, then you need to seriously blow the dust out of your cartridges. But hey, girls, whenever you need to show those creepy boys who's boss, just remember that GameGrl's got your back. Look for me on specially-marked boxes of Betty Crocker brand snacks and have an adult call the toll-free number to subscribe to the exclusive girls-only GameGrl Magazine. Alright, check you later girlfriends!)
 Commentary: |-
     <i>Michael Guy Bowman:</i>

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -264,6 +264,14 @@ Art Tags:
 Referenced Tracks:
 - Condescescion
 - Love You (Feferi's Theme)
+Commentary: |-
+    <i>Toby Fox:</i> ([Tumblr](https://fwugradiation.tumblr.com/post/18531350938/glub-glub-wub-wub-based-off-of-the-old-condesce))
+
+    <img src="media/misc/glubglub2.gif" width="100" pixelate inline>
+
+    GLUB GLUB WUB WUB
+
+    based off of the old condesce theme I did [[track:condescescion|last time she debuted]]
 ---
 Track: Pumpkin Party in Sea Hitler's Water Apocalypse
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -183,8 +183,16 @@ Duration: '0:15'
 URLs:
 - https://www.youtube.com/watch?v=A2TB9hcb38g
 - https://hsmusic.wiki/media/misc/archive/Condescescion.mp3
-Referenced Tracks:
-- Hate You
+Commentary: |-
+    <i>Toby Fox:</i> ([Tumblr](https://web.archive.org/web/20121124063921/https://fwugradiation.tumblr.com/post/8941917003/just-screwing-around-but-sometimes-music-plays-in))
+
+    <img src="media/misc/04060.gif" width="240">
+
+    just screwing around, but sometimes music plays in my head as I read panels and I wanted to get something out for her before I went to bed
+
+    <i>Quasar Nebula:</i>
+
+    Appears to be an unofficial name, possibly originating in the Homestuck Sound Test. This track is an early sketch that eventually turned into [[Hate You]].
 ---
 Track: Davesprite2
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -328,6 +328,8 @@ URLs:
 - https://hsmusic.wiki/media/misc/archive/Firefly%20Cloud%20Remix.mp3
 Referenced Tracks:
 - Firefly Cloud
+Sampled Tracks:
+- Firefly Cloud
 ---
 Track: Five-Four Stress
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -310,6 +310,7 @@ URLs:
 - https://hsmusic.wiki/media/misc/archive/Feel.mp3
 ---
 Track: Fill 'Em With Midnight
+Duration: '2:14'
 Artists:
 - Malcolm Brown
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -274,6 +274,8 @@ URLs:
 - https://youtube.com/@AliceFlare
 - https://twitter.com/AliceInAltoland
 - https://instagram.com/mermaidmelodymagic
+- https://www.twitch.tv/aliceflare
+- https://ko-fi.com/aliceflare
 - https://aliceflare.carrd.co
 ---
 Artist: Alice Hu
@@ -1112,6 +1114,7 @@ Artist: Bryan Loren
 Artist: BUGFlower413
 URLs:
 - https://www.youtube.com/@BugFlower413
+- https://twitter.com/BUGFlower99
 - https://www.deviantart.com/bugflower413
 - https://www.instagram.com/bugflower413/
 ---
@@ -1232,6 +1235,8 @@ URLs:
 Artist: Caliginously0sedated
 Aliases:
 - t33thnb0n35
+Dead URLs:
+- https://www.instagram.com/Caliginously0sedated/
 ---
 Artist: Callan Bencich
 URLs:
@@ -1246,10 +1251,11 @@ URLs:
 ---
 Artist: CapitainLazar
 Aliases:
+- CapitainJoe
 - Stuck At Home Tome
 URLs:
-- https://twitter.com/capitainjoe
 - https://www.youtube.com/@stuckhometome
+- https://twitter.com/capitainjoe
 ---
 Artist: Captainquestion
 URLs:
@@ -2383,8 +2389,6 @@ Artist: E.N.
 ---
 Artist: Earth, Wind & Fire
 ---
-Artist: Ehidney
----
 Artist: Ed Bryan
 ---
 Artist: eddieDraws
@@ -2443,6 +2447,8 @@ Aliases:
 URLs:
 - https://egosweetheart.tumblr.com/
 - https://twitter.com/egosweetheart
+---
+Artist: Ehidney
 ---
 Artist: Eiffel 65
 ---
@@ -2931,8 +2937,8 @@ URLs:
 ---
 Artist: garbageGothic
 URLs:
-- https://twitter.com/GarbageGothic
 - https://www.youtube.com/@garbageGothic
+- https://twitter.com/Garbagegothic
 ---
 Artist: GavynTGM
 URLs:
@@ -5407,6 +5413,7 @@ URLs:
 - https://mloreley.tumblr.com
 - https://www.youtube.com/@MLoreley
 - https://www.patreon.com/mloreley
+- https://mloreley.carrd.co/
 ---
 Artist: Mmetafour
 URLs:
@@ -7491,6 +7498,7 @@ URLs:
 - https://twitter.com/redasatomato
 - https://www.youtube.com/@tomatokind
 - https://www.instagram.com/redasatomato/
+- https://www.twitch.tv/redasatomato
 ---
 Artist: redrosesrot
 Aliases:
@@ -9641,6 +9649,10 @@ URLs:
 - https://twitter.com/RichaadEB
 - https://www.youtube.com/@RichaadEB
 - https://open.spotify.com/artist/4IF11U0nzFhAaLDGZH3vSx
+- https://music.apple.com/us/artist/richaadeb/898452408
+- https://www.instagram.com/richaadeb/
+- https://www.tiktok.com/@richaadeb
+- https://www.twitch.tv/richaadeb
 ---
 Artist: rilez
 URLs:


### PR DESCRIPTION
Lands ee3da34 and e78b02b by @JebbJabroni. This is a follow-up to #384, for which the source commit (1d6a637) included all the flashes, but was missing artist and track additions (because it missed those two commits). This PR lands certain differences between Jebb's tracks/flashes and the ones we created for the earlier PR.

Merge alongside hsmusic/hsmusic-media#24.