### PR TITLE
Swapped Nyeh Heh Heh / Bonetrousle references.

### DIFF
--- a/album/entertaining-sound.yaml
+++ b/album/entertaining-sound.yaml
@@ -190,7 +190,7 @@ Referenced Tracks:
 - Undyne
 - track:ruins-undertale
 - Dogsong
-- Nyeh Heh Heh!
+- Bonetrousle
 - Penumbra Phantasm
 - Doctor
 - It's Raining Somewhere Else

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -14062,7 +14062,7 @@ Duration: '5:58'
 URLs:
 - https://soundcloud.com/nine-zero-music/backbone
 Referenced Tracks:
-- Nyeh Heh Heh!
+- Bonetrousle
 - track:megalovania-undertale
 ---
 Track: Badgers

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -744,7 +744,7 @@ URLs:
 Referenced Tracks:
 - track:megalovania-undertale
 - Heartache
-- Nyeh Heh Heh!
+- Bonetrousle
 ---
 Track: Michael Bowman Remix
 Artists:

--- a/album/undertale-soundtrack.yaml
+++ b/album/undertale-soundtrack.yaml
@@ -159,6 +159,8 @@ URLs:
 - https://tobyfox.bandcamp.com/track/nyeh-heh-heh-2
 - https://www.youtube.com/watch?v=-W6_6WHBm1Q
 - https://open.spotify.com/track/6YEGQH32aAXb9vQQbBrPlw
+Referenced Tracks:
+- Bonetrousle
 ---
 Track: Snowy
 Duration: '1:44'
@@ -227,8 +229,6 @@ URLs:
 - https://tobyfox.bandcamp.com/track/bonetrousle
 - https://www.youtube.com/watch?v=AKAiUtWZ4xY
 - https://open.spotify.com/track/2AtC6i0b8TjpjhWBZYLprX
-Referenced Tracks:
-- Nyeh Heh Heh!
 ---
 Track: Dating Start!
 Duration: '1:56'
@@ -665,7 +665,7 @@ URLs:
 - https://open.spotify.com/track/4OOA9mtwTevG39jcALusOu
 Referenced Tracks:
 - track:sans
-- Nyeh Heh Heh!
+- Bonetrousle
 ---
 Track: The Choice
 Duration: '2:12'
@@ -877,7 +877,7 @@ URLs:
 - https://open.spotify.com/track/2uJGEsQ1pvi0pDqxTcDxIj
 Referenced Tracks:
 - Enemy Approaching
-- Nyeh Heh Heh!
+- Bonetrousle
 - track:sans
 - Snowdin Town
 - Undyne

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -336,18 +336,22 @@ Content: |-
     - fixed [[track:namco-high-be-true-to-yourself]] referencing [[track:title-theme-namco-high]], instead of the other way around (thanks, Niklink!)
     - fixed [[track:battle-music]] referencing [[track:title-theme-namco-high]] instead of [[track:namco-high-be-true-to-yourself]]
     - fixed [[track:fallen-down-undertale]] not referencing [[track:fallen-down]]
+    - fixed [[track:bonetrousle]] referencing [[track:nyeh-heh-heh]], instead of the other way around (thanks, Morris!)
+    - fixed [[track:song-that-might-play-when-you-fight-sans]] and [[track:bring-it-in-guys]] referencing [[track:nyeh-heh-heh]] instead of [[track:bonetrousle]] (thanks, Morris!)
     - fixed many [[track:undertale]] references: (thanks, vriska/leo!)
         - fixed [[track:memory-undertale]] referencing [[track:his-theme]] instead of [[track:undertale]]
         - fixed [[track:undertale]] referencing [[track:his-theme]]
         - fixed [[track:the-choice]] referencing [[track:once-upon-a-time]] and [[track:his-theme]], and not sampling [[track:undertale]]
         - fixed [[track:finale-undertale]] referencing [[track:his-theme]] instead of [[track:memory-undertale]]
         - fixed [[track:his-theme]] not referencing [[track:memory-undertale]]
+    - fixed [[track:toby-fox-has-written-hundreds-of-unique-original-songs]] referencing [[track:nyeh-heh-heh]] instead of [[track:bonetrousle]]
     - fixed [[track:my-grand-dad-is-the-green-sun]] not sampling [[track:flare]] (thanks, Rosetta Leijonde!)
     - fixed [[track:sunsetter-ska]] not referencing [[track:sunsetter]]
-    - fixed [[track:megalovania-smash-bros]] referencing [[track:megalovania-halloween]] instead of [[track:megalovania-undertale]], and not referencing [[track:heartache]] and [[track:nyeh-heh-heh]] (thanks, Morris!)
+    - fixed [[track:megalovania-smash-bros]] referencing [[track:megalovania-halloween]] instead of [[track:megalovania-undertale]], and not referencing [[track:heartache]] and [[track:bonetrousle]] (thanks, Morris!)
     - fixed [[track:old-skacret]] not referencing [[track:old-secret]], and added listening link (thanks, Rosetta Leijonde!)
     - fixed [[track:spider-dance-from-undertale-but-now-its-ska-i-guess-yikes]] not referencing [[track:spider-dance]], and added a SoundCloud listening link (thanks, Rosetta Leijonde!)
     - fixed [[track:lifelight]] not referencing [[track:lifelight-jp]] (thanks, Morris!)
+    - fixed [[track:backbone]] referencing [[track:nyeh-heh-heh]] instead of [[track:bonetrousle]]
     - fixed [[track:grand-dads-secret-slide]] not sampling [[track:slider-super-mario-64]]
     - fixed [[track:no-credit-card]] not sampling [[track:the-power-of-love]] (thanks, Rosetta Leijonde!)
     - fixed [[track:ephemeral-muse-final-remix-psycholonials]] not being listed as a rerelease of [[track:ephemeral-muse-final-remix]] (thanks, Lilith!)


### PR DESCRIPTION
In https://web.archive.org/web/20190214235523/https://topics.nintendo.co.jp/c/article/0e438e10-2b35-11e9-b104-0a6d14145cb1.html, Toby mentions that Bonetrousle was the battle theme for his original fever dream ending game, which would get recylced into Deltarune. This implies that Bonetrousle was the original song, and that Nyeh Heh Heh! was based on it.