### PR TITLE
Land t2k's Vast Error tag definitions

### DIFF
--- a/tags.yaml
+++ b/tags.yaml
@@ -945,114 +945,332 @@ Tag: Weddell (Oceanfalls)
 Color: '#21f2c8'
 Tag: Zachery (Oceanfalls)
 ---
+# This is the Vast Error section. I'm tempest2k, and I am leaving here a guide that I think will be necessary to navigate the sheer magnitude of VE's cast. This first part is organized by grouping the Main 12 and characters closely associated with them. The order is, MAIN, ALT!SELF/VES, LUSUS, ANCESTOR, ASSOCIATED DENIZEN, LAND/PLANET, with exclusions when relevant. A notable exception to this is Rogi under Occeus, who just seems like he fits there.
 Color: '#b95c00'
 Tag: Arcjec (Vast Error)
+---
+Color: '#b95c00'
+Tag: Arcjec's lusus (Vast Error)
+---
+Color: '#cd6500'
+Tag: The Forgiven (Vast Error)
+---
+Color: '#10E0FF'
+Tag: Zehanpuryu (Vast Error)
+---
+Color: '#b95c00'
+Tag: LoMaM (Vast Error)
 ---
 Color: '#6c8400'
 Tag: Ellsee (Vast Error)
 ---
-Color: '#004696'
-Tag: Lavian (Vast Error)
+Color: '#6c8400'
+Tag: Ellsee's lusus (Vast Error)
 ---
-Color: '#00A596'
+Color: '#6c8400'
+Tag: The Vivifier (Vast Error)
+---
+Color: '#77c350'
+Tag: Lilith (Vast Error)
+---
+Color: '#6c8400'
+Tag: LoVaT (Vast Error)
+---
+Color: '#487aef'
+Tag: Laivan (Vast Error)
+---
+Color: '#487aef'
+Tag: Mutt (Vast Error)
+---
+Color: '#487aef'
+Tag: The Jagerman (Vast Error)
+---
+Color: '#ffffff'
+Tag: Haniel (Vast Error)
+---
+Color: '#487aef'
+Tag: LoCaD (Vast Error)
+---
+Color: '#008b8b'
 Tag: Serpaz (Vast Error)
 ---
-Color: '#407D00'
+Color: '#008b8b'
+Tag: Lefty (Vast Error)
+---
+Color: '#20401f'
+Tag: Sorush (Vast Error)
+---
+Color: '#008b8b'
+Tag: LoSaF (Vast Error)
+---
+Color: '#588a00'
 Tag: Albion (Vast Error)
 ---
-Color: '#7f0000'
+Color: '#588a00'
+Tag: Albion's lusus (Vast Error)
+---
+Color: '#588a00'
+Tag: The Exemplar (Vast Error)
+---
+Color: '#FFE094'
+Tag: Bathkol (Vast Error)
+---
+Color: '#588a00'
+Tag: LoAaR (Vast Error)
+---
+Color: '#eb0000'
 Tag: Sova (Vast Error)
 ---
-Color: '#c44000'
+Color: '#eb0000'
+Tag: Sova's lusus (Vast Error)
+---
+Color: '#eb0000'
+Tag: The Annalist (Vast Error)
+---
+Color: '#bd1864'
+Tag: Jegudial (Vast Error)
+---
+Color: '#eb0000'
+Tag: LoDaL (Vast Error)
+---
+Color: '#cd6500'
 Tag: Dismas (Vast Error)
 ---
-Color: '#b49e18'
+Color: '#cd6500'
+Tag: Dismas' lusus (Vast Error)
+---
+Color: '#cd6500'
+Tag: The Fomenter (Vast Error)
+---
+Color: '#46fbc4'
+Tag: Forcas
+---
+Color: '#cd6500'
+Tag: LoLaS (Vast Error)
+---
+Color: '#daaf2d'
 Tag: Jentha (Vast Error)
 ---
-Color: '#00007f'
+Color: '#daaf2d'
+Tag: Jentha's lusus (Vast Error)
+---
+Color: '#daaf2d'
+Tag: The Supernova (Vast Error)
+---
+Color: '#fff547'
+Tag: Af (Vast Error)
+---
+Color: '#daaf2d'
+Tag: LoTGaS (Vast Error)
+---
+Color: '#487aef'
 Tag: Occeus (Vast Error)
 ---
-Color: '#39017F'
+Color: '#487aef'
+Tag: Occeus' lusus (Vast Error)
+---
+Color: '#ABA698'
+Tag: Rogi (Vast Error)
+---
+Color: '#BA1915'
+Tag: Wormwood (Vast Error)
+---
+Color: '#487aef'
+Tag: LoBaG (Vast Error)
+---
+Color: '#a34bff'
 Tag: Taz (Vast Error)
 ---
