### PR TITLE
Oceanfalls Vol. 2 art + tag fixes

### DIFF
--- a/album/oceanfalls-vol-2.yaml
+++ b/album/oceanfalls-vol-2.yaml
@@ -145,6 +145,7 @@ Art Tags:
 - Five (Oceanfalls)
 - Solis (Oceanfalls)
 - Lune (Oceanfalls)
+- Sis (Oceanfalls)
 ---
 Track: Monstertown
 Artists:
@@ -165,6 +166,7 @@ URLs:
 Cover Artists:
 - leiirue
 Cover Art Date: January 25, 2024
+# Unnamed one-off character, per leii
 ---
 Track: Nothing But a Small Request
 Artists:
@@ -200,6 +202,7 @@ URLs:
 - https://nightslights.bandcamp.com/track/encounter-with-hostile-maids
 Cover Artists:
 - yazshu
+# Unnamed one-off characters, per leii
 ---
 Track: Dear Little Queen
 Artists:
@@ -358,6 +361,10 @@ Cover Artists:
 Cover Art Date: January 25, 2024
 Art Tags:
 - Five (Oceanfalls)
+- Reed (Oceanfalls)
+- Meimona (Oceanfalls)
+- Nino (Oceanfalls)
+- Aria (Oceanfalls)
 ---
 Track: Left in a Forest
 Artists:

--- a/album/oceanfalls-vol-2.yaml
+++ b/album/oceanfalls-vol-2.yaml
@@ -3,6 +3,7 @@ Date: April 27, 2019
 Date Added: January 12, 2021
 URLs:
 - https://nightslights.bandcamp.com/album/oceanfalls-vol-2
+- https://www.youtube.com/watch?v=UyeKdsKg0vw
 Cover Artists:
 - nights
 Color: '#ca7150'
@@ -37,8 +38,16 @@ Artists:
 Duration: '1:17'
 URLs:
 - https://nightslights.bandcamp.com/track/a-wild-monster-appeared
+Cover Artists:
+- "[AT]"
+Cover Art Date: January 25, 2024
 Referenced Tracks:
 - track:battle-wild-pokemon-pokemon-red-and-blue-versions
+Art Tags:
+- Nino (Oceanfalls)
+- Five (Oceanfalls)
+- 'cw: blood'
+- 'cw: body horror'
 ---
 Track: Moongaze
 Artists:
@@ -102,6 +111,11 @@ Artists:
 Duration: '2:42'
 URLs:
 - https://nightslights.bandcamp.com/track/reminiscence
+Cover Artists:
+- Wights End
+Cover Art Date: January 25, 2024
+Art Tags:
+- Aria (Oceanfalls)
 ---
 Track: Aria's House
 Artists:
@@ -111,6 +125,11 @@ URLs:
 - https://nightslights.bandcamp.com/track/arias-house
 Referenced Tracks:
 - track:illusions-oceanfalls
+Cover Artists:
+- n3rdysk3tch3s
+Cover Art Date: January 25, 2024
+Art Tags:
+- Aria (Oceanfalls)
 ---
 Track: Arts and Crafts
 Artists:
@@ -131,6 +150,9 @@ Artists:
 Duration: '1:18'
 URLs:
 - https://nightslights.bandcamp.com/track/monstertown
+Cover Artists:
+- Wights End
+Cover Art Date: January 25, 2024
 ---
 Track: No Horn No Cash No Service
 Artists:
@@ -138,6 +160,9 @@ Artists:
 Duration: '2:24'
 URLs:
 - https://nightslights.bandcamp.com/track/no-horn-no-cash-no-service
+Cover Artists:
+- leiirue
+Cover Art Date: January 25, 2024
 ---
 Track: Nothing But a Small Request
 Artists:
@@ -219,6 +244,12 @@ Artists:
 Duration: '1:38'
 URLs:
 - https://nightslights.bandcamp.com/track/remember-you
+Cover Artists:
+- Nights
+Cover Art Date: January 25, 2024
+Art Tags:
+- Nino (Oceanfalls)
+- Aria (Oceanfalls)
 ---
 Track: Sage Chains
 Artists:
@@ -237,6 +268,12 @@ Artists:
 Duration: '2:38'
 URLs:
 - https://nightslights.bandcamp.com/track/swaying-chains
