### PR TITLE
Add Undertale commentary from sheet music booklet

### DIFF
--- a/album/undertale-soundtrack.yaml
+++ b/album/undertale-soundtrack.yaml
@@ -39,7 +39,8 @@ URLs:
 - https://www.youtube.com/watch?v=3BR7-AzE2dQ
 - https://open.spotify.com/track/4XX5uZb9PvTKh8Nm2KSJfk
 Commentary: |-
-    <i>Toby Fox:</i> (sheet music booklet)
+    <i>Toby Fox:</i> ([collector's edition sheet music booklet](https://www.fangamer.com/products/undertale-game-switch-ps4-vita))
+
     This song was created as an homage to the title music to [[artist:mother|MOTHER]], eventually released in the US as EarthBound Beginnings. What inspired me most is how emotional and nostalgic it felt, even with just a few long notes and a simple bassline. I wanted to replicate that. You don't need to write something complicated to express a deep feeling. When something is simple, it's easy to capture your pure expression. And so I think this is a sincere song.
 ---
 Track: Start Menu
@@ -68,7 +69,8 @@ URLs:
 - https://www.youtube.com/watch?v=qH5hM1ILuFQ
 - https://open.spotify.com/track/1jDMi92a9zNQuPD3uPMkla
 Commentary: |-
-    <i>Toby Fox:</i> (sheet music booklet)
+    <i>Toby Fox:</i> ([collector's edition sheet music booklet](https://www.fangamer.com/products/undertale-game-switch-ps4-vita))
+
     Ironically, this is one of many songs in this booklet not to be originally composed for Undertale. I actually created this for a fan-album called [[album:i-miss-you-earthbound-2012|"I Miss You"]] as an attempt at creating an original "Game Over" theme. My main inspiration was the Game Over theme from Zelda 1. I liked how strangely soothing it felt.
 
     Someone recently asked me how I create songs that fit the characters and scenarios in the game so perfectly. Well, given the fact that some of them weren't created for UNDERTALE... I actually think I'm just good at using the fact that the human mind loves to make associations. Whatever you hear first in a scenario will be the thing that "fits."
@@ -170,7 +172,8 @@ URLs:
 Referenced Tracks:
 - Bonetrousle
 Commentary: |-
-    <i>Toby Fox:</i> (sheet music booklet)
+    <i>Toby Fox:</i> ([collector's edition sheet music booklet](https://www.fangamer.com/products/undertale-game-switch-ps4-vita))
+
     This song wasn't made for Undertale either. It (and [[track:bonetrousle|Bonetrousle]]) were the main battle themes of [[album:deltarune-ch1-ost|an RPG game I was working on before Undertale, based off of a dream I had.]] However, I didn't plan it very well, so the project fell apart before I accomplished a single room. [[track:sans|"Sans"]] was also a song in the game called "Muscles," and [[track:heartache|"Heartache"]] was a song called "Joker Battle." Anyway, I always mess up playing this song on the piano, so if you can't play it, it's not a big deal. Since it's Papyrus, it's OK as long as you try your best.
 ---
 Track: Snowy
@@ -223,7 +226,8 @@ URLs:
 Referenced Tracks:
 - Snowy
 Commentary: |-
-    <i>Toby Fox:</i> (sheet music booklet)
+    <i>Toby Fox:</i> ([collector's edition sheet music booklet](https://www.fangamer.com/products/undertale-game-switch-ps4-vita))
+
     This song is a major-sounding arrangement of [[track:snowy|"Snowy"]] from earlier in the soundtrack.
 
     I really liked playing this one on the piano. Whenever I played it my mom would get it stuck in her head and whistle it. So I'm quite proud of it.
@@ -339,7 +343,8 @@ URLs:
 Referenced Tracks:
 - Undertale
 Commentary: |-
-    <i>Toby Fox:</i> (sheet music booklet)
+    <i>Toby Fox:</i> ([collector's edition sheet music booklet](https://www.fangamer.com/products/undertale-game-switch-ps4-vita))
+
     This melody was based off of the song [[track:undertale|"UNDERTALE"]] and originally intended to be a theme for Asgore.
 
     However, the theme ended up used in different contexts, and by the end of the game, it ended up as another character's theme.
@@ -831,7 +836,8 @@ Referenced Tracks:
 - Your Best Friend
 - Snowdin Town
 Commentary: |-
-    <i>Toby Fox:</i> (sheet music booklet)
+    <i>Toby Fox:</i> ([collector's edition sheet music booklet](https://www.fangamer.com/products/undertale-game-switch-ps4-vita))
+
     I didn't actually make these piano arrangements or this booklet (that was Sebastian and Audrey) so I don't think this song is arranged the way I actually play it myself, but... There was a period where I played this song nearly every day on the piano, dreaming about the game I had not finished yet...
 
     However, my wrists have some kind of problem now, so I can't play the piano for very long anymore. That's OK though. Anyway, once you learn this song, be sure to play it any way you like. Express yourself. But, you must make sure that your self-expression doesn't destroy your body.

--- a/album/undertale-soundtrack.yaml
+++ b/album/undertale-soundtrack.yaml
@@ -38,6 +38,9 @@ URLs:
 - https://tobyfox.bandcamp.com/track/once-upon-a-time-2
 - https://www.youtube.com/watch?v=3BR7-AzE2dQ
 - https://open.spotify.com/track/4XX5uZb9PvTKh8Nm2KSJfk
+Commentary: |-
+    <i>Toby Fox:</i> (sheet music booklet)
+    This song was created as an homage to the title music to [[artist:mother|MOTHER]], eventually released in the US as EarthBound Beginnings. What inspired me most is how emotional and nostalgic it felt, even with just a few long notes and a simple bassline. I wanted to replicate that. You don't need to write something complicated to express a deep feeling. When something is simple, it's easy to capture your pure expression. And so I think this is a sincere song.
 ---
 Track: Start Menu
 Duration: 0:32
@@ -64,6 +67,11 @@ URLs:
 - https://tobyfox.bandcamp.com/track/fallen-down-2
 - https://www.youtube.com/watch?v=qH5hM1ILuFQ
 - https://open.spotify.com/track/1jDMi92a9zNQuPD3uPMkla
+Commentary: |-
+    <i>Toby Fox:</i> (sheet music booklet)
+    Ironically, this is one of many songs in this booklet not to be originally composed for Undertale. I actually created this for a fan-album called [[album:i-miss-you-earthbound-2012|"I Miss You"]] as an attempt at creating an original "Game Over" theme. My main inspiration was the Game Over theme from Zelda 1. I liked how strangely soothing it felt.
+
+    Someone recently asked me how I create songs that fit the characters and scenarios in the game so perfectly. Well, given the fact that some of them weren't created for UNDERTALE... I actually think I'm just good at using the fact that the human mind loves to make associations. Whatever you hear first in a scenario will be the thing that "fits."
 ---
 Track: Ruins
 Directory: ruins-undertale
@@ -161,6 +169,9 @@ URLs:
 - https://open.spotify.com/track/6YEGQH32aAXb9vQQbBrPlw
 Referenced Tracks:
 - Bonetrousle
+Commentary: |-
+    <i>Toby Fox:</i> (sheet music booklet)
+    This song wasn't made for Undertale either. It (and [[track:bonetrousle|Bonetrousle]]) were the main battle themes of [[album:deltarune-ch1-ost|an RPG game I was working on before Undertale, based off of a dream I had.]] However, I didn't plan it very well, so the project fell apart before I accomplished a single room. [[track:sans|"Sans"]] was also a song in the game called "Muscles," and [[track:heartache|"Heartache"]] was a song called "Joker Battle." Anyway, I always mess up playing this song on the piano, so if you can't play it, it's not a big deal. Since it's Papyrus, it's OK as long as you try your best.
 ---
 Track: Snowy
 Duration: '1:44'
@@ -211,6 +222,11 @@ URLs:
 - https://open.spotify.com/track/6VhLpbQlPWgU11As8woUIC
 Referenced Tracks:
 - Snowy
+Commentary: |-
+    <i>Toby Fox:</i> (sheet music booklet)
+    This song is a major-sounding arrangement of [[track:snowy|"Snowy"]] from earlier in the soundtrack.
+
+    I really liked playing this one on the piano. Whenever I played it my mom would get it stuck in her head and whistle it. So I'm quite proud of it.
 ---
 Track: Shop
 Directory: shop-undertale
@@ -322,6 +338,15 @@ URLs:
 - https://open.spotify.com/track/4LrlsO9cnnNjxBiHeRedjF
 Referenced Tracks:
 - Undertale
+Commentary: |-
+    <i>Toby Fox:</i> (sheet music booklet)
+    This melody was based off of the song [[track:undertale|"UNDERTALE"]] and originally intended to be a theme for Asgore.
+
+    However, the theme ended up used in different contexts, and by the end of the game, it ended up as another character's theme.
+
+    I already said it, but simplicity is purity. It takes only a few notes to create a dream... to create a memory.
+
+    [[track:dont-forget|Don't forget]] that...
 ---
 Track: Bird That Carries You Over A Disproportionately Small Gap
 Duration: 0:25
@@ -805,6 +830,13 @@ Referenced Tracks:
 - Undertale
 - Your Best Friend
 - Snowdin Town
+Commentary: |-
+    <i>Toby Fox:</i> (sheet music booklet)
+    I didn't actually make these piano arrangements or this booklet (that was Sebastian and Audrey) so I don't think this song is arranged the way I actually play it myself, but... There was a period where I played this song nearly every day on the piano, dreaming about the game I had not finished yet...
+
+    However, my wrists have some kind of problem now, so I can't play the piano for very long anymore. That's OK though. Anyway, once you learn this song, be sure to play it any way you like. Express yourself. But, you must make sure that your self-expression doesn't destroy your body.
+
+    PS - It's irrelevant to the piano version, but the way I arranged it in game is inspired by the band [[artist:anamanaguchi|Anamanaguchi]].
 ---
 Track: Burn in Despair!
 Duration: 0:21

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -261,6 +261,7 @@ Content: |-
         - added citations for commentary across [[album:stuckhome-syndrome-part-one-v1]]
         - added various links for [[artist:burnedkirby]], including mini-commentary relating to [[track:rediscover-fusion]]
     - added commentary from [[artist:mark-j-hadley]] (YouTube) to [[track:ocean-stars]] (thanks, Pyryte!)
+    - added commentary from [[artist:toby-fox]] (sheet music booklet) to [[album:undertale-soundtrack]] (thanks, vriska/leo and Autumn!)
     - added commentary from [[artist:toby-fox]] (Tumblr) to [[track:undertale]] (thanks, vriska/leo!)
     - added commentary from [[artist:wheals]] (SoundCloud) to [[track:step-back-doors-closing-step-back-to-allow-the-doors-to-close]] (thanks, Rosetta Leijonde!)
     - added commentary from [[artist:circlejourney]] (Jade commentary.txt) to [[track:on-an-island-far-away]] (thanks, Niklink!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -261,7 +261,7 @@ Content: |-
         - added citations for commentary across [[album:stuckhome-syndrome-part-one-v1]]
         - added various links for [[artist:burnedkirby]], including mini-commentary relating to [[track:rediscover-fusion]]
     - added commentary from [[artist:mark-j-hadley]] (YouTube) to [[track:ocean-stars]] (thanks, Pyryte!)
-    - added commentary from [[artist:toby-fox]] (sheet music booklet) to [[album:undertale-soundtrack]] (thanks, vriska/leo and Autumn!)
+    - added commentary from [[artist:toby-fox]] (colector's edition sheet music booklet) to [[track:once-upon-a-time]], [[track:fallen-down-undertale]], [[track:nyeh-heh-heh]], [[track:snowdin-town]], [[track:memory-undertale]], and [[track:hopes-and-dreams]] (thanks, vriska/leo, Autumn!)
     - added commentary from [[artist:toby-fox]] (Tumblr) to [[track:undertale]] (thanks, vriska/leo!)
     - added commentary from [[artist:wheals]] (SoundCloud) to [[track:step-back-doors-closing-step-back-to-allow-the-doors-to-close]] (thanks, Rosetta Leijonde!)
     - added commentary from [[artist:circlejourney]] (Jade commentary.txt) to [[track:on-an-island-far-away]] (thanks, Niklink!)


### PR DESCRIPTION
The [Undertale collector's edition](https://www.fangamer.com/products/undertale-game-switch-ps4-vita) contains a [sheet music booklet](https://drive.google.com/drive/folders/1CdoC3wyLLOU1R8JHG3cMSvFOTgvzfnVJ) with commentary for 6 tracks from the OST. This adds that commentary to the wiki.

[Thanks to Autumn, who provided the scans on fedi!](https://dragon.style/@AutumnWyvern/111916551678643150)