-Color: '#A00078'
+Color: '#a34bff'
+Tag: Taz's lusus (Vast Error)
+---
+Color: '#a34bff'
+Tag: Deadlock (Vast Error)
+---
+Color: '#9c4dad'
+Tag: Azgobah (Vast Error)
+---
+Color: '#a34bff'
+Tag: LoGaG (Vast Error)
+---
+Color: '#db00db'
 Tag: Calder (Vast Error)
 ---
-Color: '#510049'
+Color: '#db00db'
+Tag: Calder's lusus (Vast Error)
+---
+Color: '#db00db'
+Tag: Ceasar (Vast Error)
+---
+Color: '#033476'
+Tag: Procel (Vast Error)
+---
+Color: '#db00db'
+Tag: LoMaQ (Vast Error)
+---
+Color: '#db00db'
 Tag: Murrit (Vast Error)
 ---
-Color: '#0989a0'
+Color: '#db00db'
+Tag: Alt!Murrit (Vast Error)
+---
+Color: '#db00db'
+Tag: Acerigger (Vast Error)
+---
+Color: '#b70d0e'
+Tag: Gusion (Vast Error)
+---
+Color: '#db00db'
+Tag: LoWaR (Vast Error)
+---
+# This next section is for a particular off-brand of alt-selves that felt too specific to be included in the prior section. They are the characters in Sova's in-universe play, "Upon the Twelfth Hour," that are obviously based directly on herself and her friends. They will be listed in the same order as the Main 12 above are, and should be considered archetypes of those characters when that system is functional. For good measure, I'll comment in who each character is based on.
+Color: '#b95c00'
+Tag: The Lonely (Vast Error)
+# based on Arcjec
+---
+Color: '#6c8400'
+Tag: The Invoker (Vast Error)
+# based on Ellsee
+---
+Color: '#487aef'
+Tag: The Forthright (Vast Error)
+# based on Laivan
+---
+Color: '#008b8b'
+Tag: The Entertainer (Vast Error)
+# based on Serpaz
+---
+Color: '#588a00'
+Tag: The Enlightened (Vast Error)
+# based on Albion
+---
+Color: '#eb0000'
+Tag: The Songbird (Vast Error)
+# based on Sova
+---
+Color: '#cd6500'
+Tag: The Stranger (Vast Error)
+# based on Dismas
+---
+Color: '#daaf2d'
+Tag: The Pundit (Vast Error)
+# based on Jentha
+---
+Color: '#487aef'
+Tag: The Practitioner (Vast Error)
+# based on Occeus
+---
+Color: '#a34bff'
+Tag: The Champion (Vast Error)
+# based on Taz
+---
+Color: '#db00db'
+Tag: The Nobleman (Vast Error)
+# based on Calder
+---
+Color: '#db00db'
+Tag: The Watcher (Vast Error)
+# based on Murrit
+---
+# This section is for the secondary cast, and also Snowbound Blood characters. This is mostly a complete overlap but otherwise Secily wouldn't really have a place to go. Not listed in order of importance.
+Color: '#008b8b'
 Tag: Secily (Vast Error)
 ---
-Color: '#61467b'
+Color: '#008b8b'
+Tag: Arcamu (Vast Error)
+# Secily's ancestor
+---
+Color: '#588a00'
+Tag: Noxious (Vast Error)
+---
+Color: '#7154ae'
 Tag: Sestro (Vast Error)
 ---
-Color: '#00722d'
+Color: '#7154ae'
+Tag: The Executive (Vast Error)
+---
+Color: '#008f48'
 Tag: Hamifi (Vast Error)
 ---
-Color: '#0040af'
+Color: '#01C09F'
+Tag: Turnin (Vast Error)
+---
+Color: '#ff8f8f'
+Tag: Racren (Vast Error)
+---
+Color: '#095afe'
 Tag: Bytcon (Vast Error)
 ---
-Color: '#163b3b'
+Color: '#13989a'
 Tag: Cadlys (Vast Error)
 ---
-Color: '#619319'
+Color: '#588a00'
 Tag: Sirage (Vast Error)
 ---
-Color: '#b25d2c'
+Color: '#cd6500'
 Tag: Husske (Vast Error)
 ---
-Color: '#1a1280'
+Color: '#487aef'
 Tag: Rypite (Vast Error)
 ---
-Color: '#2d6461'
+Color: '#008b8b'
 Tag: Crytum (Vast Error)
 ---
-Color: '#FB3C5D'
+Color: '#fbec5d'
 Tag: Mshiri (Vast Error)
 ---
-Color: '#542853'
+Color: '#db00db'
 Tag: Oricka (Vast Error)
 ---
 Color: '#B07800'
 Tag: Sabine (Vast Error)
 ---
-Color: '#48574a'
+Color: '#6a816f'
 Tag: Raurou (Vast Error)
 ---