+Cover Artists:
+- yazshu
+Cover Art Date: January 25, 2024
+Art Tags:
+- Corona (Oceanfalls)
+- 'cw: blood (abstract)'
 ---
 Track: In Another World
 Artists:
@@ -314,6 +351,11 @@ Artists:
 Duration: '1:49'
 URLs:
 - https://nightslights.bandcamp.com/track/the-fifth-flower
+Cover Artists:
+- Hiklight
+Cover Art Date: January 25, 2024
+Art Tags:
+- Five (Oceanfalls)
 ---
 Track: Left in a Forest
 Artists:
@@ -332,6 +374,11 @@ Artists:
 Duration: '1:36'
 URLs:
 - https://nightslights.bandcamp.com/track/court-of-one-thousand-and-one-pawns
+Cover Artists:
+- nights
+Cover Art Date: January 25, 2024
+Art Tags:
+- Suvillan (Oceanfalls)
 ---
 Section: Bonus tracks
 ---

--- a/album/oceanfalls-vol-2.yaml
+++ b/album/oceanfalls-vol-2.yaml
@@ -71,6 +71,7 @@ Cover Artists:
 Art Tags:
 - Nino (Oceanfalls)
 - Five (Oceanfalls)
+- Ludwig (Oceanfalls)
 ---
 Track: Deep Into the Dead Forest
 Artists:
@@ -93,6 +94,7 @@ Cover Artists:
 - Wights End
 Art Tags:
 - Aria (Oceanfalls)
+- Ludwig (Oceanfalls)
 ---
 Track: Long Ago
 Artists:

--- a/album/oceanfalls-vol-2.yaml
+++ b/album/oceanfalls-vol-2.yaml
@@ -202,7 +202,10 @@ URLs:
 - https://nightslights.bandcamp.com/track/encounter-with-hostile-maids
 Cover Artists:
 - yazshu
-# Unnamed one-off characters, per leii
+Art Tags:
+- Avarita (Oceanfalls)
+- Gula (Oceanfalls)
+- Ira (Oceanfalls)
 ---
 Track: Dear Little Queen
 Artists:

--- a/album/oceanfalls-vol-3.yaml
+++ b/album/oceanfalls-vol-3.yaml
@@ -98,6 +98,7 @@ Art Tags:
 - Nino (Oceanfalls)
 - Meimona (Oceanfalls)
 - Kaji (Oceanfalls)
+- Boyfriend (Oceanfalls)
 ---
 Track: Best Boyfriend
 Artists:
@@ -107,6 +108,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/best-boyfriend
 Cover Artists:
 - nights
+Art Tags:
+- Boyfriend (Oceanfalls)
 Lyrics: |-
     (Meow)
 ---
@@ -216,6 +219,7 @@ Cover Artists:
 - nights
 Art Tags:
 - Selene (Oceanfalls)
+- Cats
 Referenced Tracks:
 - ANGRY CAT OwO
 ---
@@ -281,6 +285,7 @@ Referenced Tracks:
 - Galactic Princess Selene Opening 1
 Art Tags:
 - Selene (Oceanfalls)
+- Cats
 ---
 Track: Kaji's Theme
 Artists:

--- a/album/oceanfalls-vol-3.yaml
+++ b/album/oceanfalls-vol-3.yaml
@@ -34,6 +34,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/a-long-time-ago
 Cover Artists:
 - nights
+Art Tags:
+- Lady Oshen
 ---
 Track: The Cavern of Illusions
 Artists:
@@ -137,6 +139,9 @@ Cover Artists:
 - nights
 Art Tags:
 - Kaji (Oceanfalls)
+- Blackfin (Oceanfalls)
+- Warty (Oceanfalls)
+- Weddell (Oceanfalls)
 ---
 Track: Galactic Princess Selene Opening 1
 Artists:
@@ -184,6 +189,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/cinders
 Cover Artists:
 - Hadron
+Art Tags:
+- Marzipan Aries (Oceanfalls)
 ---
 Track: Raven Hood (Mei Appears)
 Artists:
@@ -242,6 +249,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/onyxs-theme
 Cover Artists:
 - nights
+Art Tags:
+- Onyx (Oceanfalls)
 ---
 Track: Tale of Valkyries
 Artists:
@@ -254,6 +263,7 @@ Cover Artists:
 Art Tags:
 - Nino (Oceanfalls)
 - Meimona (Oceanfalls)
+- Herja Aquarius (Oceanfalls)
 ---
 Track: Ytu Rendy
 Artists:
@@ -310,5 +320,8 @@ Cover Artists:
 - Hadron
 Art Tags:
 - Kaji (Oceanfalls)
+- Blackfin (Oceanfalls)
+- Warty (Oceanfalls)
+- Weddell (Oceanfalls)
 Referenced Tracks:
 - Sea Patrol (Ocean Quarrel)

--- a/album/oceanfalls-vol-4.yaml
+++ b/album/oceanfalls-vol-4.yaml
@@ -154,6 +154,7 @@ Cover Artists:
 - Hiklight
 Art Tags:
 - Kaji (Oceanfalls)
+- Warty (Oceanfalls)
 ---
 Track: Limefalls
 Artists:

--- a/album/oceanfalls-vol-4.yaml
+++ b/album/oceanfalls-vol-4.yaml
@@ -124,6 +124,7 @@ URLs:
 Cover Artists:
 - nights
 Art Tags:
+- Sis (Oceanfalls)
 - Solis (Oceanfalls)
 ---
 Track: Inept Quartet

--- a/album/oceanfalls-vol-4.yaml
+++ b/album/oceanfalls-vol-4.yaml
@@ -89,6 +89,7 @@ Cover Artists:
 - Griffin Wayne
 Art Tags:
 - Meimona (Oceanfalls)
+- Boyfriend (Oceanfalls)
 ---
 Track: Beloved Little Prodigy
 Artists:

--- a/album/oceanfalls-vol-five.yaml
+++ b/album/oceanfalls-vol-five.yaml
@@ -85,6 +85,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/metal-and-meat
 Cover Artists:
 - nights
+Art Tags:
+- Ruby (Oceanfalls)
 ---
 Track: Birthday Girl
 Artists:
@@ -130,6 +132,7 @@ URLs:
 Cover Artists:
 - nights
 Art Tags:
+- Zachery (Oceanfalls)
 - Sis (Oceanfalls)
 ---
 Track: Hazardous Path

--- a/album/oceanfalls-vol-five.yaml
+++ b/album/oceanfalls-vol-five.yaml
@@ -44,6 +44,8 @@ Art Tags:
 - Aria (Oceanfalls)
 - Reed (Oceanfalls)
 - Nino (Oceanfalls)
+- Ludwig (Oceanfalls)
+- Boyfriend (Oceanfalls)
 ---
 Track: Memories of Home
 Artists:

--- a/album/oceanfalls-vol-five.yaml
+++ b/album/oceanfalls-vol-five.yaml
@@ -14,6 +14,7 @@ Art Tags:
 - Five (Oceanfalls)
 - Solis (Oceanfalls)
 - Lune (Oceanfalls)
+- Sis (Oceanfalls)
 Cover Art File Extension: png
 Track Art File Extension: png
 Wallpaper File Extension: png
@@ -116,6 +117,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/hollowed-halls
 Cover Artists:
 - InkyKnight
+Art Tags:
+- Sis (Oceanfalls)
 ---
 Track: Emblems of a Magnum Opus
 Artists:
@@ -126,6 +129,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/emblems-of-a-magnum-opus
 Cover Artists:
 - nights
+Art Tags:
+- Sis (Oceanfalls)
 ---
 Track: Hazardous Path
 Artists:

--- a/artists.yaml
+++ b/artists.yaml
@@ -683,6 +683,13 @@ Artist: aswfs
 Dead URLs:
 - https://aswfs.tumblr.com/
 ---
+Artist: '[AT]'
+Aliases:
+- D nD
+Dead URLs:
+- https://www.youtube.com/@dnd402/
+  # Not dead, but nothing particular here. They commented ":)) my art" during the Vol. 2 stream.
+---
 Artist: Audra Furuichi
 URLs:
 - https://twitter.com/kyubikitsy
@@ -6055,6 +6062,16 @@ URLs:
 - https://www.deviantart.com/myotishi
 ---
 Artist: N.W.A.
