### PR TITLE
Miscellaneous fixes & additions

### DIFF
--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -1248,7 +1248,7 @@ URLs:
 - https://unofficialmspafans.bandcamp.com/track/doghead
 - https://youtu.be/wXJ4nXAu2CM
 Cover Artists:
-- albel-is-mine
+- xemmy
 Art Tags:
 - Jade
 - Green Sun

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -30,14 +30,14 @@ Additional Files:
   Files:
   - banner.png
 Commentary: |-
-    <i>Liza Fletcher:</i>
+    <i>LizaWithAZed:</i>
     This album means a lot to me, for a lot of reasons. Not just because it represents literally months of planning, organization, rounds of messaging, upsets, drama, triumph and general hard work on the part of me and some very good friends of mine. Not just because we managed to get some of the top talent in the fandom to contribute not only music but track art. Not just because that talent includes music and art team members and the uniquely universally beloved superfan Dante Basco. Not just because that talent also includes many friends I love dearly, some of whom I got to know through this project.
     No, this album is special to me because the original [[album:lofam]] holds a very dear place in my heart. It was the first album of Homestuck-related music I ever owned. I played it over and over, and read the album commentary until I damn near had it memorized. It was LoFaM which spurred me to stop lurking on the MSPA forums and dive headlong into the collective insanity we call Homestuck fandom. And right when I did so coincided with the start of the second fanmusic thread, and a guy named Underwater Basketweaving posting something he called Fighting Spirit. I downloaded it, loved it, and have been hip deep in collecting fanmusic - not just that already collected for my convenience in an album - ever since.
     Fighting Spirit is in here, and its sequel, and many others I and my compatriots ran across in our scouring of not only the fanmusic thread but tindeck, soundcloud, tumblr and basically anywhere on the big wide internet where MSPA fans celebrate their love of this remarkable work of fiction through music.
     It's my hope that, having gathered it all here for your convenience, you too are spurred to start your own search for the best, including many pieces that for one reason or another we had to leave off. The Land of Fans and Music is not just this 2-disc set or its predecessor; they're only the tip of the vast landscape of amazing talent. Come in. Explore. Get lost in it, like I did. I haven't regretted it for a second.
     <hr>
     *Special Thanks:*
-    <b>-CONCEPTION/ORGANIZATION-</b><br>Lambda Elise Merryberry<br>Liza Fletcher
+    <b>-CONCEPTION/ORGANIZATION-</b><br>Lambda Elise Merryberry<br>LizaWithAZed
     <b>-ORGANIZATION TEAM-</b><br>Slogbait<br>Veritas Unae<br>Rachel Rose Mitchell<br>Paige 'hrmnzr" Stanley<br>Astro Kid<br>clumsyroyalty (clumsyroyalty)<br>Shoona<br>Charles "Crazy-8" Neudorf<br>Catboss (Cat Boss)<br>Brad "Avinoch" Griffin<br>Mark "Dagoth Xil" Ciocca
     <b>-MASTERING-</b><br>Brad "Avinoch" Griffin<br>Veritas Unae
     <b>-COMMENTARY BOOKLET-</b><br>Brad "Avinoch" Griffin

--- a/album/pesterquest-soundtrack.yaml
+++ b/album/pesterquest-soundtrack.yaml
@@ -469,7 +469,7 @@ URLs:
 ---
 Track: Requiem
 Directory: requiem-pesterquest
-Originally Released As: track:requiem
+Originally Released As: track:requiem-labyrinths-heart
 Additional Names:
 - Name: >-
     Nepeta's Theme "Requiem"

--- a/album/undertale-soundtrack.yaml
+++ b/album/undertale-soundtrack.yaml
@@ -676,6 +676,8 @@ URLs:
 - https://open.spotify.com/track/3bmbaQXM98fEAoQotiNu9Q
 ---
 Track: Undertale
+Contributors:
+- Stephanie MacIntire (guitar)
 Duration: '6:21'
 URLs:
 - https://tobyfox.bandcamp.com/track/undertale

--- a/artists.yaml
+++ b/artists.yaml
@@ -5411,9 +5411,9 @@ Artist: Liz Fish
 URLs:
 - https://lizardlicks.tumblr.com/
 ---
-Artist: Liza Fletcher
----
 Artist: LizaWithAZed
+Aliases:
+- Liza Fletcher
 URLs:
 - https://lizawithazed.tumblr.com/
 - https://twitter.com/alllukesfault

--- a/artists.yaml
+++ b/artists.yaml
@@ -10189,8 +10189,13 @@ Aliases:
 URLs:
 - https://twitter.com/its_agred
 ---
-Artist: albel-is-mine
+Artist: xemmy
+Aliases:
+- albel-is-mine
 URLs:
+- https://xemmyq.tumblr.com
+# albel-is-mine.tumblr.com isn't dead, but it does say moved to xemmyQ
+Dead URLs:
 - https://albel-is-mine.tumblr.com/
 ---
 Artist: Allister Brimble

--- a/artists.yaml
+++ b/artists.yaml
@@ -8747,6 +8747,11 @@ Artist: Steffan Andrews
 ---
 Artist: Stemage
 ---
+Artist: Stephanie MacIntire
+URLs:
+- https://stephaniemacintire.bandcamp.com
+- https://www.youtube.com/@stephaniemacintire8421
+---
 Artist: Stephen Burns
 ---
 Artist: Stephen Hillenburg


### PR DESCRIPTION
- [x] Corrects line 472 in [hsmusic-data/album/pesterquest-soundtrack.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/pesterquest-soundtrack.yaml), to be Clark Powell's Requiem instead of James Dever's.

Line 472 before the pull request:
`Originally Released As: track:requiem`
Line 472 after merging pull:
`Originally Released As: track:requiem-labyrinths-heart`

- [x] Also changes albel-is-mine (moved to aliases, xemmy's the main name) to xemmy, and adds their current tumblr, [xemmyq.tumblr.com](https://xemmyq.tumblr.com), with the old URL moved to Dead URLs in [hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml)

- [x] Merges the two Liza artist entries in [hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml) into one, with LizaWithAZed being the main name, and the surname being an alias (per Niklink); also replaces the surname in [hsmusic-data/album/lofam2.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/lofam2.yaml) with LizaWithAZed
- [x] Adds Stephanie MacIntire as a contributor (guitar) on the self-titled Undertale track on UNDERTALE [hsmusic-data/album/undertale-soundtrack.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/undertale-soundtrack.yaml), and as an artist in [hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml), per [UNDERTALE Soundtrack's Bandcamp credits](https://tobyfox.bandcamp.com/album/undertale-soundtrack)