-Color: '#b29e14'
+Color: '#daaf2d'
 Tag: Hayyan (Vast Error)
 ---
-Color: '#004182'
+Color: '#095afe'
 Tag: Necron (Vast Error)
 ---
-Color: '#930000'
+Color: '#eb0000'
 Tag: Valtel (Vast Error)
 ---
 Color: '#CD4748'
 Tag: Yeshin (Vast Error)
 ---
-Color: '#962600'
+Color: '#eb0000'
 Tag: Cinare (Vast Error)
 ---
-Color: '#397e57'
+Color: '#008f48'
 Tag: Glomer (Vast Error)
 ---
-Color: '#039639'
+Color: '#008f48'
 Tag: Gerbat (Vast Error)
 ---
-Color: '#39007e'
+Color: '#a34bff'
+Tag: Cretas (Vast Error)
+---
+Color: '#a34bff'
 Tag: Endari (Vast Error)
 ---
-Color: '#270051'
+Color: '#7154ae'
 Tag: Edolon (Vast Error)
+---
+Color: '#a34bff'
+Tag: Seinru (Vast Error)
 ---
 Color: '#cd6500'
 Tag: Talald (Vast Error)
 ---
-Color: '#ffffff'
-Tag: LoMaM (Vast Error)
+Color: '#a34bff'
+Tag: Pozzol (Vast Error)
 ---
+Color: '#a34bff'
+Color: Vilcus (Vast Error)
+---
+# These are carapacians.
 Color: '#ffff01'
 Tag: CM (Vast Error)
 ---
@@ -1065,20 +1283,37 @@ Tag: EE (Vast Error)
 Color: '#8a8a8a'
 Tag: Scathing Sharper (Vast Error)
 ---
+# These are narrators, and other characters who are otherwise in a more meta or omnipresent setting in the story. The only reason Mimesis is first here is because it felt right putting them next to Jack.
+Color: '#de00ff'
+Tag: Mimesis
+---
 Color: '#ffffff'
 Tag: White Noise (Vast Error)
 ---
-Color: '#FFD90F'
-Tag: Bart
+Color: '#EAFF9D'
+Tag: Metatron (Vast Error)
+---
+Color: '#ECFF9E'
+Tag: Kheparia
+---
+Color: '#F4B3B0'
+Tag: Gaiaeon
+---
+Color: '#B6C4C2'
+Tag: Repiton
 ---
 Color: '#ffffff'
 Tag: The Static
 ---
+# This is the end of the Vast Error section, but it should be noted that Bart, Weird Al, and Hulk Hogan are only being tracked because of Vast Error.
+Color: '#FFD90F'
+Tag: Bart
+---
 Color: '#ffffff'
 Tag: Weird Al
 ---
-Color: '#B6C4C2'
-Tag: Repiton
+Color: '#ffffff'
+Tag: Hulk Hogan
 ---
 Color: '#4040ff'
 Tag: Sonic

--- a/tags.yaml
+++ b/tags.yaml
@@ -1268,7 +1268,7 @@ Color: '#a34bff'
 Tag: Pozzol (Vast Error)
 ---
 Color: '#a34bff'
-Color: Vilcus (Vast Error)
+Tag: Vilcus (Vast Error)
 ---
 # These are carapacians.
 Color: '#ffff01'

--- a/tags.yaml
+++ b/tags.yaml
@@ -945,168 +945,44 @@ Tag: Weddell (Oceanfalls)
 Color: '#21f2c8'
 Tag: Zachery (Oceanfalls)
 ---
-# This is the Vast Error section. I'm tempest2k, and I am leaving here a guide that I think will be necessary to navigate the sheer magnitude of VE's cast. This first part is organized by grouping the Main 12 and characters closely associated with them. The order is, MAIN, ALT!SELF/VES, LUSUS, ANCESTOR, ASSOCIATED DENIZEN, LAND/PLANET, with exclusions when relevant. A notable exception to this is Rogi under Occeus, who just seems like he fits there.
+### This is the Vast Error section. I'm tempest2k, and I am leaving here a guide that I think will be necessary to navigate the sheer magnitude of VE's cast.
+## Main 12 + altselves
 Color: '#b95c00'
 Tag: Arcjec (Vast Error)
----
-Color: '#b95c00'
-Tag: Arcjec's lusus (Vast Error)
----
-Color: '#cd6500'
-Tag: The Forgiven (Vast Error)
----
-Color: '#10E0FF'
-Tag: Zehanpuryu (Vast Error)
----
-Color: '#b95c00'
-Tag: LoMaM (Vast Error)
 ---
 Color: '#6c8400'
 Tag: Ellsee (Vast Error)
 ---