+---
+Artist: n3rdysk3tch3s
+Aliases:
+- Lulu
+URLs:
+- https://doodles-of-a-nerd-kid.tumblr.com/
+- https://www.instagram.com/n3rdysk3tch3s/
+- https://02x.lu/
+Dead URLs:
+- https://twitter.com/xLuDrawsx
 ---
 Artist: Naofumi Hataya
 ---

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -145,7 +145,7 @@ Content: |-
     - tidied, touched up with links, and double-checked for accuracy almost all transcribed commentary originating in booklets, from albums: [[album:alternia]], [[album:sburb]], [[album:alterniabound]], [[album:homestuck-vol-10]], [[album:beyond-canon]]
     - added Bandcamp commentary/credit blurbs, as well as news and descriptions from whatpumpkin.com, across [[group:official]]
     - added various missing MSPA news blurbs across [[group:official]], including practically all albums, plus [[track:black]], [[track:unite-synchronization]] and [[track:eternity-served-cold]] (thanks, Lilith!)
-    - added new artworks (and listening link) to [[album:oceanfalls-vol-2]]!
+    - added new artworks (and listening link) to [[album:oceanfalls-vol-2]]! (thanks to leii for help with the art tags!)
     - added a bunch of fan animations (thanks, Jebb!)
         - added animations by [[artist:shadok]]: [[flash:homestuck-the-baby-is-you-animated]] through [[flash:noelle-is-spamtons-mom]]
         - added animations by [[artist:bugflower413]]: [[flash:damara-ascend]] through [[flash:dethrone-bugflower413]]
@@ -290,11 +290,16 @@ Content: |-
     - fixed [[track:feels-jam]] being tagged [[tag:lomax]] instead of [[tag:lotak]] (thanks, Pyryte!)
     - fixed [[track:random-encounter]] not being tagged [[tag:ludwig-oceanfalls]]
     - fixed [[track:ghostdog-good-boy]] not being tagged [[tag:ludwig-oceanfalls]]
+    - fixed [[track:arts-and-crafts]] not being tagged [[tag:sis-oceanfalls]] (thanks, leii!)
     - fixed [[track:sea-patrol-ocean-quarrel]] not being tagged [[tag:boyfriend-oceanfalls]]
     - fixed [[track:best-boyfriend]] not being tagged [[tag:boyfriend-oceanfalls]]
     - fixed [[track:angry-cat-owo-oceanfalls-version]] not being tagged [[tag:cats]]
     - fixed [[track:galactic-princess-selene-battle-theme]] not being tagged [[tag:cats]]
     - fixed [[track:oceancute]] not being tagged [[tag:boyfriend-oceanfalls]]
