### PR TITLE
Lofam5a2 mastering

### DIFF
--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -88,6 +88,8 @@ Additional Names:
     [YouTube](https://www.youtube.com/watch?v=FxTJ0EZhcL8)
 Artists:
 - Grace Medley
+Contributors:
+- Grace Medley (mastering)
 Duration: 0:24
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/s-disc-1
@@ -101,6 +103,8 @@ Commentary: |-
 Track: LAND OF PULSE AND HAZE
 Artists:
 - METIANULL
+Contributors:
+- Grace Medley (mastering)
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/land-of-pulse-and-haze-2
@@ -123,6 +127,8 @@ Commentary: |-
 Track: Moonlight Riders
 Artists:
 - John Tay
+Contributors:
+- Ucklin (mastering)
 Duration: 1:31
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/moonlight-riders
@@ -164,6 +170,8 @@ Commentary: |-
 Track: Sunslambo
 Artists:
 - nononimo
+Contributors:
+- Tee-vee (mastering)
 Duration: 3:05
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sunslambo
@@ -184,6 +192,8 @@ Commentary: |-
 Track: Duet
 Suffix Directory: true
 Main Release: Strife 2
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:38
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/duet
@@ -237,6 +247,8 @@ Suffix Directory: true
 Always Reference By Directory: true
 Artists:
 - Thomas Ferkol
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 3:44
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dictator
@@ -255,6 +267,8 @@ Commentary : |-
 Track: vriskafic8ion
 Suffix Directory: true
 Main Release: i dreamed of feeling better, vol. 1
+Contributors:
+- Ucklin (mastering)
 Duration: 2:34
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/vriskafic8ion
@@ -274,6 +288,8 @@ Additional Names:
 - Flight of the Asteroid (production name)
 Artists:
 - Jebb
+Contributors:
+- Ucklin (mastering)
 Duration: 4:24
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/flight-of-the-meteor-year-1
@@ -368,6 +384,8 @@ Commentary: |-
 Track: Across Time
 Suffix Directory: true
 Main Release: Heaven;Sent
+Contributors:
+- Rainy (mastering)
 Duration: 2:38
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/across-time
@@ -381,6 +399,8 @@ Commentary: |-
 Track: Slow Dancing in the Clockwork Hall
 Suffix Directory: true
 Main Release: SBURBAN NEIGHBORHOOD
+Contributors:
+- Grace Medley (mastering)
 Duration: 2:23
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/slow-dancing-in-the-clockwork-hall
@@ -405,6 +425,8 @@ Commentary: |-
 Track: Fill 'em with Daylight (YD Club Mix)
 Artists:
 - yuuDii
+Contributors:
+- ruby (mastering)
 Duration: 3:20
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/fill-em-with-daylight-yd-club-mix
@@ -427,6 +449,8 @@ Commentary: |-
 Track: Ruined Singularity
 Suffix Directory: true
 Main Release: Vinculum Vitae
+Contributors:
+- Rainy (mastering)
 Duration: 3:14
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/ruined-singularity
@@ -447,6 +471,8 @@ Commentary: |-
 Track: Virtua-Bounce
 Artists:
 - David Ko
+Contributors:
+- Tee-vee (mastering)
 Duration: 1:34
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/virtua-bounce
@@ -468,6 +494,8 @@ Commentary: |-
 Track: Sburban Keygen (WORKING 2009 NO VIRUS)
 Artists:
 - TBYT
+Contributors:
+- Grace Medley (mastering)
 Duration: 2:43
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sburban-keygen-working-2009-no-virus
@@ -492,6 +520,8 @@ Commentary: |-
 Track: Everyone Here, Fine and Happy, Let's Eat Some Cake and Play a Song
 Suffix Directory: true
 Main Release: SBURBAN NEIGHBORHOOD
+Contributors:
+- Grace Medley (mastering)
 Duration: 3:34
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/everyone-here-fine-and-happy-lets-eat-some-cake-and-play-a-song
@@ -521,6 +551,8 @@ Commentary: |-
 Track: The Final Spice is Cardamom for Apple Pie, Cloves for Pumpkins
 Artists:
 - subversiveasset
+Contributors:
+- Grace Medley (mastering)
 Duration: 3:53
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-final-spice-is-cardamom-for-apple-pie-cloves-for-pumpkins
@@ -558,6 +590,8 @@ Commentary: |-
 Track: Ruination
 Artists:
 - Viceroy of Monte Cristo
+Contributors:
+- Tee-vee (mastering)
 Duration: 3:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/ruination
@@ -585,6 +619,8 @@ Additional Names:
 - Brain Failure (quirk-free)
 Artists:
 - yuuDii
+Contributors:
+- Grace Medley (mastering)
 Duration: 3:23
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/braiin-faiiliiure
@@ -607,6 +643,8 @@ Commentary: |-
 Track: Shire Strife
 Artists:
 - Alex Rosetti
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 1:44
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/shire-strife
@@ -626,6 +664,8 @@ Commentary: |-
 Track: Fright Rush
 Main Release: 'Paradox Struck: Volume 1'
 Suffix Directory: true
+Contributors:
+- Ucklin (mastering)
 Duration: 0:57
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/fright-rush
@@ -640,6 +680,8 @@ Track: Make Them Pay
 Suffix Directory: true
 Artists:
 - Grace Medley
+Contributors:
+- Rainy (mastering)
 Duration: 3:06
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/make-them-pay
@@ -667,6 +709,8 @@ Commentary: |-
 Track: PLEA AND JUDGEMENT
 Artists:
 - METIANULL
+Contributors:
+- Ucklin (mastering)
 Duration: 2:09
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/plea-and-judgement
@@ -683,6 +727,8 @@ Commentary: |-
 Track: Lunar Solace
 Artists:
 - Monckat
+Contributors:
+- Grace Medley (mastering)
 Duration: 2:57
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/lunar-solace
@@ -716,6 +762,8 @@ Commentary: |-
 Track: Beckoning
 Suffix Directory: true
 Main Release: 'FNF: COLORS & MAYHEM Vol. 1'
+Contributors:
+- ruby (mastering)
 Duration: 1:23
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/beckoning
@@ -737,6 +785,8 @@ Additional Names:
   Annotation: English
 Artists:
 - Archonic
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 2:01
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/yo-quiero-la-homestuck
@@ -762,6 +812,8 @@ Commentary: |-
 Track: Fugalanthequins
 Artists:
 - Shwan
+Contributors:
+- ruby (mastering)
 Duration: 4:12
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/fugalanthequins
@@ -789,6 +841,8 @@ Commentary: |-
 Track: Cometfall
 Suffix Directory: true
 Main Release: Vinculum Vitae
+Contributors:
+- Ucklin (mastering)
 Duration: 3:07
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/cometfall
@@ -807,6 +861,8 @@ Commentary: |-
 Track: The Deceased Friends And Family
 Artists:
 - Tee-vee
+Contributors:
+- ruby (mastering)
 Duration: 7:36
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-deceased-friends-and-family
@@ -838,6 +894,8 @@ Commentary: |-
 Track: Maybe it'll turn out better this time
 Artists:
 - Circlejourney
+Contributors:
+- Ucklin (mastering)
 Duration: 3:31
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/maybe-itll-turn-out-better-this-time
@@ -890,6 +948,8 @@ Commentary: |-
 Track: Lilith
 Suffix Directory: true
 Main Release: Heaven;Sent
+Contributors:
+- Rainy (mastering)
 Duration: 3:27
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/lilith
@@ -909,6 +969,8 @@ Artists:
 - SplitSuns
 - WHATISLOSTINTHEMINES (prod., vocals, add. guitar)
 - Ucklin (lyrics, vocals)
+Contributors:
+- Tee-vee (mastering)
 Duration: 10:25
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/stuck
@@ -1032,6 +1094,8 @@ Commentary: |-
 Track: Prologue
 Suffix Directory: true
 Main Release: Friendsim 2 - Volume 1
+Contributors:
+- Ucklin (mastering)
 Duration: 2:53
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/prologue
@@ -1061,6 +1125,8 @@ Additional Names:
     [YouTube](https://www.youtube.com/watch?v=27NkGH8WcNs)
 Artists:
 - Grace Medley
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 0:20
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/s-disc-2
@@ -1083,6 +1149,8 @@ Commentary: |-
 Track: Symphony of Skaia
 Artists:
 - JulianMOCs
+Contributors:
+- Grace Medley (mastering)
 Duration: 2:02
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/symphony-of-skaia
@@ -1106,6 +1174,8 @@ Commentary: |-
 Track: When the Curtains Part
 Suffix Directory: true
 Main Release: SBURBAN NEIGHBORHOOD
+Contributors:
+- Grace Medley (mastering)
 Duration: 3:53
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/when-the-curtains-part
@@ -1132,6 +1202,8 @@ Commentary: |-
 Track: Grimnarc Voodoo
 Suffix Directory: true
 Main Release: Heaven;Sent
+Contributors:
+- Grace Medley (mastering)
 Duration: 5:00
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/grimnarc-voodoo
@@ -1151,6 +1223,8 @@ Commentary: |-
 Track: Karkat Loses His Mind And Learns Holy C
 Artists:
 - Gryotharian
+Contributors:
+- Ucklin (mastering)
 Duration: 2:47
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/karkat-loses-his-mind-and-learns-holy-c
@@ -1173,6 +1247,8 @@ Commentary: |-
 Track: Acid Hive
 Artists:
 - Torrent 64
+Contributors:
+- Rainy (mastering)
 Duration: 2:25
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/acid-hive
@@ -1208,6 +1284,8 @@ Commentary: |-
 Track: MnSttR
 Artists:
 - nononimo
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/mnsttr
@@ -1234,6 +1312,8 @@ Suffix Directory: true
 Always Reference By Directory: true
 Artists:
 - Thomas Ferkol
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 4:55
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/puppeteer-2
@@ -1251,6 +1331,8 @@ Commentary: |-
 Track: Grubheap
 Artists:
 - Spiny
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:32
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/grubheap
@@ -1277,6 +1359,8 @@ Additional Names:
 - PillarsOfFlesh (production name)
 Artists:
 - Jebb
+Contributors:
+- Ucklin (mastering)
 Duration: 2:59
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/eternal-pulse
@@ -1348,6 +1432,8 @@ Track: "RE:TCON (Act 2 RE:DUX)"
 Directory: retcon-act-2-redux
 Artists:
 - Tee-vee
+Contributors:
+- Tee-vee (mastering)
 Duration: 4:14
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/re-tcon-act-2-re-dux
@@ -1407,6 +1493,8 @@ Commentary: |-
 Track: '"Shred them to pieces"'
 Artists:
 - Eternal Wonder
+Contributors:
+- Ucklin (mastering)
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/shred-them-to-pieces
@@ -1426,6 +1514,8 @@ Commentary: |-
 Track: Crystalanachronysms
 Artists:
 - SolusLunes
+Contributors:
+- Grace Medley (mastering)
 Duration: 5:18
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/crystalanachronysms
@@ -1451,6 +1541,8 @@ Commentary: |-
 Track: The Oligarch
 Suffix Directory: true
 Main Release: Heaven;Sent
+Contributors:
+- Ucklin (mastering)
 Duration: 3:02
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-oligarch
@@ -1466,6 +1558,8 @@ Commentary: |-
 Track: Requiem for a Daybreaker
 Artists:
 - artist:kobacat
+Contributors:
+- Tee-vee (mastering)
 Duration: 4:36
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/requiem-for-a-daybreaker
@@ -1490,6 +1584,8 @@ Commentary: |-
 Track: Slick Tricks
 Suffix Directory: true
 Main Release: Vinculum Vitae
+Contributors:
+- Rainy (mastering)
 Duration: 2:49
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/slick-tricks
@@ -1509,6 +1605,8 @@ Commentary: |-
 Track: Stepping Stones
 Suffix Directory: true
 Main Release: Agents Of Reality
+Contributors:
+- Ucklin (mastering)
 Duration: 3:42
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/stepping-stones
@@ -1527,6 +1625,8 @@ Commentary: |-
 Track: 'Waltz in A Minor "Homestuck" (Op. 9)'
 Artists:
 - casualclassical
+Contributors:
+- Tee-vee (mastering)
 Duration: 3:26
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/waltz-in-a-minor-homestuck-op-9
@@ -1557,6 +1657,8 @@ Commentary: |-
 Track: Terminal Loop
 Artists:
 - Pax Probliscum
+Contributors:
+- Ucklin (mastering)
 Duration: 2:22
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/terminal-loop
@@ -1580,6 +1682,8 @@ Commentary: |-
 Track: Switched-On Showtime
 Artists:
 - Not Eno
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:23
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/switched-on-showtime
@@ -1603,6 +1707,8 @@ Commentary: |-
 Track: Chroma
 Suffix Directory: true
 Main Release: Heaven;Sent
+Contributors:
+- Grace Medley (mastering)
 Duration: 3:02
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/chroma
@@ -1621,6 +1727,8 @@ Commentary: |-
 Track: Rage Against Existence
 Artists:
 - Cerulean
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:37
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/rage-against-existence
@@ -1636,6 +1744,8 @@ Commentary: |-
 Track: Caffeinated Jittering
 Artists:
 - Kanishka
+Contributors:
+- Ucklin (mastering)
 Duration: 2:45
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/caffeinated-jittering
@@ -1662,6 +1772,8 @@ Commentary: |-
 Track: Lost in the Dream Bubbles
 Artists:
 - Swagazaki
+Contributors:
+- Rainy (mastering)
 Duration: 1:39
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/lost-in-the-dream-bubbles
@@ -1683,6 +1795,8 @@ Commentary: |-
 Track: Flushing Pale
 Suffix Directory: true
 Main Release: Friendsim 2 - Volume 1
+Contributors:
+- Grace Medley (mastering)
 Duration: 3:08
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/flushing-pale
@@ -1705,6 +1819,8 @@ Commentary: |-
 Track: Under A Starry Night Sky
 Artists:
 - monofe
+Contributors:
+- Tee-vee (mastering)
 Duration: 4:55
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/under-a-starry-night-sky
@@ -1729,6 +1845,8 @@ Commentary: |-
 Track: Light in the Darkness
 Suffix Directory: true
 Main Release: track:light-in-the-darkness # CANWAVE 3
+Contributors:
+- ruby (mastering)
 Duration: 7:52
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/light-in-the-darkness
@@ -1755,6 +1873,8 @@ Track: Derse Dreamers II
 Artists:
 - horizon (Rose)
 - LO,ON (Dave)
+Contributors:
+- ruby (mastering)
 Duration: 4:04
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/derse-dreamers-ii
@@ -1868,6 +1988,8 @@ Commentary: |-
 Track: Shattered Twilight
 Artists:
 - Elisa Flore
+Contributors:
+- Tee-vee (mastering)
 Duration: 5:52
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/shattered-twilight
@@ -1897,6 +2019,7 @@ Artists:
 - Rainy
 Contributors:
 - Tee-vee (guitars)
+- ruby (mastering)
 Duration: 2:33
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dreams-of-a-better-future
@@ -1933,6 +2056,8 @@ Artists:
 - Pixels & Paradiddles
 - pixelseph
 - paradiddlesjosh
+Contributors:
+- Ucklin (mastering)
 Duration: 2:42
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/deadkidsgodhood
@@ -1985,6 +2110,8 @@ Commentary: |-
 Track: GALACTIC INCOHERENCE ~ Cosmic NaN Propagation
 Artists:
 - Cosmoptera
+Contributors:
+- Rainy (mastering)
 Duration: 9:46
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/galactic-incoherence-cosmic-nan-propagation
@@ -2023,6 +2150,7 @@ Artists:
 - Soapstone
 Contributors:
 - Jordan Sunlight (guitar solo)
+- ruby (mastering)
 Duration: 2:56
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/yellow-yard
@@ -2106,6 +2234,8 @@ Additional Names:
     [YouTube](https://www.youtube.com/watch?v=L1BM_PQL5NE)
 Artists:
 - Grace Medley
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 0:31
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/s-disc-3
@@ -2134,6 +2264,8 @@ Additional Names:
 - Musty Mafia (original name)
 Artists:
 - Jebb
+Contributors:
+- Ucklin (mastering)
 Duration: 4:13
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/ace-celerando
@@ -2185,6 +2317,8 @@ Commentary: |-
 Track: Delta Version
 Artists:
 - Rom M
+Contributors:
+- Tee-vee (mastering)
 Duration: 3:42
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/delta-version
@@ -2229,6 +2363,8 @@ Commentary: |-
 Track: Sunbumper
 Artists:
 - yuuDii
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 3:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sunbumper
@@ -2260,6 +2396,8 @@ Commentary: |-
 Track: The Imminently Deceased
 Artists:
 - dron3canon
+Contributors:
+- Ucklin (mastering)
 Duration: 3:42
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-imminently-deceased
@@ -2287,6 +2425,8 @@ Commentary: |-
 Track: Dusksetter
 Artists:
 - ruby
+Contributors:
+- ruby (mastering)
 Duration: 4:43
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dusksetter
@@ -2319,6 +2459,8 @@ Commentary: |-
 Track: Sburban Juxtaposition
 Artists:
 - horizon
+Contributors:
+- ruby (mastering)
 Duration: 5:19
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sburban-juxtaposition
@@ -2410,6 +2552,8 @@ Commentary: |-
 Track: I'm a Member of the Midnight Crew (Special Soapstone Version)
 Artists:
 - Soapstone
+Contributors:
+- ruby (mastering)
 Duration: 3:18
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/im-a-member-of-the-midnight-crew-special-soapstone-version
@@ -2473,6 +2617,8 @@ Commentary: |-
 Track: Liquid Noir
 Artists:
 - yuuDii
+Contributors:
+- ruby (mastering)
 Duration: 3:29
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/liquid-noir
@@ -2522,6 +2668,8 @@ Commentary: |-
 Track: Four Boys Blues
 Artists:
 - Funk McLovin
+Contributors:
+- Ucklin (mastering)
 Duration: 2:57
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/four-boys-blues
@@ -2597,6 +2745,8 @@ Commentary: |-
 Track: Celestial Company
 Artists:
 - corvidc0rvus
+Contributors:
+- Ucklin (mastering)
 Duration: 2:58
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/celestial-company
@@ -2618,6 +2768,8 @@ Commentary: |-
 Track: Moonslayer
 Directory: moonslayer-lofam5a2
 Main Release: same name single
+Contributors:
+- Tee-vee (mastering)
 Duration: 5:04
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/moonslayer
@@ -2635,6 +2787,8 @@ Commentary: |-
 Track: Frost and Frogs
 Suffix Directory: true
 Main Release: BETA
+Contributors:
+- Tee-vee (mastering)
 Duration: 4:52
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/frost-and-frogs
@@ -2656,6 +2810,8 @@ Track: dog
 Artists:
 - Gryotharian
 - Hart
+Contributors:
+- Ucklin (mastering)
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dog
@@ -2677,6 +2833,8 @@ Commentary: |-
 Track: Arf!
 Artists:
 - yoyoYolo
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:41
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/arf
@@ -2697,6 +2855,8 @@ Commentary: |-
 Track: Frog Eater
 Suffix Directory: true
 Main Release: Heaven;Sent
+Contributors:
+- Grace Medley (mastering)
 Duration: 4:00
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/frog-eater
@@ -2720,6 +2880,8 @@ Suffix Directory: true
 Always Reference By Directory: true
 Artists:
 - ruby
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:46
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/movement
@@ -2746,6 +2908,8 @@ Commentary: |-
 Track: THE LAST HOUR
 Artists:
 - Ray Mike
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 1:36
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-last-hour
@@ -2761,6 +2925,8 @@ Commentary: |-
 Track: All Work and No Play
 Artists:
 - Kanishka
+Contributors:
+- Ucklin (mastering)
 Duration: 4:38
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/all-work-and-no-play
@@ -2783,6 +2949,8 @@ Commentary: |-
 Track: '[S] Emerge'
 Artists:
 - Wr3ck0rdz
+Contributors:
+- ruby (mastering)
 Duration: 3:22
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/s-emerge
@@ -2808,6 +2976,8 @@ Commentary: |-
 Track: Adventurous Ascent
 Artists:
 - LudicrousFalcon
+Contributors:
+- ruby (mastering)
 Duration: 4:04
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/adventurous-ascent
@@ -2841,6 +3011,8 @@ Commentary: |-
 Track: Ultramagnetoparakineticrystalphotogrammetry
 Suffix Directory: true
 Main Release: Vinculum Vitae
+Contributors:
+- Ucklin (mastering)
 Duration: 4:08
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/ultramagnetoparakineticrystalphotogrammetry
@@ -2868,6 +3040,8 @@ Commentary: |-
 Track: Serendipitous Strife
 Artists:
 - Cecily Renns
+Contributors:
+- Tee-vee (mastering)
 Duration: 2:23
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/serendipitous-strife
@@ -2886,6 +3060,8 @@ Commentary: |-
 Track: Strident Sburban Serenata
 Artists:
 - Adrian "gravitygauntlet" Wahrer
+Contributors:
+- Ucklin (mastering)
 Duration: 3:24
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/strident-sburban-serenata
@@ -2913,6 +3089,8 @@ Commentary: |-
 Track: Versus Oblivion
 Artists:
 - yuuDii
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 3:41
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/versus-oblivion
@@ -2952,6 +3130,8 @@ Commentary: |-
 Track: "'Til Death, We Grieve"
 Suffix Directory: true
 Main Release: There's No Place Like Home
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 6:48
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/til-death-we-grieve
@@ -2978,6 +3158,8 @@ Commentary: |-
 Track: Lost Memories
 Artists:
 - ascendantDreamweaver
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 7:20
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/lost-memories
@@ -3050,6 +3232,8 @@ Artists:
 - Pixels & Paradiddles
 - pixelseph
 - paradiddlesjosh
+Contributors:
+- Ucklin (mastering)
 Duration: 5:48
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/clockstopper-new-game-all-clocks
@@ -3109,6 +3293,8 @@ Track: The Ballad of Moro and San
 Artists:
 - Grace Medley
 - Kal-la-kal-la
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 4:12
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-ballad-of-moro-and-san
@@ -3143,6 +3329,8 @@ Commentary: |-
 Track: Penumbral Awakening
 Artists:
 - ruby
+Contributors:
+- ruby (mastering)
 Duration: 3:33
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/penumbral-awakening
@@ -3166,6 +3354,8 @@ Commentary: |-
 Track: Dance of Storms
 Artists:
 - Tensei
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 4:34
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dance-of-storms
@@ -3195,6 +3385,7 @@ Artists:
 - Grace Medley
 Contributors:
 - Veritas Unae (vocals)
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 4:30
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/caliborns-lament
@@ -3350,6 +3541,8 @@ Commentary: |-
 Track: Stargazing with Gods
 Artists:
 - Rose Gray
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 9:45
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/stargazing-with-gods
@@ -3394,6 +3587,8 @@ Artists:
 - WHATISLOSTINTHEMINES
 - Ucklin
 Count In Artist Totals: false
+Contributors:
+- WHATISLOSTINTHEMINES (mastering)
 Duration: 20:09
 URLs:
 - https://www.youtube.com/watch?v=khh1d83wOig

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -202,6 +202,8 @@ Content: |-
     <!-- series additions -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     - added series for [[group:michael-guy-bowman]] (thanks, Lilith, plus <<Lan:categorization help>>!)
+    <!-- crediting additions (not fixes) -->
+    - added mastering credits across [[album:lofam5a2]] (thanks, ruby!)
     <!-- commentary additions -->
     - added Skaianet Radio commentary to [[track:liquid-negrocity]] (thanks, Lilith, Jackie!)
     - added MSPA news post referencing source to [[track:black]] (thanks, Lilith!)


### PR DESCRIPTION
i have no idea why these past commits keep haunting me (yes, i worked on a new branch and made sure it was up to date with the original repo) but the only relevant files here are agents-of-reality.yaml, lofam5a2.yaml, and flashes.yaml. I'll get that sorted out later 

RE:TCON (Act 2 RE:DUX), Dusksetter, Penumbral Awakening are mastered by their artists.