-Color: '#6c8400'
-Tag: Ellsee's lusus (Vast Error)
----
-Color: '#6c8400'
-Tag: The Vivifier (Vast Error)
----
-Color: '#77c350'
-Tag: Lilith (Vast Error)
----
-Color: '#6c8400'
-Tag: LoVaT (Vast Error)
----
 Color: '#487aef'
 Tag: Laivan (Vast Error)
----
-Color: '#487aef'
-Tag: Mutt (Vast Error)
----
-Color: '#487aef'
-Tag: The Jagerman (Vast Error)
----
-Color: '#ffffff'
-Tag: Haniel (Vast Error)
----
-Color: '#487aef'
-Tag: LoCaD (Vast Error)
 ---
 Color: '#008b8b'
 Tag: Serpaz (Vast Error)
 ---
-Color: '#008b8b'
-Tag: Lefty (Vast Error)
----
-Color: '#20401f'
-Tag: Sorush (Vast Error)
----
-Color: '#008b8b'
-Tag: LoSaF (Vast Error)
----
 Color: '#588a00'
 Tag: Albion (Vast Error)
----
-Color: '#588a00'
-Tag: Albion's lusus (Vast Error)
----
-Color: '#588a00'
-Tag: The Exemplar (Vast Error)
----
-Color: '#FFE094'
-Tag: Bathkol (Vast Error)
----
-Color: '#588a00'
-Tag: LoAaR (Vast Error)
 ---
 Color: '#eb0000'
 Tag: Sova (Vast Error)
 ---
-Color: '#eb0000'
-Tag: Sova's lusus (Vast Error)
----
-Color: '#eb0000'
-Tag: The Annalist (Vast Error)
----
-Color: '#bd1864'
-Tag: Jegudial (Vast Error)
----
-Color: '#eb0000'
-Tag: LoDaL (Vast Error)
----
 Color: '#cd6500'
 Tag: Dismas (Vast Error)
----
-Color: '#cd6500'
-Tag: Dismas' lusus (Vast Error)
----
-Color: '#cd6500'
-Tag: The Fomenter (Vast Error)
----
-Color: '#46fbc4'
-Tag: Forcas
----
-Color: '#cd6500'
-Tag: LoLaS (Vast Error)
 ---
 Color: '#daaf2d'
 Tag: Jentha (Vast Error)
 ---
-Color: '#daaf2d'
-Tag: Jentha's lusus (Vast Error)
----
-Color: '#daaf2d'
-Tag: The Supernova (Vast Error)
----
-Color: '#fff547'
-Tag: Af (Vast Error)
----
-Color: '#daaf2d'
-Tag: LoTGaS (Vast Error)
----
 Color: '#487aef'
 Tag: Occeus (Vast Error)
 ---
-Color: '#487aef'
-Tag: Occeus' lusus (Vast Error)
----
 Color: '#ABA698'
 Tag: Rogi (Vast Error)
----
-Color: '#BA1915'
-Tag: Wormwood (Vast Error)
----
-Color: '#487aef'
-Tag: LoBaG (Vast Error)
+# not a troll!
 ---
 Color: '#a34bff'
 Tag: Taz (Vast Error)
 ---
-Color: '#a34bff'
-Tag: Taz's lusus (Vast Error)
----
-Color: '#a34bff'
-Tag: Deadlock (Vast Error)
----
-Color: '#9c4dad'
-Tag: Azgobah (Vast Error)
----
-Color: '#a34bff'
-Tag: LoGaG (Vast Error)
----
 Color: '#db00db'
 Tag: Calder (Vast Error)
----
-Color: '#db00db'
-Tag: Calder's lusus (Vast Error)
----
-Color: '#db00db'
-Tag: Ceasar (Vast Error)
----
-Color: '#033476'
-Tag: Procel (Vast Error)
----
-Color: '#db00db'
-Tag: LoMaQ (Vast Error)
 ---
 Color: '#db00db'
 Tag: Murrit (Vast Error)
@@ -1114,17 +990,122 @@ Tag: Murrit (Vast Error)
 Color: '#db00db'
 Tag: Alt!Murrit (Vast Error)
 ---
+## Vast Error lusii
+Color: '#B95C00'
+Tag: Arcjec's lusus (Vast Error)
+---
+Color: '#6c8400'
+Tag: Ellsee's lusus (Vast Error)
+---
+Color: '#487aef'
+Tag: Mutt (Vast Error)
+---
+Color: '#008b8b'
+Tag: Lefty (Vast Error)
+---
+Color: '#588a00'
+Tag: Albion's lusus (Vast Error)
+---
+Color: '#eb0000'
+Tag: Sova's lusus (Vast Error)
+---
+Color: '#cd6500'
+Tag: Dismas' lusus (Vast Error)
+---
+Color: '#daaf2d'
+Tag: Jentha's lusus (Vast Error)
+---
+Color: '#487aef'
+Tag: Occeus' lusus (Vast Error)
+---
+Color: '#a34bff'
+Tag: Taz's lusus (Vast Error)
+---
 Color: '#db00db'