+    - fixed [[track:burning-wood-blocks]] not being tagged [[tag:sis-oceanfalls]]
+    - fixed [[album:oceanfalls-vol-five]] not being tagged [[tag:sis-oceanfalls]]
+    - fixed [[track:hollowed-halls]] not being tagged [[tag:sis-oceanfalls]]
+    - fixed [[track:emblems-of-a-magnum-opus]] not being tagged [[tag:sis-oceanfalls]]
     - fixed [[track:cinq]] not being tagged [[tag:ludwig-oceanfalls]] and [[tag:boyfriend-oceanfalls]]
     - fixed [[flash:1940]] not featuring [[track:squiddles]] and [[track:friendship-aneurysm]] (thanks, Pyryte!)
     - fixed domains for battleofthebits links on [[track:grrrarrr]] and [[artist:baron-knoxburry]] (thanks, Pyryte!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -145,6 +145,7 @@ Content: |-
     - tidied, touched up with links, and double-checked for accuracy almost all transcribed commentary originating in booklets, from albums: [[album:alternia]], [[album:sburb]], [[album:alterniabound]], [[album:homestuck-vol-10]], [[album:beyond-canon]]
     - added Bandcamp commentary/credit blurbs, as well as news and descriptions from whatpumpkin.com, across [[group:official]]
     - added various missing MSPA news blurbs across [[group:official]], including practically all albums, plus [[track:black]], [[track:unite-synchronization]] and [[track:eternity-served-cold]] (thanks, Lilith!)
+    - added new artworks (and listening link) to [[album:oceanfalls-vol-2]]!
     - added a bunch of fan animations (thanks, Jebb!)
         - added animations by [[artist:shadok]]: [[flash:homestuck-the-baby-is-you-animated]] through [[flash:noelle-is-spamtons-mom]]
         - added animations by [[artist:bugflower413]]: [[flash:damara-ascend]] through [[flash:dethrone-bugflower413]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -291,13 +291,22 @@ Content: |-
     - fixed [[track:random-encounter]] not being tagged [[tag:ludwig-oceanfalls]]
     - fixed [[track:ghostdog-good-boy]] not being tagged [[tag:ludwig-oceanfalls]]
     - fixed [[track:arts-and-crafts]] not being tagged [[tag:sis-oceanfalls]] (thanks, leii!)
+    - fixed [[track:encounter-with-hostile-maids]] not being tagged [[tag:avarita-oceanfalls]], [[tag:gula-oceanfalls]], and [[tag:ira-oceanfalls]] (thanks, leii!)
+    - fixed [[track:a-long-time-ago]] not being tagged [[tag:lady-oshen-oceanfalls]] (thanks, leii!)
     - fixed [[track:sea-patrol-ocean-quarrel]] not being tagged [[tag:boyfriend-oceanfalls]]
     - fixed [[track:best-boyfriend]] not being tagged [[tag:boyfriend-oceanfalls]]
+    - fixed [[track:adventure-at-sea]] not being tagged [[tag:blackfin-oceanfalls]], [[tag:warty-oceanfalls]], and [[tag:weddell-oceanfalls]] (thanks, leii!)
+    - fixed [[track:cinders-oceanfalls]] not being tagged [[tag:marzipan-aries-oceanfalls]] (thanks, leii!)
     - fixed [[track:angry-cat-owo-oceanfalls-version]] not being tagged [[tag:cats]]
+    - fixed [[track:onyxs-theme]] not being tagged [[tag:onyx-oceanfalls]]
+    - fixed [[track:tale-of-valkyries]] not being tagged [[tag:herja-aquarius-oceanfalls]] (thanks, leii!)
     - fixed [[track:galactic-princess-selene-battle-theme]] not being tagged [[tag:cats]]
+    - fixed [[track:sea-patrol-ocean-calm]] not being tagged [[tag:blackfin-oceanfalls]], [[tag:warty-oceanfalls]], and [[tag:weddell-oceanfalls]] (thanks, leii!)
     - fixed [[track:oceancute]] not being tagged [[tag:boyfriend-oceanfalls]]
     - fixed [[track:burning-wood-blocks]] not being tagged [[tag:sis-oceanfalls]]
+    - fixed [[track:portside]] not being tagged [[tag:warty-oceanfalls]] (thanks, leii!)
     - fixed [[album:oceanfalls-vol-five]] not being tagged [[tag:sis-oceanfalls]]
+    - fixed [[track:metal-and-meat]] not being tagged [[tag:zachery-oceanfalls]] (thanks, leii!)
     - fixed [[track:hollowed-halls]] not being tagged [[tag:sis-oceanfalls]]
     - fixed [[track:emblems-of-a-magnum-opus]] not being tagged [[tag:sis-oceanfalls]]
     - fixed [[track:cinq]] not being tagged [[tag:ludwig-oceanfalls]] and [[tag:boyfriend-oceanfalls]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -288,6 +288,14 @@ Content: |-
     - fixed [[track:break-shot]] not being tagged [[tag:green-sun]] and [[tag:ah]] (thanks, Pyryte, FF!)
     - fixed [[track:lost-memories]] not being tagged [[tag:bk]] (thanks, Pyryte!)
     - fixed [[track:feels-jam]] being tagged [[tag:lomax]] instead of [[tag:lotak]] (thanks, Pyryte!)
+    - fixed [[track:random-encounter]] not being tagged [[tag:ludwig-oceanfalls]]
+    - fixed [[track:ghostdog-good-boy]] not being tagged [[tag:ludwig-oceanfalls]]
+    - fixed [[track:sea-patrol-ocean-quarrel]] not being tagged [[tag:boyfriend-oceanfalls]]
+    - fixed [[track:best-boyfriend]] not being tagged [[tag:boyfriend-oceanfalls]]
+    - fixed [[track:angry-cat-owo-oceanfalls-version]] not being tagged [[tag:cats]]
+    - fixed [[track:galactic-princess-selene-battle-theme]] not being tagged [[tag:cats]]
+    - fixed [[track:oceancute]] not being tagged [[tag:boyfriend-oceanfalls]]
+    - fixed [[track:cinq]] not being tagged [[tag:ludwig-oceanfalls]] and [[tag:boyfriend-oceanfalls]]
     - fixed [[flash:1940]] not featuring [[track:squiddles]] and [[track:friendship-aneurysm]] (thanks, Pyryte!)
     - fixed domains for battleofthebits links on [[track:grrrarrr]] and [[artist:baron-knoxburry]] (thanks, Pyryte!)
     - fixed Bandcamp link for [[track:the-land-of-wind-and-shade]] (thanks, Pyryte!)

--- a/tags.yaml
+++ b/tags.yaml
@@ -865,6 +865,9 @@ Tag: Ruta (Oceanfalls)
 Color: '#fef49f'
 Tag: Selene (Oceanfalls)
 ---
+Color: '#89e0a5'
+Tag: Sis (Oceanfalls)
+---
 Color: '#ff6600'
 Tag: Solis (Oceanfalls)
 ---

--- a/tags.yaml
+++ b/tags.yaml
@@ -826,6 +826,12 @@ Tag: Phoebe (Desynced)
 Color: '#9868bc'
 Tag: Aria (Oceanfalls)
 ---
+Color: '#fda27b'
+Tag: Avarita (Oceanfalls)
+---
+Color: '#cf7c72'
+Tag: Blackfin (Oceanfalls)
+---
 Color: '#47abc7'
 Tag: Boyfriend (Oceanfalls)
 ---
@@ -835,11 +841,23 @@ Tag: Corona (Oceanfalls)
 Color: '#c578d4'
 Tag: Five (Oceanfalls)
 ---
+Color: '#a2e69d'
+Tag: Gula (Oceanfalls)
+---
+Color: '#b9976a'
+Tag: Herja Aquarius (Oceanfalls)
+---
+Color: '#87a0fe'
+Tag: Ira (Oceanfalls)
+---
 Color: '#76d8fd'
 Tag: Kaji (Oceanfalls)
 ---
 Color: '#eb0013'
 Tag: Kotori (Oceanfalls)
+---
+Color: '#6e78d4'
+Tag: Lady Oshen (Oceanfalls)
 ---
 Color: '#c1c1c1'
 Tag: Ludwig (Oceanfalls)
@@ -847,14 +865,23 @@ Tag: Ludwig (Oceanfalls)
 Color: '#a380c4'
 Tag: Lune (Oceanfalls)
 ---
+Color: '#fec6ae'
+Tag: Marzipan Aries (Oceanfalls)
+---
 Color: '#318fee'
 Tag: Meimona (Oceanfalls)
 ---
 Color: '#359e41'
 Tag: Nino (Oceanfalls)
 ---
+Color: '#a1a1a1'
+Tag: Onyx (Oceanfalls)
+---
 Color: '#9a6062'
 Tag: Reed (Oceanfalls)
+---
+Color: '#b9a6a2'
+Tag: Ruby (Oceanfalls)
 ---
 Color: '#5c66e8'
 Tag: Ruit (Oceanfalls)
@@ -876,6 +903,15 @@ Tag: Suvillan (Oceanfalls)
 ---
 Color: '#e2b82c'
 Tag: The Queen (Oceanfalls)
+---
+Color: '#fec294'
+Tag: Warty (Oceanfalls)
+---
+Color: '#a99586'
+Tag: Weddell (Oceanfalls)
+---
+Color: '#21f2c8'
+Tag: Zachery (Oceanfalls)
 ---
 Color: '#b95c00'
 Tag: Arcjec (Vast Error)

--- a/tags.yaml
+++ b/tags.yaml
@@ -826,6 +826,9 @@ Tag: Phoebe (Desynced)
 Color: '#9868bc'
 Tag: Aria (Oceanfalls)
 ---
+Color: '#47abc7'
+Tag: Boyfriend (Oceanfalls)
+---
 Color: '#a3cb6a'
 Tag: Corona (Oceanfalls)
 ---
@@ -837,6 +840,9 @@ Tag: Kaji (Oceanfalls)
 ---
 Color: '#eb0013'
 Tag: Kotori (Oceanfalls)
+---
+Color: '#c1c1c1'
+Tag: Ludwig (Oceanfalls)
 ---
 Color: '#a380c4'
 Tag: Lune (Oceanfalls)


### PR DESCRIPTION
Oceanfalls Vol. 2 just got a full album upload/premier on YouTube, featuring several new artworks for tracks which, due to time constraints, lacked art before! This PR adds all those artworks (with the correct `Cover Art Date`), as well as some miscellaneous tag-related stuff.

Basically good to go, just waiting on [some stuff in #art-tag-review](https://discord.com/channels/749042497610842152/954144431051788370/1200267597518737508) (we'll look back on this later, if there's no review there).

Merge alongside hsmusic/hsmusic-media#28.