-Tag: Acerigger (Vast Error)
----
-Color: '#b70d0e'
-Tag: Gusion (Vast Error)
+Tag: Calder's lusus (Vast Error)
 ---
 Color: '#db00db'
-Tag: LoWaR (Vast Error)
+Tag: Murrit's lusus (Vast Error)
+# I don't remember ever seeing him and the wiki says he 'He dies for an unknown reason' which I think is funny
 ---
-# This next section is for a particular off-brand of alt-selves that felt too specific to be included in the prior section. They are the characters in Sova's in-universe play, "Upon the Twelfth Hour," that are obviously based directly on herself and her friends. They will be listed in the same order as the Main 12 above are, and should be considered archetypes of those characters when that system is functional. For good measure, I'll comment in who each character is based on.
-Color: '#b95c00'
+Color: '#588a00'
+Tag: Sirage's lusus (Thaumatrope)
+---
+Color: '#487aef'
+Tag: Rypite's lusus (Thaumatrope)
+---
+Color: '#008b8b'
+Tag: Platycat (Vast Error)
+# Crytum's lusus
+---
+Color: '#008b8b'
+Tag: Secily's lusus (Vast Error)
+---
+Color: '#CD4748'
+Tag: Yeshin's lusus (Vast Error)
+---
+Color: '#eb0000'
+Tag: Lutzia's lusus (Thaumatrope)
+---
+## Ancestors (some characters do not have known ancestors)
+Color: '#B95C00'
+Tag: The Forgiven (Vast Error)
+# Arcjec's ancestor
+---
+Color: '#6c8400'
+Tag: The Vivifier (Vast Error)
+# Ellsee's ancestor
+---
+Color: '#487aef'
+Tag: The Jagerman (Vast Error)
+# Laivan's ancestor
+---
+Color: '#008b8b'
+Tag: The Bohemian (Vast Error)
+# Serpaz's ancestor, but technically this might not be public knowledge?
+---
+Color: '#588a00'
+Tag: The Exemplar (Vast Error)
+# Albion's ancestor
+---
+Color: '#eb0000'
+Tag: The Annalist (Vast Error)
+# Sova's ancestor
+---
+Color: '#cd6500'
+Tag: The Fomenter (Vast Error)
+# Dismas' ancestor
+---
+Color: '#daaf2d'
+Tag: The Supernova (Vast Error)
+# Jentha's ancestor
+---
+Color: '#487aef'
+Tag: The Vanguard (Vast Error)
+# Occeus' ancestor, who apparently *has been mentioned in the comic* (on page 1909) but is not documented on the wiki in any form??
+---
+Color: '#a34bff'
+Tag: Deadlock (Vast Error)
+# Taz's ancestor
+---
+Color: '#db00db'
+Tag: Persolus (Vast Error)
+# Calder's ancestor - technically his full title is much longer, but it seemed too long to include in its entirety
+---
+Color: '#db00db'
+Tag: Switchem (Vast Error)
+# Murrit's ancestor - honestly, I would be shocked if this tag was used at all. I am really not holding my breath for him to be included in anything more than behind-the-scenes lore tidbits.
+---
+Color: '#487aef'
+Tag: The Bravura (Vast Error)
+# Rypite's ancestor
+---
+Color: '#7154ae'
+Tag: The Holistic Blight (Vast Error)
+# Edolon's ancestor
+---
+## Upon The Twelfth Hour (Sova's in-universe play) - every character is clearly based on the main 12 and should be included under character (archetype) when that system is functional
+Color: '#B95C00'
 Tag: The Lonely (Vast Error)
 # based on Arcjec
 ---
@@ -1172,22 +1153,105 @@ Color: '#db00db'
 Tag: The Watcher (Vast Error)
 # based on Murrit
 ---
-# This section is for the secondary cast, and also Snowbound Blood characters. This is mostly a complete overlap but otherwise Secily wouldn't really have a place to go. Not listed in order of importance.
-Color: '#008b8b'
-Tag: Secily (Vast Error)
+## Denizens - some of them technically have canon colors, but I thought it would be better to color code them by the aspects they hold
+Color: '#10E0FF'
+Tag: Zehanpuryu (Vast Error)
+---
+Color: '#77c350'
+Tag: Lilith (Vast Error)
+---
+Color: '#ffffff'
+Tag: Haniel (Vast Error)
+---
+Color: '#20401f'
+Tag: Sorush (Vast Error)
+---
+Color: '#FFE094'
+Tag: Bathkol (Vast Error)
+---
+Color: '#bd1864'
+Tag: Jegudial (Vast Error)
+---
+Color: '#46fbc4'
+Tag: Forcas (Vast Error)
+---
+Color: '#fff547'
+Tag: Af (Vast Error)
+---
+Color: '#BA1915'
+Tag: Wormwood (Vast Error)
+---
+Color: '#9c4dad'
+Tag: Azgobah (Vast Error)
+---
+Color: '#033476'
+Tag: Procel (Vast Error)
+---
+Color: '#b70d0e'
+Tag: Gusion (Vast Error)
+---
+## Vast Error Locations
+Color: '#B6C4C2'
+Tag: Repiton
+---
+Color: '#ffffff'
+Tag: The Static
+---
+Color: '#B95C00'
+Tag: LoMaM (Vast Error)
+# Land of Mirage and Monochrome
+---
+Color: '#6c8400'
+Tag: LoVaT (Vast Error)
+# Land of Vigor and Tundra
+---
+Color: '#487aef'
+Tag: LoCaD (Vast Error)
+# Land of Construct and Deluge
 ---
 Color: '#008b8b'
-Tag: Arcamu (Vast Error)
-# Secily's ancestor
+Tag: LoSaF (Vast Error)
+# Land of Spiral and Fracture
 ---
 Color: '#588a00'
-Tag: Noxious (Vast Error)
+Tag: LoAaR (Vast Error)
+# Land of Asteroids and Runes
 ---
+Color: '#eb0000'
+Tag: LoDaL (Vast Error)
+# Land of Daze and Lattice
+---
+Color: '#cd6500'
+Tag: LoLaS (Vast Error)
+# Land of Labyrinth and Surge
+---
+Color: '#daaf2d'
+Tag: LoTGaS (Vast Error)
+# Land of Tall Grass and Sunflowers
+---
+Color: '#487aef'
+Tag: LoBaG (Vast Error)
+# Land of Bane and Gargoyles
+---
+Color: '#a34bff'
+Tag: LoGaG (Vast Error)
+# Land of Growth and Gravity
+---
+Color: '#db00db'
+Tag: LoMaQ (Vast Error)
+# Land of Murk and Quagmire
+---
+Color: '#db00db'
+Tag: LoWaR (Vast Error)
+# Land of Wave and Record
+---
+## Secondary Cast
 Color: '#7154ae'
 Tag: Sestro (Vast Error)
 ---
 Color: '#7154ae'
 Tag: The Executive (Vast Error)
+# Sestro's ancestor, also referred to as Clarud
 ---
 Color: '#008f48'
 Tag: Hamifi (Vast Error)
@@ -1195,65 +1259,8 @@ Tag: Hamifi (Vast Error)
 Color: '#01C09F'
 Tag: Turnin (Vast Error)
 ---
-Color: '#ff8f8f'
+Color: '#eb0000'
 Tag: Racren (Vast Error)
----
-Color: '#095afe'
-Tag: Bytcon (Vast Error)
----
-Color: '#13989a'
-Tag: Cadlys (Vast Error)
----
-Color: '#588a00'
-Tag: Sirage (Vast Error)
----
-Color: '#cd6500'
-Tag: Husske (Vast Error)
----
-Color: '#487aef'
-Tag: Rypite (Vast Error)
----
-Color: '#008b8b'
-Tag: Crytum (Vast Error)
----
-Color: '#fbec5d'
-Tag: Mshiri (Vast Error)
----
-Color: '#db00db'
-Tag: Oricka (Vast Error)
----
-Color: '#B07800'
-Tag: Sabine (Vast Error)
----
-Color: '#6a816f'
-Tag: Raurou (Vast Error)
----
-Color: '#daaf2d'
-Tag: Hayyan (Vast Error)
----
-Color: '#095afe'
-Tag: Necron (Vast Error)
----
-Color: '#eb0000'
-Tag: Valtel (Vast Error)
----
-Color: '#CD4748'
-Tag: Yeshin (Vast Error)
----
-Color: '#eb0000'
-Tag: Cinare (Vast Error)
----
-Color: '#008f48'
-Tag: Glomer (Vast Error)
----
-Color: '#008f48'
-Tag: Gerbat (Vast Error)
----
-Color: '#a34bff'
-Tag: Cretas (Vast Error)
----
-Color: '#a34bff'
-Tag: Endari (Vast Error)
 ---
 Color: '#7154ae'
 Tag: Edolon (Vast Error)
@@ -1270,7 +1277,220 @@ Tag: Pozzol (Vast Error)
 Color: '#a34bff'
 Tag: Vilcus (Vast Error)
 ---
-# These are carapacians.
+Color: '#5D7B49'
+Tag: Pascal (Vast Error)
+---
+Color: '#B48E44'
+Tag: Garnie (Vast Error)
+---
+Color: '#487aef'
+Tag: Dexous (Vast Error)
+---
+Color: '#cd6500'
+Tag: Rodere (Vast Error)
+---
+Color: '#008f48'
+Tag: The Principal (Vast Error)
+---
+Color: '#008f48'
+Tag: Dionys (Vast Error)
+# WE DON'T KNOW THEIR BLOOD COLOR YET. COOL. SUPER COOL. WHY DON'T THEY HAVE A WIKI PAGE. we do know that he's a jadeblood but there's no specific color code
+---
+Color: '#D8AA09'
+Tag: Cul (Vast Error)
+# also known as Culium, WHY DON'T THEY HAVE A WIKI PAGE!
+---
+## Snowbound Blood / Wartorn Trails / tertiary cast?
+Color: '#008b8b'
+Tag: Secily (Vast Error)
+---
+Color: '#008b8b'
+Tag: Arcamu (Vast Error)
+# Secily's ancestor, also referred to as The Commandant, but Arcamu will probably be more recognizable
+---
+Color: '#FB3C5D'
+Tag: Mshiri (Vast Error)
+---
+Color: '#eb0000'
+Tag: Cinare (Vast Error)
+---
+Color: '#095afe'
+Tag: Necron (Vast Error)
+---
+Color: '#db00db'
+Tag: Oricka (Vast Error)
+---
+Color: '#CD4748'
+Tag: Yeshin (Vast Error)
+---
+Color: '#588a00'
+Tag: Noxious (Vast Error)
+---
+Color: '#487aef'
+Tag: Rypite (Vast Error)
+---
+Color: '#588a00'
+Tag: Sirage (Vast Error)
+---
+Color: '#095afe'
+Tag: Bytcon (Vast Error)
+---
+Color: '#a34bff'
+Tag: Endari (Vast Error)
+---
+Color: '#008f48'
+Tag: Glomer (Vast Error)
+---
+Color: '#008b8b'
+Tag: Crytum (Vast Error)
+---
+Color: '#B07800'
+Tag: Sabine (Vast Error)
+---
+Color: '#6a816f'
+Tag: Raurou (Vast Error)
+---
+Color: '#daaf2d'
+Tag: Hayyan (Vast Error)
+---
+Color: '#eb0000'
+Tag: Valtel (Vast Error)
+---
+Color: '#cd6500'
+Tag: Husske (Vast Error)
+---
+Color: '#008f48'
+Tag: Gerbat (Vast Error)
+---
+Color: '#a34bff'
+Tag: Cretas (Vast Error)
+---
+Color: '#13989a'
+Tag: Cadlys (Vast Error)
+---
+# Thaumatrope - characters from either Syzygy or Haustoria
+Color: '#eb0000'
+Tag: Cepros (Thaumatrope)
+---
+Color: '#cf372f'
+Tag: Tafner (Thaumatrope)
+---
+Color: '#FFE2E2'
+Tag: Phoene (Thaumatrope)
+---
+Color: '#d1cdc7'
+Tag: Degner (Thaumatrope)
+---
+Color: '#9880AB'
+Tag: Roxett (Thaumatrope)
+---
+Color: '#A3731A'
+Tag: Hemiot (Thaumatrope)
+---
+Color: '#588a00'
+Tag: Tenemi (Thaumatrope)
+---
+Color: '#A34434'
+Tag: Shiopa (Thaumatrope)
+---
+Color: '#06D6D6'
+Tag: Femmis (Thaumatrope)
+---
+Color: '#E6B400'
+Tag: Medjed (Thaumatrope)
+---
+Color: '#eb0000'
+Tag: Lutzia (Thaumatrope)
+---
+Color: '#04A180'
+Tag: Helica (Thaumatrope)
+---
+Color: '#728682'
+Tag: Alcest (Thaumatrope)
+---
+Color: '#cd6500'
+Tag: Bor (Thaumatrope)
+---
+Color: '#018BCB'
+Tag: Kim (Thaumatrope)
+---
+Color: '#daaf2d'
+Tag: Margol (Thaumatrope)
+---
+Color: '#D86B18'
+Tag: Cera (Thaumatrope)
+---
+Color: '#CB1E00'
+Tag: Neeris (Thaumatrope)
+---
+Color: '#5BB43B'
+Tag: Urodea (Thaumatrope)
+---
+Color: '#E5856D'
+Tag: Yarina (Thaumatrope)
+---
+Color: '#9CD47D'
+Tag: Sahvel (Thaumatrope)
+---
+## Tertiary cast / minor characters
+Color: '#292FA5'
+Tag: Divino (Vast Error)
+---
+Color: '#207D00'
+Tag: Mekris (Vast Error)
+---
+Color: '#67489B'
+Tag: Gingou (Vast Error)
+---
+Color: '#008f48'
+Tag: Cepora (Vast Error)
+---
+Color: '#ff7600'
+Tag: Ouroborus/Jormandgund (Vast Error)
+# cherub/s used in a one panel gag that were previously cut characters
+---
+Color: '#ffffff'
+Tag: Nocent Bystan (Vast Error)
+---
+Color: '#ffffff'
+Tag: Notrel Evantt (Vast Error)
+# I think typing "Notrel Evantt" into this file without a trace of irony has made me go completely insane.
+---
+Color: '#861422'
+Tag: Sterco (Vast Error)
+---
+Color: '#510E93'
+Tag: Keiksi (Vast Error)
+---
+Color: '#a34bff'
+Tag: Neilna (Vast Error)
+---
+Color: '#095afe'
+Tag: Iderra (Vast Error)
+---
+Color: '#5E4689'
+Tag: Nez (Vast Error)
+---
+Color: '#B2112B'
+Tag: Quever (Vast Error)
+# one of Xamag's OCs, Cretas' bondmate
+---
+Color: '#daaf2d'
+Tag: Vellia (Vast Error)
+---
+Color: '#daaf2d'
+Tag: Lipsen (Vast Error)
+# the dead troll from Occeus' intro??? why is this in the dcrc characters.css file????
+---
+Color: '#daaf2d'
+Tag: Vyr (Vast Error)
+# CHARACTER ONLY MENTIONED IN [S] TURNIN'S SOCIAL MEDIA FEED. DO WE EVEN KNOW WHAT THEY LOOK LIKE? THE FACT THAT THIS IS IN THE CSS FILE CONCERNS ME. IS THIS REALLY SOMEONE WE NEED TO TAG
+---
+Color: '#588a00'
+Tag: Linole (Vast Error)
+# another [S] Turnin social media feed troll that we have never even seen
+---
+## Vast Error Carapacians
 Color: '#ffff01'
 Tag: CM (Vast Error)
 ---
@@ -1283,7 +1503,39 @@ Tag: EE (Vast Error)
 Color: '#8a8a8a'
 Tag: Scathing Sharper (Vast Error)
 ---
-# These are narrators, and other characters who are otherwise in a more meta or omnipresent setting in the story. The only reason Mimesis is first here is because it felt right putting them next to Jack.
+Color: '#ffff01'
+Tag: Karen (Vast Error)
+---
+## Specific Consorts - I find this highly unncessary but the css file has 'em so, may as well.
+Color: '#CC05B6'
+Tag: Guy (Vast Error)
+# blue and purple snake
+---
+Color: '#55C91B'
+Tag: Lady (Vast Error)
+# green snake that appears on page 620 of Vast Error
+---
+Color: '#C62501'
+Tag: Bucko (Vast Error)
+# a red shopkeeper type snake who appears on page 849
+---
+Color: '#13A872'
+Tag: Man (Vast Error)
+# the wife of Lady? also a green snake. page 853
+---
+Color: '#ADDB03'
+Tag: Kid (Vast Error)
+# the kid of Man and Lady? more of a lime snake. honestly too off-screen to even recognize in track art
+---
+Color: '#573D76'
+Tag: Tee Hanos (Vast Error)
+# platypus type thing that looks like Thanos
+---
+Color: '#cd6500'
+Tag: Granite (Vast Error)
+# pangolian (whatever that is) potion seller. the css file doesn't have a color for this one but the wiki page lists it
+---
+## 'Divine' characters
 Color: '#de00ff'
 Tag: Mimesis
 ---
@@ -1292,20 +1544,15 @@ Tag: White Noise (Vast Error)
 ---
 Color: '#EAFF9D'
 Tag: Metatron (Vast Error)
+# technically metatron is a denizen but that's stupid. he stays in this section.
 ---
-Color: '#ECFF9E'
+Color: '#DAED87'
 Tag: Kheparia
 ---
-Color: '#F4B3B0'
+Color: '#D08FD9'
 Tag: Gaiaeon
 ---
-Color: '#B6C4C2'
-Tag: Repiton
----
-Color: '#ffffff'
-Tag: The Static
----
-# This is the end of the Vast Error section, but it should be noted that Bart, Weird Al, and Hulk Hogan are only being tracked because of Vast Error.
+### This is the end of the Vast Error section, but it should be noted that Bart, Weird Al, and Hulk Hogan are only being tracked because of Vast Error.
 Color: '#FFD90F'
 Tag: Bart
 ---


### PR DESCRIPTION
This PR rebases and combines these two pull requests from @tempest2k:

* #324 — This was the initial tag list, with an alternate sorting and a bit more detail in the guide/comments.
* #340 — This was the final tag list, with everything sorted to align closer to [networked tags](https://github.com/hsmusic/hsmusic-data/pull/293) and more concise guide/comment information.

t2k's work includes defining all the tags with names and colors, positioning them under relevant species tags, and noting relevant archetype information (e.g. The Forgiven is Arcjec's ancestor). This should all be pretty smooth to work into the networked tags system!

Actually tagging tracks with the characters is a separate todo. Most likely, it makes sense to just base the per-track tags off of this branch, and merge both the tag definitions and tag usages at the same time.