### PR TITLE
Album additions: Stable Time Loops and Paradoxes & Induction!

### DIFF
--- a/album/9.yaml
+++ b/album/9.yaml
@@ -496,6 +496,7 @@ Commentary: |-
     For this piece I wanted something simple but dynamic. The theme was of Rose "escaping from the shittiness" so I had her positioned as if she were falling  (or maybe leaping) from the terrifying shitty world. I got a lot of help from meems regarding colour and content and was able to make a dramatic piece that really reflected the song. Hooray for teamwork. Meems and I are a real ride or die duo.
 ---
 Track: Starsetter
+Directory: starsetter-canmt
 Artists:
 - WarxTron
 Cover Artists:

--- a/album/_.yaml
+++ b/album/_.yaml
@@ -323,7 +323,7 @@ URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/starcrusher
 - https://youtu.be/2WrB5d91OFI
 Referenced Tracks:
-- Starsetter
+- track:starsetter-canmt
 - Ocean Stars
 - Bridge of Stars
 Sampled Tracks:

--- a/album/alternate-hues-and-melodies.yaml
+++ b/album/alternate-hues-and-melodies.yaml
@@ -26,6 +26,7 @@ Art Tags:
 Cover Art File Extension: png
 Color: '#d3eee4'
 Groups:
+- The Paradox Music Team
 - Fandom
 ---
 Track: DUNGENESS SHOWDOWN

--- a/album/cosmic-caretakers.yaml
+++ b/album/cosmic-caretakers.yaml
@@ -86,8 +86,8 @@ Commentary: |-
     this was done pretty quick, its a simple concept that didnt take much doing. the thing i like most is probably the scratch lightning, ive been drawing a lot of lightning recently.
 ---
 Track: Egbert's Kitchen
-Artists:
-- Pascal van den Bos
+Directory: egberts-kitchen-cosmic-caretakers
+Originally Released As: track:egberts-kitchen
 Duration: '3:01'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/egberts-kitchen
@@ -98,8 +98,6 @@ Art Tags:
 - John's dad
 - Underlings
 - LoWaS
-Referenced Tracks:
-- Under The Hat
 Commentary: |-
     <i>Pascal van den Bos:</i>
     For this track i went for the style of music i think Dad listens to, [[Under The Hat]] but even jazzier haha. The chiptune breakdown in the middle is also kind of a reference to [[Showtime (Original Mix)]] which is the Strife! theme you hear when John encountered Dad. It worked pretty well, i think this is what you'd hear when you walk in to the kitchen when Dad is baking something.

--- a/album/greatest-hits-2.yaml
+++ b/album/greatest-hits-2.yaml
@@ -467,7 +467,7 @@ URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/echo-chamber-2
 ---
 Track: Starsetter
-Originally Released As: track:starsetter
+Originally Released As: track:starsetter-canmt
 Directory: starsetter-greatest-hits-2
 Duration: '02:19'
 Cover Artists:

--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -886,8 +886,6 @@ Commentary: |-
     Had quite a bit of fun doin' this one. Also quite proud of the name  Even if I do have to occasionally explain it to people who don't read the comic...
 ---
 Track: Havoc
-Additional Names:
-- Induction (on [Induction](https://svix.bandcamp.com/album/induction))
 Artists:
 - Svix
 Duration: '2:35'
@@ -898,14 +896,14 @@ Cover Artists:
 - Emi
 Cover Art File Extension: jpg
 Referenced Tracks:
-- My Hibernation
+- track:my-hibernation-original
 Art Tags:
 - The Handmaid
 - Doc Scratch
 Commentary: |-
     <i>Svix:</i> (composer)
 
-    Havoc began as an intro section for [[track:my-hibernation|another song]] I made a while back but I quite liked the melody and decided to make a separate track out of it. I submitted it to Homestuck as I felt the chiptune nature of the piece fit in with the comic's style and I'd been wanting to write a 'Strife' type tune for some time.
+    Havoc began as an intro section for [[track:my-hibernation-original|another song]] I made a while back but I quite liked the melody and decided to make a separate track out of it. I submitted it to Homestuck as I felt the chiptune nature of the piece fit in with the comic's style and I'd been wanting to write a 'Strife' type tune for some time.
 
     The track itself has a lot of C64 elements in the percussion and synths that blend into more powerful sounds for a more Drum and Bass style which is something I quite like to do with my music.
 ---

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -189,6 +189,8 @@ Cover Artists:
 Cover Art File Extension: jpg
 Art Tags:
 - Squarewave
+Referenced Tracks:
+- track:fin-induction
 Commentary: |-
     <i>Kiko B.:</i> (track artist, [Tumblr](https://kingcheddarxvii.tumblr.com/post/24963011080/since-the-album-is-out-now-i-guess-its-okay-to))
 

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -12,7 +12,7 @@ Color: '#009a85'
 Groups:
 - Beyond
 Commentary: |-
-    <i>Svix:</i> (Bandcamp credits blurb)
+    <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/album/induction))
 
     The culmination of nearly 3 years of learning and producing music.
 
@@ -20,7 +20,7 @@ Commentary: |-
 
     Hidden track included with album purchase!
 
-    <i>Svix:</i> (Bandcamp about blurb, excerpt)
+    <i>Svix:</i> ([Bandcamp credits blurb](https://svix.bandcamp.com/album/induction))
 
     Guest remixes by<br>
     [[artist:glaze]]<br>
@@ -36,9 +36,9 @@ Duration: '2:30'
 URLs:
 - https://svix.bandcamp.com/track/induction
 Commentary:
-    <i>Svix:</i> (Bandcamp description, excerpt)
+    <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/track/induction))
 
-    Originally appeared as '[[track:havoc|Havoc]]' on [[album:homestuck-vol-8|Homestuck Volume 8]]
+    Originally appeared as [[track:havoc|'Havoc']] on [[album:homestuck-vol-8|Homestuck Volume 8]]
 ---
 Track: My Hibernation
 Directory: my-hibernation
@@ -298,7 +298,7 @@ Duration: '2:56'
 URLs:
 - https://svix.bandcamp.com/track/the-fox-cub-2
 ---
-Section: Bonus tracks
+Section: Download-only track
 ---
 Track: Fin
 Directory: fin-induction
@@ -317,13 +317,11 @@ Referenced Tracks:
 - Shake Your Tail
 - The Fox Cub
 Commentary: |-
-  <i>Svix:</i> ([composer, YouTube description](https://www.youtube.com/watch?v=8UFXoZfWagQ))
+    <i>Svix:</i> ([YouTube description](https://www.youtube.com/watch?v=8UFXoZfWagQ), excerpt)
 
-  The bonus track for my album [[album:induction|Induction]]:
-
-  This was incredibly fun to make, I used the VST VOPM to achieve the YM2612 chip sound and emulated various leads and basses from some of my favourite sonic zones, of which this is a homage to. Also I couldn't help but mix elements from Flying Battery zone in with [[track:fire-forget|Fire + Forget]] since they seemed to work together so well!
+    This was incredibly fun to make, I used the VST VOPM to achieve the YM2612 chip sound and emulated various leads and basses from some of my favourite sonic zones, of which this is a homage to. Also I couldn't help but mix elements from Flying Battery zone in with [[track:fire-forget|Fire + Forget]] since they seemed to work together so well!
 ---
-Section: Main album
+Section: Remixes
 ---
 Track: Verisimilitude (Glaze Remix)
 Directory: verisimilitude-glaze-remix

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -1,0 +1,353 @@
+Album: Induction
+Directory: induction
+Artists:
+- Svix
+Date: March 26, 2012
+URLs:
+- https://svix.bandcamp.com/album/induction
+Cover Artists:
+- Svix
+Cover Art File Extension: png
+Color: #8e8785
+Groups:
+- Beyond
+Commentary: |-
+    <i>Svix:</i> (Bandcamp credits blurb)
+
+    The culmination of nearly 3 years of learning and producing music.
+
+    Features the best of my previous work, remastered and in some cases<br>completely redone.
+
+    Hidden track included with album purchase!
+
+    <i>Svix:</i> (Bandcamp about blurb, excerpt)
+
+    Guest remixes by<br>
+    [[artist:glaze]]<br>
+    [[artist:saxxon-fox|Sanxion7]]<br>
+    [[artist:metawulf]]
+---
+Section: Main album
+---
+Track: Induction
+Directory: induction
+Originally Released As: Havoc
+Duration: '2:30'
+URLs:
+- https://svix.bandcamp.com/track/induction
+Commentary:
+    <i>Svix:</i> (Bandcamp description, excerpt)
+
+    Originally appeared as '[[track:havoc|Havoc]]' on [[album:homestuck-vol-8|Homestuck Volume 8]]
+---
+Track: My Hibernation
+Directory: my-hibernation
+Duration: '3:32'
+URLs:
+- https://svix.bandcamp.com/track/my-hibernation-2
+Referenced Tracks:
+- Havoc
+- track:my-hibernation-original
+Lyrics: |-
+    Come and find me when the night's bright
+    The place we like to hear
+    Come defeat me at my own fight
+    And I will keep you near
+
+    Sing to me your incantation
+    And hold onto my waist
+    Wake me from my hibernation
+    And listen to my bass
+
+    Go end what you've begun
+    before you are outdone
+
+    Take your time and you just might find
+    You're gaining momentum
+---
+Track: Verisimilitude
+Directory: verisimilitude-induction
+Duration: '5:18'
+URLs:
+- https://svix.bandcamp.com/track/verisimilitude-2
+- https://www.youtube.com/watch?v=6-CllxbnGU8
+Lyrics: |-
+    Colour
+    The kind I wish I saw before my feelings were like no
+
+    Other
+    You took me by the hand and then showed me the door
+
+    Maybe
+    I misinterpreted the way you talked and the looks you
+
+    Gave me
+    Remember what you said? It went something like this:
+
+    Colour
+    The tiny little spark I see when you're going to break
+
+    Cover
+    I look into your eyes and there's nothing there so
+
+    Tell me
+    was everything it seemed or was the light hiding what I
+
+    could see
+    Remember what you said? It went something like this:
+
+    Why can't you recall in your history
+    Shades of umber
+    I'm caught under
+    inky thunder
+
+    Your intent to me is a mystery
+    Just a semblance
+    of true vengeance
+    Heed my entrance
+---
+Track: It Really Doesn't Matter
+Directory: it-really-doesnt-matter
+Duration: '5:39'
+URLs:
+- https://svix.bandcamp.com/track/it-really-doesnt-matter-2
+Lyrics: |-
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to when you've lost all faith
+    in your plans to make amends
+    of which are prone to shatter
+
+    Where will you be when I have left you for the sky
+    It really doesn't matter
+
+    How will you fly when I have done all this and why
+    d'you think it really matters?
+
+    Turn around, I'm not to follow
+    Times have changed, I hope you realise now
+    Close your mouth, there's no tomorrow
+    Who d'you think you're calling?
+
+    Turn around, I'm not to follow
+    Why persist and make this harder for us
+    Can't you see our past was hollow
+    Look at you you're falling
+---
+Track: Goodbye
+Directory: goodbye-induction
+Duration: '4:02'
+URLs:
+- https://svix.bandcamp.com/track/goodbye-2
+Lyrics: |-
+    Conversation
+    No sensation, things I've yet to say
+
+    Your words still sting
+    just lingering
+    I hang my head in weak dismay
+
+    Thoughts of sorrow
+    bar tomorrow, keep me from the night
+
+    I walk the paths
+    back to the past
+    and they all lead to the same place
+
+    Why do I still call your name?
+    After all this time has passed
+
+    When I think of what we could have been like
+    Think of what we could have been
+
+    Why do I still feel the same?
+    You and I weren't meant to last
+
+    But I think of what we could have been like
+    Think of what we could have
+
+    Former feelings still have meaning
+    voids I've yet to fill
+
+    There's moving on
+    It's been and gone
+    But I can't help but keep standing still
+
+    Your affection
+    stark reflection
+    how things used to be
+
+    Gotta bide my time
+    Gotta keep me mine
+
+    Gotta stop myself from thinking
+
+    Why do I still call your name?
+    After all this time has passed
+
+    When I think of what we could have been like
+    Think of what we could have been
+
+    Why do I still feel the same?
+    You and I weren't meant to last
+
+    But I think of what we could have been like
+    Think of what we could have
+    Think of what we could have been
+
+    Broken
+    is how you left me
+
+    Unspoken
+    your thoughts about me now
+
+    Shattered
+    the trust I held in you
+
+    Mattered
+    I guess you'd disagree
+
+    Darling
+    the rift between us is
+
+    Startling
+    these shifting waves hold me
+
+    Under
+    I hold my breath and I
+
+    Wonder
+    do you still think of me?
+
+    Why was it easy?
+    Why was it just me?
+    Why did it all make sense?
+    It never hit me 'til your hand just slipped right through mine
+    until your hand just slipped right through mine
+---
+Track: Wistful
+Directory: wistful-induction
+Duration: '3:42'
+URLs:
+- https://svix.bandcamp.com/track/wistful-2
+---
+Track: You Fade Away
+Directory: you-fade-away
+Duration: '3:39'
+URLs:
+- https://svix.bandcamp.com/track/you-fade-away-2
+Lyrics: |-
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    Telling me to obey
+    When really you're the prey, you fade away
+
+    Let me lead you astray
+    Into a blind foray, you fade away
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    Try your best to convey
+    Your most dishonest way, you fade away
+
+    Let me leave you halfway
+    between the night and day, you fade away
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    I see you've learnt how to fly
+    But your wings are clipped and the wind is dark and heavy
+
+    No you don't have to lie
+    The voice inside reveals what you want me to be
+
+    Fighting your way upstream
+    To tell me everything's fine and then I see
+
+    Maybe it's all a dream
+    I'd think it so but the marks you left upon me
+---
+Track: Shake Your Tail
+Directory: shake-your-tail
+Duration: '3:50'
+URLs:
+- https://svix.bandcamp.com/track/shake-your-tail-2
+Lyrics: |-
+    Hold your head up baby
+    Hold your head up high
+    Shake your tail baby
+    Shake it don't be shy
+---
+Track: Fire + Forget
+Directory: fire-forget
+Duration: '4:16'
+URLs:
+- https://svix.bandcamp.com/track/fire-forget-2
+---
+Track: The Fox Cub
+Directory: the-fox-cub
+Duration: '2:56'
+URLs:
+- https://svix.bandcamp.com/track/the-fox-cub-2
+---
+Section: Bonus tracks
+---
+Track: Fin
+Directory: fin-induction
+Duration: '4:33'
+URLs:
+- https://www.youtube.com/watch?v=8UFXoZfWagQ
+Referenced Tracks:
+- track:goodbye-induction
+- Havoc
+- track:my-hibernation-original
+- track:verisimilitude-induction
+- track:flying-battery-zone-act-1
+- track:fire-forget
+Commentary: |-
+  <i>Svix:</i> ([composer, YouTube description](https://www.youtube.com/watch?v=8UFXoZfWagQ))
+
+  The bonus track for my album [[album:induction|Induction]]:
+
+  This was incredibly fun to make, I used the VST VOPM to achieve the YM2612 chip sound and emulated various leads and basses from some of my favourite sonic zones, of which this is a homage to. Also I couldn't help but mix elements from Flying Battery zone in with [[track:fire-forget|Fire + Forget]] since they seemed to work together so well!
+---
+Section: Main album
+---
+Track: Verisimilitude (Glaze Remix)
+Directory: verisimilitude-glaze-remix
+Artists:
+- Glaze
+Duration: '3:53'
+URLs:
+- https://svix.bandcamp.com/track/verisimilitude-glaze-remix
+- https://www.youtube.com/watch?v=XWzq9mr6Ag0
+Referenced Tracks:
+- track:verisimilitude-induction
+---
+Track: You Fade Away (Sanxion7 Remix)
+Directory: you-fade-away-sanxion7-remix
+Artists:
+- Sanxion7
+Duration: '2:58'
+URLs:
+- https://svix.bandcamp.com/track/you-fade-away-sanxion7-remix
+Referenced Tracks:
+- track:you-fade-away
+---
+Track: Goodbye (Metawulf Remix)
+Directory: goodbye-metawulf-remix
+Artists:
+- Metawulf
+Duration: '4:17'
+URLs:
+- https://svix.bandcamp.com/track/goodbye-metawulf-remix
+Referenced Tracks:
+- track:goodbye-induction

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -8,7 +8,7 @@ URLs:
 Cover Artists:
 - Svix
 Cover Art File Extension: png
-Color: #8e8785
+Color: '#009a85'
 Groups:
 - Beyond
 Commentary: |-
@@ -24,7 +24,7 @@ Commentary: |-
 
     Guest remixes by<br>
     [[artist:glaze]]<br>
-    [[artist:saxxon-fox|Sanxion7]]<br>
+    [[artist:sanxion7]]<br>
     [[artist:metawulf]]
 ---
 Section: Main album
@@ -46,8 +46,8 @@ Duration: '3:32'
 URLs:
 - https://svix.bandcamp.com/track/my-hibernation-2
 Referenced Tracks:
-- Havoc
 - track:my-hibernation-original
+- Havoc
 Lyrics: |-
     Come and find me when the night's bright
     The place we like to hear
@@ -310,8 +310,12 @@ Referenced Tracks:
 - Havoc
 - track:my-hibernation-original
 - track:verisimilitude-induction
-- track:flying-battery-zone-act-1
+- track:flying-battery-zone-act-2
 - track:fire-forget
+- track:wistful-induction
+- You Fade Away
+- Shake Your Tail
+- The Fox Cub
 Commentary: |-
   <i>Svix:</i> ([composer, YouTube description](https://www.youtube.com/watch?v=8UFXoZfWagQ))
 
@@ -325,6 +329,7 @@ Track: Verisimilitude (Glaze Remix)
 Directory: verisimilitude-glaze-remix
 Artists:
 - Glaze
+- WoodenToaster
 Duration: '3:53'
 URLs:
 - https://svix.bandcamp.com/track/verisimilitude-glaze-remix

--- a/album/licord-you-can-not-sound-good.yaml
+++ b/album/licord-you-can-not-sound-good.yaml
@@ -63,7 +63,7 @@ URLs:
 Referenced Tracks:
 - licord nacrasty
 - Moshi Moshi?
-- Starsetter
+- track:starsetter-canmt
 ---
 Track: please dont confuse licord with black or liquid negrocity, that is the point of licord
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -2297,13 +2297,6 @@ Duration: '3:34'
 URLs:
 - https://www.youtube.com/watch?v=NvmxWizEJNM
 ---
-Track: More Real than Kraft Mayo
-Artists:
-- Frost Carter
-Duration: '2:21'
-URLs:
-- https://www.youtube.com/watch?v=k_-P6O_n1co
----
 Track: 'NV: Strife'
 Artists:
 - Cecily Renns
@@ -2342,16 +2335,6 @@ Referenced Tracks:
 - Jadesprite
 - Blue Atom
 - Softly
----
-Track: Temporal Virtuoso
-Artists:
-- Pascal van den Bos
-Duration: '2:29'
-URLs:
-- https://www.youtube.com/watch?v=GalZ7f-Sc2o
-Referenced Tracks:
-- Cascade (Beta)
-- Time on My Side
 ---
 Track: Vexation
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -33933,6 +33933,15 @@ Lyrics: |-
 ---
 Track: Rain
 Always Reference By Directory: true
+Directory: rain-rob-scallon
+Artists:
+- Rob Scallon
+Duration: '2:02'
+URLs:
+- https://www.youtube.com/watch?v=kdURqcVxIdk
+---
+Track: Rain
+Always Reference By Directory: true
 Directory: rain-sugoisounds
 Artists:
 - Sugoisounds

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -831,11 +831,12 @@ URLs:
 - https://www.youtube.com/watch?v=osUNwI2SiUQ
 ---
 Track: My Hibernation
+Directory: my-hibernation-original
 Artists:
 - Svix
-Duration: '3:32'
+Duration: '4:00'
 URLs:
-- https://svix.bandcamp.com/track/my-hibernation-2
+- https://www.youtube.com/watch?v=3mg4M4eLdYM 
 Lyrics: |-
     Come and find me when the night's bright
     The place we like to hear
@@ -3880,6 +3881,29 @@ Artists:
 Duration: '1:30'
 URLs:
 - https://www.youtube.com/watch?v=26MopY4DTZU
+---
+Track: Flying Battery Zone Act 1
+# Official release (as Flying Battery)
+#    HISTORY OF SONIC MUSIC 20th Anniversary Edition
+# Reference:
+#    https://vgmdb.net/album/29437
+# sorry if the duration of the video doesn't match the listed duration, the ones I found that were 1:31 in length but the echo went gradually out of sync after the first loop so I had to find this one
+Directory: flying-battery-zone-act-1
+Artists:
+- Sonic the Hedgehog
+Duration: '1:47'
+URLs:
+- https://www.youtube.com/watch?v=_T7hdIh-gtw
+---
+Track: Flying Battery Zone Act 2
+# No official release of the in-game track (or Sonic the Hedgehog 3 & Knuckles' in-game soundtrack at all)
+Directory: flying-battery-zone-act-2
+Referenced Tracks:
+- Flying Battery Zone Act 1
+Artists:
+- Sonic the Hedgehog
+URLs:
+- https://www.youtube.com/watch?v=qXchxWqLqyc
 ---
 Track: Focus
 Directory: focus-super-hexagon

--- a/album/stable-time-loops-and-paradoxes.yaml
+++ b/album/stable-time-loops-and-paradoxes.yaml
@@ -1,0 +1,715 @@
+Album: Stable Time Loops and Paradoxes
+Directory: stable-time-loops-and-paradoxes
+Date: April 13, 2018
+URLs:
+- https://www.youtube.com/playlist?list=PLtcgklmZsk9C-zU_MOKHdizqkW8uhlATJ
+Cover Artists:
+- Culdhira
+Art Tags:
+- John
+- Rose
+- Dave
+- Jade
+- Jane
+- Roxy
+- Dirk
+- Jake
+- LoWaS
+Color: '#7cf2fc'
+Groups:
+- The Paradox Music Team
+- Fandom
+Commentary: |-
+<i>Pascal van den Bos:</i> (booklet commentary)
+Hi there!, i'm PotatoBoss, i pretty much started this album, even though i never would have thought it'd get this big. Anyway thank you for downloading this album, and be sure to check out all the amazing artists and musicians if you have time, they all worked very hard and it would be much appreciated. Thanks!
+Additional Files:
+- Title: Album Booklet
+  Files: 
+  - STLaP - Commentary Booklet.pdf
+---
+Section: Disc 1
+---
+Track: ~~Disc 1~~
+Directory: disc-1-stlap
+Artists:
+- apatheticPianist
+Duration: '0:34'
+URLs:
+- https://www.youtube.com/watch?v=BSBxb5j-j5c
+Referenced Tracks:
+- track:showtime-original-mix
+Commentary: |-
+<i>apatheticPianist:</i> (composer, booklet commentary)
+This is an arrangement of Showtime that I've had lying around for a while - and it happened to be perfect for the opening disc jingle, so here we are! I actually managed to knock this recording out in my first three tries,  which is kinda crazy... and that's really all there is to say on the matter.
+---
+Track: Egbert's Kitchen
+Directory: egberts-kitchen-stlap
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- cup
+Art Tags:
+- John's dad
+- John
+Duration: '2:59'
+URLs:
+- https://www.youtube.com/watch?v=7FSsG2AF12M
+Referenced Tracks:
+- track:under-the-hat
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+For this track i went for the style of music i think Dad listens to, a jazzier version of [[track:under-the-hat|Under the Hat]] fit this idea. Also the chiptune breakdown in the middle is supposed to reference [[track:showtime-original-mix|the original Strife! theme for dad]]. So later with a bit of saxophone it worked! I think it came out pretty well, and i think this is what you'd hear whenever you walk into the kitchen when Dad is baking.
+---
+Track: Penumbra Phantasm (Frosty Style)
+Additional Names:
+- Name: Penumbra Phantasm (Frosty Edition)
+  Annotation: original name
+Directory: penumbra-phantasm-frosty-style
+Artists:
+- Frost Carter
+Cover Artists:
+- melodic-co
+Art Tags:
+- John
+Duration: '2:40'
+URLs: 
+- https://www.youtube.com/watch?v=CyvbG6L0IDU
+Referenced Tracks:
+- track:penumbra-phantasm
+Commentary: |-
+<i>Frost Carter:</i> (composer, booklet commentary)
+This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from PotatoBoss, the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
+---
+Track: Solicide
+Directory: solicide
+Artists:
+- Baleish
+Cover Artists:
+- doctorcorby
+Art Tags:
+- Rose
+- Green Sun
+- Thorns of Oglogoth
+Duration: '2:59'
+URLs:
+- https://www.youtube.com/watch?v=MUUpyZPWbew
+Referenced Tracks:
+- Flare
+- track:beatdown-strider-style
+- Time on My Side
+- Aggrieve
+- track:upward-movement-dave-owns
+Sampled Tracks:
+- Derse Dreamers
+Commentary: |-
+<i>Baleish:</i> (composer, booklet commentary)
+Y'know that feeling you get when you've been told by gods to blow up a sun twice the size of a universe? well if you have, i think it'd feel something like Solicide. So I was just spittin' some phat-tunes-y'all, y'know, some chill Dave song, when I was like... "Nah, this is just too spooky for Dave, but maybe spooky enough for Rose?" so I changed the idea from a song about Dave & Time to a song about Rose's (and Dave's kinda) mission to heck up the green sun. (P.S. you can't go wrong with hella' samples + at least 73 different phasers.) (P.P.S if y'all wanna see what this lit jam was like when it was just a simple "chill dave song" then too bad because the Instaudio link is dead R.I.P) (P.P.P.S lol nice name that wasn't used nerd) (P.P.P.P.S oh wait that was me...)
+---
+Track: 8r8k the 8ottle
+Directory: 8r8k-the-8ottle
+Additional Names:
+- Break the Bottle (English, normalized)
+Artists:
+- apatheticPianist
+- Pascal van den Bos (mastering)
+Cover Artists:
+- Camelote
+Art Tags:
+- John
+- Rose
+- Dave
+- Jade
+- Lil Cal
+- Gate
+Duration: '4:13'
+URLs:
+- https://www.youtube.com/watch?v=1VhMGErwclI
+Referenced Tracks:
+- track:sburban-jungle
+- track:showtime-original-mix
+- track:endless-climb
+- track:aggrieve
+- Sunsetter
+- track:beatdown-strider-style
+- track:mutiny
+- track:lotus
+- track:black
+- Courser
+- track:cascade-beta
+- track:spiders-claw
+- track:doctor
+- track:penumbra-phantasm
+- Crystalanthemums
+- track:upward-movement-dave-owns
+- Another Jungle
+- track:MeGaLoVania
+Commentary: |-
+<i>apatheticPianist:</i> (composer, booklet commentary)
+As you've probably gathered from listening to it, this song is themed around the first five acts of Homestuck! It has a similar structure to [[track:cue-the-curtains|Cue the Curtains]], but with five parts instead of four (which is oddly appropriate, in retrospect - five parts, five acts): John, Rose, Dave and Jade, Bec Noir and Vriska's machinations that led to him, and finally the kids' ascensions and the Scratch. The title uses Vriska's quirk for two reasons: because she had a pretty big hand in the creation of Bec Noir... and also becasue she's "stealing the spotlight" from the Beta Kids. Anyways, a huge thanks to PotatoBoss for mastering this song, and I hope y'all enjoy it!
+---
+Track: Me/Ga/Lo/Vania
+Directory: me-ga-lo-vania
+Artists:
+- Frost Carter
+Cover Artists:
+- Méline Hamard 
+Art Tags:
+- Vriska
+Duration: '2:40'
+URLs:
+- https://www.youtube.com/watch?v=Fs79Uru26xc
+Referenced Tracks:
+- track:megalovania-halloween
+Commentary: |-
+<i>Frost Carter:</i> (composer, booklet commentary)
+It's funny, you can't seem to go two steps on the internet without stumbling across a remix of [[track:megalovania-halloween|one certain song]] that shall not be named. Y'know, that [[track:megalovania-undertale|one song]] that's associated with that [[track:sans|one character]] from that one game? Yeah, you know what I'm talking about. Well, I decided to add to the pile with this remix of the OG version of that song, complete with a sound effect from that other game that probably helped inspire that first game that I mentioned. Gosh, this commentary would probably look so ridicuolous to anyone who hasn't ever been on the internet.
+---
+Track: Hospitalized
+Directory: hospitalized
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- SoulofWoods
+Art Tags:
+- John
+- Dave
+- Warhammer of Zillyhoo
+- Caledfwlch
+Duration: '2:03'
+URLs:
+- https://www.youtube.com/watch?v=JLLIa558rug
+Referenced Tracks:
+- track:doctor
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+I was trying to create kind of a battle theme for a john dave team battle, the name hospitalized is another joke on [[track:doctor|doctor]] because doctor is partially in it. but this is something i'd imagine plays when john and dave are battling together. Fun fact (again): the sick lead is the Romantic Trumpet from Touhou with way too much chorus.
+---
+Track: Temporal Virtuoso
+Directory: temporal-virtuoso
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- Pastel Colors
+Art Tags:
+- Dirk's bro
+Duration: '2:29'
+URLs:
+- https://www.youtube.com/watch?v=GalZ7f-Sc2o
+Referenced Tracks:
+- track:cascade-beta
+- Time on My Side
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+I really like to make dave songs, this song was inspired by a bass player on youtube named <a href="https://www.youtube.com/user/Davie504">Davie504</a>. I wrote the first bass parts with some squares (the square in the middle even sounds like [[track:walk-stab-walk-rande|Walk Stab Walk]] even though i didn't intend it to) to give it some variation. Then some phat beats for dave coolness and [[track:time-on-my-side|Time on My Side]] combined with [[track:cascade-beta|Cascade]] to give it max awesomeness, i guess you could see it as a strife theme for alpha Dave fighting those clowns on top of the "purple house".
+---
+Section: Disc 2
+---
+Track: ~~Disc 2~~
+Directory: disc-2-stlap
+Artists:
+- Frost Carter
+Cover Artists:
+- Hilaletto
+Art Tags:
+- Rose
+Duration: '0:07'
+URLs:
+- https://www.youtube.com/watch?v=ZKLSeqvv2NY
+Referenced Tracks:
+- track:aggrieve
+Commentary: |-
+<i>Frost Carter:</i> (composer, booklet commentary)
+This is, as I'm sure you noticed, a quick one. It didn't really take all that much effort. Honestly, it'll likely take longer to read this than to actually listen to the song, so I won't take anymore of your time.
+---
+Track: Velvet Pillow
+Directory: velvet-pillow
+Artists: 
+- Pascal van den Bos
+Cover Artists:
+- Méline Hamard
+Art Tags:
+- Rose's mom
+- Rose
+- 'cw: alcohol'
+Duration: '2:08'
+URLs:
+- https://www.youtube.com/watch?v=lHlrhPY62Qk
+Referenced Tracks:
+- track:aggrieve
+- track:sburban-jungle
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+With this track i kinda wanted to remake a Strife! theme for Mom. The bass in the beginning is building the tension of Rose trying to sneak out of the house, and when [[track:aggrieve|Aggrieve]] starts playing you know she got busted. I also added parts of [[track:sburban-jungle|Sburban Jungle]] to foreshadow her entering the medium soon, and the guitar just makes everything 10x cooler. 
+---
+Track: More Real than Kraft Mayo
+Directory: more-real-than-kraft-mayo
+Artists:
+- Frost Carter
+Cover Artists:
+- Paula Zotter
+Art Tags:
+- Dave
+Duration: '2:21'
+URLs:
+- https://www.youtube.com/watch?v=k_-P6O_n1co
+Commentary: |-
+<i>Frost Carter:</i> (composer, booklet commentary)
+This song just kinda exists. I don't really remember initially making it. Maybe it magically appeared one day, ascended from Heaven to change the world and herald the 2nd coming of Christ himself. Or maybe I made it in the middle of the night on 0 sleep and forgot. Whichever you perfer. I won't make the choice for you. I'm not your mom.
+---
+Track: Petrichor
+Directory: petrichor
+Artists:
+- Baleish
+Cover Artists:
+- Baleish
+Art Tags:
+- Dirk
+Duration: '3:06'
+URLs:
+- https://www.youtube.com/watch?v=TSnh-JprdQU
+Commentary: |-
+<i>Baleish:</i> (composer, booklet commentary)
+"Rooftop-shenanigans-with-Dirk" might as well be the title since that's what it is. I had an idea where I could make a song on FamiTracker and then master it on FL Studio, so I did! This idea turned out well, I just had to export each track on FamiTracker separately and then import them all to FL Studio and so I could just mix it as much as i wanted like some kind of evil scientist, but way less exciting...
+---
+Track: Daydreamer
+Directory: daydreamer-stlap
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- OrangeKrro
+Art Tags:
+- Jade
+- Prospit
+Duration: '2:14'
+URLs:
+- https://www.youtube.com/watch?v=JuRLjkv6zUU
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+This is what happens when you're scrolling through your Touhou soundfont trying to come up with ideas for an original track and you find a funny thing, i also used a fretless bass to have some of Jade's wackiness. Since she's a [[track:prospit-dreamers|Prospit dreamer]], i based this track on Prospit and it's dreamers. That's why this track sounds so dreamy and dissonant. I was also heavily influenced by Final Fantasy themes while making this. Overall i think it came out pretty much like how i wanted it to.
+---
+Track: Delirious Biznasty
+Directory: delirious-biznasty
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- Pascal van den Bos
+Duration: '2:01'
+URLs:
+- https://www.youtube.com/watch?v=v2FaG_2hRjM
+Lyrics: |-
+GameBro!
+	
+The GameBro is here and he's got the games
+All you other lamebrainers better feel the shame
+He can bend the rules, he's too cool for school
+And he's got just a few cheat codes for you
+There ain't nothing that'll ever hold this bad boy down
+That hat that he's wearing's like his personal crown
+He's got every game beat and skills that sweet
+But if you want in his crew, you gotta be elite
+
+Uh!
+Do it, do it, do it, do it!
+Uh!
+Alright!
+
+It's GameBro!
+When you're out of quarters, he's got your back
+He never ever betray you, man, that's a fact
+Yo, he's your best friend, and never foe
+So, come on, and let's go!
+
+The GameBro is here and he's got the games
+All you other lamebrainers better feel the shame
+He can bend the rules, he's too cool for school
+And he's got just a few cheat codes for you
+There ain't nothing that'll ever hold this bad boy down
+That hat that he's wearing's like his personal crown
+He's got every game beat and skills that sweet
+But if you want in his crew, you gotta be elite
+
+Alright bros, are you ready?
+It's time for the one, the only, GameBro!
+He's coming to your screen straight from the magazine
+The mix meister of Master Swords and mushrooms
+Are you sure you're ready for this?
+Well come on, get ready, get set, and here we go
+
+Uh!
+Do it, do it, do it, do it!
+Uh!
+Alright!
+
+Referenced Tracks:
+- Time on My Side
+- track:beatdown-strider-style
+Sampled Tracks:
+- track:gamebro-original-1990-mix
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+This is an idea that came from an emoji we have in our discord server, which is the deliriousbiznasty emoji. I wanted to make a song with that name based on the GameBro, so then FrostyMac suggested that i use the vocals from Jit's GameBro song and it worked out pretty fucking hella rad as fuck.
+---
+Track: Tranquil Downpour
+Directory: tranquil-downpour
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- catharticGhost
+Art Tags:
+- John
+Duration: '2:26'
+URLs:
+- https://www.youtube.com/watch?v=ZfuQWhwOwwM
+Referenced Tracks:
+- track:rain-rob-scallon
+- track:doctor
+- Windswept Shale
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+I was messing around with a midi i made of Rob Scallon's "[[track:rain-rob-scallon|Rain]]", and i found out that if everything is a square, it sounds like a Cavestory song. So when i added "[[track:doctor|Doctor]]" into it, it got even better. The sweet drums and the high square from "[[track:windswept-shale|Windswept Shale]]" by Baleish finished it up and made the song sound as good as it does. Also the title is kind of a nudge at "Rain" if you haven't noticed yet (ahahah I'm so clever HEEHEEHOOHOO).
+---
+Section: Disc 3
+---
+Track: ~~Disc 3~~
+Directory: disc-3-stlap
+Artists:
+- Baleish
+Cover Artists:
+- Sunbent
+Art Tags:
+- Dave
+- LoHaC
+Duration: '0:31'
+URLs:
+- https://www.youtube.com/watch?v=E4ZlBHrYie8
+Commentary: |-
+<i>Baleish:</i> (composer, booklet commentary)
+Chill beats + weird pads with spooky progressions = something that sounds like LoHAC or Dave or something else I don't know don't judge me! (also I pretty much just copied [[track:heat|Heat]] from the [[album:medium|medium album]] for this because that sounds Dave-y)
+---
+Track: Outrageously Awesome Hashrap Battle
+directory: outrageously-awesome-hashrap-battle
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- Zoe Stanley
+Art Tags:
+- Dave's bro
+- Earth
+Duration: '2:29'
+URLs:
+- https://www.youtube.com/watch?v=xorQEwN_iFk
+Referenced Tracks:
+- track:beatdown-strider-style
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+This track was inspired by Bro and Dave's battles, the beginning starts out slow and tense (Dave ascending to the roof, that's also what the strings are referencing) and then shit hits the fan. The beat becomes phatter and the Beatdown lead speeds up. I think this is what a typical battle with Bro would be like.
+---
+Track: Land of Crypts and Helium
+Directory: land-of-crypts-and-helium
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- SoulofWoods
+Art Tags:
+- Jane
+- Rabbit
+- LoCaH
+Duration: '1:27'
+URLs:
+- https://www.youtube.com/watch?v=P5htg-xI20M
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+I wanted to make an eerie song for the land of crypts and helium, i was struggling to find a fitting instrument until i accidentally knocked over my acoustic guitar (which i can't play, why do i even have that) and i really liked the sound it made. And after adding delay and reverb to a Touhou guitar it was perfect. Very fitting for that planet i'd say. The spooky pads also help give it more of a spooky cryptic vibe in my opinion.
+---
+Track: Windswept Shale
+Directory: windswept-shale
+Artists:
+- Baleish
+Cover Artists:
+- Imperial Nyx
+- Culdhira
+Art Tags:
+- WQ
+- Earth
+- Frog Temple
+Duration: '5:25'
+URLs:
+- https://www.youtube.com/watch?v=NVj9gP07lBg
+Referenced Tracks:
+- track:heat
+Commentary: |-
+<i>Baleish:</i> (composer, booklet commentary)
+This song was kinda having an identity crisis since this was gonna be a song for LoWAS as you can see by the title & intro bit, but then I did the breakdown and the [[track:heat|Heat]] motif and it didn't seem like it would fit very well so i was just like "heck it." and thought this should be song about the Forge. Nothing else to say besides damn that bass makes me wet.
+---
+Track: Slammed 8y the Sun!!!!!!!!
+Directory: slammed-8y-the-sun
+Additional Names:
+- Slammed by the Sun!!!!!!!! (English, normalized)
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- doctorcorby
+Art Tags:
+- Vriska
+Duration: '3:13'
+URLs:
+- https://www.youtube.com/watch?v=kwsKtNHcAXI
+Referenced Tracks:
+- track:killed-by-br8k-spider
+- Sunslammer
+- track:vriskas-theme
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun VRISKA GUITAR SUN!!!!!!!! 
+(Vriska ascends to god tier bluh)
+---
+Track: Wander
+Directory: wander-thomas-ferkol
+Artists:
+- Thomas Ferkol
+Cover Artists:
+- SoulofWoods
+Art Tags:
+- WV
+- PM
+- Serenity
+- AR
+- WQ
+- WK
+- Ruined Earth
+Duration: '2:50'
+URLs:
+- https://www.youtube.com/watch?v=_ArcwQzg9lE
+Referenced Tracks:
+- track:explore
+Commentary: |-
+<i>Thomas Ferkol:</i> (composer, booklet commentary)
+Wander was the result of there not being enough [[track:explore|Explore]] remixes. Back around the time I joined the music team, I was listening to Explore and thought the orchestration of the synths would translate well to strings. I'd also probably been listening to old Apocalyptica at the time, resulting in a cello ensemble with plodding gritty drum loops. While Explore soars above the remains of the world, Wander is grounded and more subdued. The interlude of ambient jungle noises was partially to reflect the world reverting back to nature, and the distant atmosphere and distorted portions are sort of the echoes and ruins left behind.
+---
+Track: Take a Stand!
+Directory: take-a-stand
+Artists:
+- Sunbent
+Contributors:
+- CALIKID (some help)
+Cover Artists:
+- SoulofWoods
+Art Tags:
+- Vriska
+- John
+- Rose
+- Dave
+- Jade
+- Lord English
+- Victory Platform
+- Light
+- Breath
+- Time
+- Space
+- Caledfwlch
+- Pop-a-matic Vrillyhoo Hammer
+- Quills of Echidna
+Duration: '6:58'
+URLs:
+- https://www.youtube.com/watch?v=bM-xp_8g62M
+Referenced Tracks:
+- track:killed-by-br8k-spider
+Commentary: |-
+<i>Sunbent:</i> (composer, booklet commentary)
+A pretty long one, and i guess it's kind of a non cannon afterwards to [[flash:8087|collide]] in my mind. I refrained from using leomotifs because I honestly don't think this song needs it. Now if you watched collide, it never actually showed them killing lord English right? Well this is in my mind the battle theme to what happened there. If you want you can watch the YouTube theories but simply put, after collide vriska summons more powerful beta (and possibly alpha) kids out of her sburb house thingy. So basically it beta kids, vriska and the ghost army vs lord English. And thats the song. I considered calling it "collide v3" but i felt it was too obvious.
+---
+Track: LOWAS M.D.
+Directory: lowas-m-d
+Artists:
+- Frost Carter
+Cover Artists:
+- Culdhira
+Art Tags:
+- John
+- Consorts
+- LoWaS
+Duration: '1:41'
+URLs:
+- https://www.youtube.com/watch?v=5Hxsk1UZdV8
+Referenced Tracks:
+- track:doctor
+- track:megalovania-halloween
+Commentary: |-
+<i>Frost Carter:</i> (composer, booklet commentary)
+This song has a truly awful name, I know. Just ignore that massive blunder on my part, and listen to the song itself. Like with most of my songs, I made this ages back, and, upon refinding it, I simply touched it up and pushed it out of the nest, where it, no doubt, landed on the ground with a thud in spectactular fashion. Oh well.
+---
+Section: Disc 4
+---
+Track: ~~Disc 4~~
+Directory: disc-4-stlap
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- Pascal van den Bos
+Art Tags:
+- Jade
+Duration: '0:36'
+URLs:
+- https://www.youtube.com/watch?v=TEe9h4TW-VA
+Referenced Tracks:
+- track:verdancy-bassline
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+I wanted to use the awesome [[track:verdancy-bassline|Verdancy bassline]] as a funny jingle, so i learned how to play it and improvised some parts and added a sick drumloop for that [[track:potential-verdancy|potential verdancy]] feel... Not much else to say on that... Here, have a Crab Apple.
+---
+Track: Fetch The Bullet!
+Directory: fetch-the-bullet
+Artists: 
+- Pascal van den Bos
+Cover Artists:
+- Camelote
+Art Tags:
+- Jade
+- Becquerel
+- Earth
+- Frog Temple
+Duration: '3:00'
+URLs:
+- https://www.youtube.com/watch?v=9GIsMmaBTUg
+Referenced Tracks:
+- track:mutiny
+- track:beatdown-strider-style
+- track:MeGaLoVania
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+This is an interesting one, Fetch the Bullet! Is based entirely on the flash [[flash:980|[S] Jade: Retrieve Package]] (specifically the old version). The song is paying its respects to the removed track [[track:mutiny|Mutiny]] which needed some love, it was removed for a reason but it's still a great (and one of my favourites) track. I also used alot of spacey synths to signify Bec traveling to space and teleporting all over the place and shit. And then [[track:MeGaLoVania|MeGaLoVania]] and [[track:beatdown-strider-style|Beatdown]] are in there for some reason. I also put in the Ultimate Guitar kit again for the reference to Jade knowing how to play guitar (man do i love that soundfont).
+---
+Track: Urban Forest
+Artists:
+- CALIKID
+Cover Artists:
+- CALIKID
+Art Tags:
+- Dave
+- Jade
+- John
+- Rose
+- Underlings
+- Lotus
+Duration: '3:44'
+URLs:
+- https://www.youtube.com/watch?v=8Yy2cSe-pyE
+Referenced Tracks:
+- track:sburban-jungle
+Commentary: |-
+<i>CALIKID:</i> (composer, booklet commentary)
+The clock is ticking and you and your friends are *doomed*. Or are you? Who's to say? But you gotta act quick! The notorious song heard in the 13th flash of Homestuck. (copyrighted by Andrew Hussie) remixed and remastered by yours truly. Completed with fantastical arpeggios and and drops so massive you'll trip on your feet. Don't hesitate now, click that play button. (You know you want to.)
+---
+Track: Death by the Time to Gardenlovania (Bassline)
+Directory: death-by-the-time-to-gardenlovania-bassline
+Artists:
+- Pascal van den Bos
+Cover Artists:
+- Cue
+Art Tags:
+- Jade
+Duration: '3:08'
+URLs:
+- https://www.youtube.com/watch?v=H2CbGnaRI8c
+Referenced Tracks:
+- track:death-by-glamour
+- track:time-on-my-side
+- track:gardener
+- track:megalovania-halloween
+- track:verdancy-bassline
+Commentary: |-
+<i>Pascal van den Bos:</i> (composer, booklet commentary)
+I was originally just going to play [[track:gardener|Gardener]] as a cover, but then I realised that's completely unoriginal and i remembered i can play some other random songs. So i just mixed those in and improvised some parts of Gardener and you get this! Fun fact: i had to play this like 30 times over because i kept fucking up (wow that wasn't fun at all).
+---
+Track: Starsetter
+Directory: starsetter-stlap
+Artists:
+- CALIKID
+Cover Artists:
+- frummpets
+Art Tags:
+- Jade
+Duration: '2:19'
+URLs:
+- https://www.youtube.com/watch?v=ddeLlAsjNgI
+Referenced Tracks:
+- track:moonsetter
+Commentary: |-
+<i>CALIKID:</i> (composer, booklet commentary)
+Ahh yes. The rain. Your friends. Your friends and the rain. But under an umbrella of course. Kick back and relax as you listen to this chill jam inspired by Toby Fox's [[track:moonsetter|Moonsetter]]. It's truly a masterpiece. The melody is so sweet that people can't help but make remixes of it, which is exactly what this is. A remix of just that. With ambience and a sick beat, this song fills every need fitted to *survive* on a barren planet that you made with your chums in a video game that may or may not destroy the world.
+---
+Track: Endless Dreamers
+Artists:
+- CALIKID
+Cover Artists:
+- CALIKID
+Art Tags:
+- Rose
+- Rose's mom
+- John's dad
+Duration: '3:50'
+URLs:
+- https://www.youtube.com/watch?v=ceu24tuArCY
+Referenced Tracks:
+- Derse Dreamers
+- track:endless-climb
+Commentary: |-
+<i>CALIKID:</i> (composer, booklet commentary)
+I was originally planning on doing [[track:endless-climb|Endless Climb]] but somehow in the middle it changed to [[track:derse-dreamers|Derse Dreamers]] too so I decided to go with it. It's full of action and heavy saws. I thought it would be cool to add a bit of a mellow sound to the beginning though so I went with that. I hope you like it!
+---
+Track: Cue the Curtains
+Artists:
+- apatheticPianist
+- Pascal van den Bos (mastering)
+Cover Artists:
+- SoulofWoods
+Art Tags:
+- Dave
+- Dirk
+- Roxy
+- Rose
+- John
+- Jade
+- Jane
+- Jake
+- Terezi
+- Kanaya
+- Karkat
+- PM
+- Jack Noir
+- The Condesce
+- Lord English
+- The Felt
+- Unbreakable Katana
+- Dragon Cane
+- Caledfwlch
+- Pop-a-matic Vrillyhoo Hammer
+- Quills of Echidna
+- Chainsaw
+- Fork
+- Homes Smell Ya Later
+- Flintlocks of Zillyhau
+- LoTaK
+- Derse
+- LoFaF
+- LoMaX
+Duration: '4:13'
+URLs:
+- https://www.youtube.com/watch?v=mBcIMWZULF4
+Referenced Tracks:
+- track:showtime-original-mix
+- track:three-in-the-morning
+- track:flare
+- track:vriskas-theme
+- track:terezis-theme
+- track:upward-movement-dave-owns
+- Time on My Side
+- track:chorale-for-jaspers
+- Rex Duodecim Angelus
+- Heir Conditioning
+- track:penumbra-phantasm
+- Even in Death
+- track:cascade-beta
+Commentary: |-
+<i>apatheticPianist:</i> (composer, booklet commentary)
+Somewhat ironically, this song actually came before [[track:8r8k-the-8ottle|8r8k the 8ottle]] - when I joined the album, a song themed around EOA6 / Collide was the first thing that came to mind, and this is the result! As you've probably noticed, it's separated pretty evenly into four parts: first Vriska vs. Lord English, then Terezi and the Striders vs. Lord Jack and Spades Slick, then the HIC fight, and finally an ending meant to call back (forward?) to Act 7. Also, giant thanks to PotatoBoss for mastering it and 8r8k the 8ottle - they definitely wouldn't have had that extra Homestuck kick without his help, hehe. Aside from that, nothing much else to say about it - it's a giant pile of motifs that I really enjoyed composing!

--- a/album/stable-time-loops-and-paradoxes.yaml
+++ b/album/stable-time-loops-and-paradoxes.yaml
@@ -20,11 +20,11 @@ Groups:
 - The Paradox Music Team
 - Fandom
 Commentary: |-
-<i>Pascal van den Bos:</i> (booklet commentary)
-Hi there!, i'm PotatoBoss, i pretty much started this album, even though i never would have thought it'd get this big. Anyway thank you for downloading this album, and be sure to check out all the amazing artists and musicians if you have time, they all worked very hard and it would be much appreciated. Thanks!
+    <i>Pascal van den Bos:</i> (booklet commentary)
+    Hi there!, i'm PotatoBoss, i pretty much started this album, even though i never would have thought it'd get this big. Anyway thank you for downloading this album, and be sure to check out all the amazing artists and musicians if you have time, they all worked very hard and it would be much appreciated. Thanks!
 Additional Files:
 - Title: Album Booklet
-  Files: 
+  Files:
   - STLaP - Commentary Booklet.pdf
 ---
 Section: Disc 1
@@ -39,8 +39,8 @@ URLs:
 Referenced Tracks:
 - track:showtime-original-mix
 Commentary: |-
-<i>apatheticPianist:</i> (composer, booklet commentary)
-This is an arrangement of Showtime that I've had lying around for a while - and it happened to be perfect for the opening disc jingle, so here we are! I actually managed to knock this recording out in my first three tries,  which is kinda crazy... and that's really all there is to say on the matter.
+    <i>apatheticPianist:</i> (composer, booklet commentary)
+    This is an arrangement of Showtime that I've had lying around for a while - and it happened to be perfect for the opening disc jingle, so here we are! I actually managed to knock this recording out in my first three tries,  which is kinda crazy... and that's really all there is to say on the matter.
 ---
 Track: Egbert's Kitchen
 Directory: egberts-kitchen-stlap
@@ -57,14 +57,13 @@ URLs:
 Referenced Tracks:
 - track:under-the-hat
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-For this track i went for the style of music i think Dad listens to, a jazzier version of [[track:under-the-hat|Under the Hat]] fit this idea. Also the chiptune breakdown in the middle is supposed to reference [[track:showtime-original-mix|the original Strife! theme for dad]]. So later with a bit of saxophone it worked! I think it came out pretty well, and i think this is what you'd hear whenever you walk into the kitchen when Dad is baking.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    For this track i went for the style of music i think Dad listens to, a jazzier version of [[track:under-the-hat|Under the Hat]] fit this idea. Also the chiptune breakdown in the middle is supposed to reference [[track:showtime-original-mix|the original Strife! theme for dad]]. So later with a bit of saxophone it worked! I think it came out pretty well, and i think this is what you'd hear whenever you walk into the kitchen when Dad is baking.
 ---
 Track: Penumbra Phantasm (Frosty Style)
 Additional Names:
 - Name: Penumbra Phantasm (Frosty Edition)
   Annotation: original name
-Directory: penumbra-phantasm-frosty-style
 Artists:
 - Frost Carter
 Cover Artists:
@@ -72,16 +71,15 @@ Cover Artists:
 Art Tags:
 - John
 Duration: '2:40'
-URLs: 
+URLs:
 - https://www.youtube.com/watch?v=CyvbG6L0IDU
 Referenced Tracks:
 - track:penumbra-phantasm
 Commentary: |-
-<i>Frost Carter:</i> (composer, booklet commentary)
-This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from PotatoBoss, the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
+    <i>Frost Carter:</i> (composer, booklet commentary)
+    This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from PotatoBoss, the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
 ---
 Track: Solicide
-Directory: solicide
 Artists:
 - Baleish
 Cover Artists:
@@ -89,7 +87,7 @@ Cover Artists:
 Art Tags:
 - Rose
 - Green Sun
-- Thorns of Oglogoth
+# - Thorns of Oglogoth
 Duration: '2:59'
 URLs:
 - https://www.youtube.com/watch?v=MUUpyZPWbew
@@ -102,11 +100,10 @@ Referenced Tracks:
 Sampled Tracks:
 - Derse Dreamers
 Commentary: |-
-<i>Baleish:</i> (composer, booklet commentary)
-Y'know that feeling you get when you've been told by gods to blow up a sun twice the size of a universe? well if you have, i think it'd feel something like Solicide. So I was just spittin' some phat-tunes-y'all, y'know, some chill Dave song, when I was like... "Nah, this is just too spooky for Dave, but maybe spooky enough for Rose?" so I changed the idea from a song about Dave & Time to a song about Rose's (and Dave's kinda) mission to heck up the green sun. (P.S. you can't go wrong with hella' samples + at least 73 different phasers.) (P.P.S if y'all wanna see what this lit jam was like when it was just a simple "chill dave song" then too bad because the Instaudio link is dead R.I.P) (P.P.P.S lol nice name that wasn't used nerd) (P.P.P.P.S oh wait that was me...)
+    <i>Baleish:</i> (composer, booklet commentary)
+    Y'know that feeling you get when you've been told by gods to blow up a sun twice the size of a universe? well if you have, i think it'd feel something like Solicide. So I was just spittin' some phat-tunes-y'all, y'know, some chill Dave song, when I was like... "Nah, this is just too spooky for Dave, but maybe spooky enough for Rose?" so I changed the idea from a song about Dave & Time to a song about Rose's (and Dave's kinda) mission to heck up the green sun. (P.S. you can't go wrong with hella' samples + at least 73 different phasers.) (P.P.S if y'all wanna see what this lit jam was like when it was just a simple "chill dave song" then too bad because the Instaudio link is dead R.I.P) (P.P.P.S lol nice name that wasn't used nerd) (P.P.P.P.S oh wait that was me...)
 ---
 Track: 8r8k the 8ottle
-Directory: 8r8k-the-8ottle
 Additional Names:
 - Break the Bottle (English, normalized)
 Artists:
@@ -144,15 +141,15 @@ Referenced Tracks:
 - Another Jungle
 - track:MeGaLoVania
 Commentary: |-
-<i>apatheticPianist:</i> (composer, booklet commentary)
-As you've probably gathered from listening to it, this song is themed around the first five acts of Homestuck! It has a similar structure to [[track:cue-the-curtains|Cue the Curtains]], but with five parts instead of four (which is oddly appropriate, in retrospect - five parts, five acts): John, Rose, Dave and Jade, Bec Noir and Vriska's machinations that led to him, and finally the kids' ascensions and the Scratch. The title uses Vriska's quirk for two reasons: because she had a pretty big hand in the creation of Bec Noir... and also becasue she's "stealing the spotlight" from the Beta Kids. Anyways, a huge thanks to PotatoBoss for mastering this song, and I hope y'all enjoy it!
+    <i>apatheticPianist:</i> (composer, booklet commentary)
+    As you've probably gathered from listening to it, this song is themed around the first five acts of Homestuck! It has a similar structure to [[track:cue-the-curtains|Cue the Curtains]], but with five parts instead of four (which is oddly appropriate, in retrospect - five parts, five acts): John, Rose, Dave and Jade, Bec Noir and Vriska's machinations that led to him, and finally the kids' ascensions and the Scratch. The title uses Vriska's quirk for two reasons: because she had a pretty big hand in the creation of Bec Noir... and also becasue she's "stealing the spotlight" from the Beta Kids. Anyways, a huge thanks to PotatoBoss for mastering this song, and I hope y'all enjoy it!
 ---
 Track: Me/Ga/Lo/Vania
 Directory: me-ga-lo-vania
 Artists:
 - Frost Carter
 Cover Artists:
-- Méline Hamard 
+- Méline Hamard
 Art Tags:
 - Vriska
 Duration: '2:40'
@@ -161,11 +158,12 @@ URLs:
 Referenced Tracks:
 - track:megalovania-halloween
 Commentary: |-
-<i>Frost Carter:</i> (composer, booklet commentary)
-It's funny, you can't seem to go two steps on the internet without stumbling across a remix of [[track:megalovania-halloween|one certain song]] that shall not be named. Y'know, that [[track:megalovania-undertale|one song]] that's associated with that [[track:sans|one character]] from that one game? Yeah, you know what I'm talking about. Well, I decided to add to the pile with this remix of the OG version of that song, complete with a sound effect from that other game that probably helped inspire that first game that I mentioned. Gosh, this commentary would probably look so ridicuolous to anyone who hasn't ever been on the internet.
+    <i>Frost Carter:</i> (composer, booklet commentary)
+    It's funny, you can't seem to go two steps on the internet without stumbling across a remix of [[track:megalovania-halloween|one certain song]] that shall not be named. Y'know, that [[track:megalovania-undertale|one song]] that's associated with that [[track:sans|one character]] from that one game? Yeah, you know what I'm talking about. Well, I decided to add to the pile with this remix of the OG version of that song, complete with a sound effect from that other game that probably helped inspire that first game that I mentioned. Gosh, this commentary would probably look so ridicuolous to anyone who hasn't ever been on the internet.
 ---
 Track: Hospitalized
-Directory: hospitalized
+Directory: hospitalized-stlap
+Always Reference By Directory: true
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -173,19 +171,18 @@ Cover Artists:
 Art Tags:
 - John
 - Dave
-- Warhammer of Zillyhoo
-- Caledfwlch
+# - Warhammer of Zillyhoo
+# - Caledfwlch
 Duration: '2:03'
 URLs:
 - https://www.youtube.com/watch?v=JLLIa558rug
 Referenced Tracks:
 - track:doctor
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-I was trying to create kind of a battle theme for a john dave team battle, the name hospitalized is another joke on [[track:doctor|doctor]] because doctor is partially in it. but this is something i'd imagine plays when john and dave are battling together. Fun fact (again): the sick lead is the Romantic Trumpet from Touhou with way too much chorus.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    I was trying to create kind of a battle theme for a john dave team battle, the name hospitalized is another joke on [[track:doctor|doctor]] because doctor is partially in it. but this is something i'd imagine plays when john and dave are battling together. Fun fact (again): the sick lead is the Romantic Trumpet from Touhou with way too much chorus.
 ---
 Track: Temporal Virtuoso
-Directory: temporal-virtuoso
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -199,8 +196,8 @@ Referenced Tracks:
 - track:cascade-beta
 - Time on My Side
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-I really like to make dave songs, this song was inspired by a bass player on youtube named <a href="https://www.youtube.com/user/Davie504">Davie504</a>. I wrote the first bass parts with some squares (the square in the middle even sounds like [[track:walk-stab-walk-rande|Walk Stab Walk]] even though i didn't intend it to) to give it some variation. Then some phat beats for dave coolness and [[track:time-on-my-side|Time on My Side]] combined with [[track:cascade-beta|Cascade]] to give it max awesomeness, i guess you could see it as a strife theme for alpha Dave fighting those clowns on top of the "purple house".
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    I really like to make dave songs, this song was inspired by a bass player on youtube named <a href="https://www.youtube.com/user/Davie504">Davie504</a>. I wrote the first bass parts with some squares (the square in the middle even sounds like [[track:walk-stab-walk-rande|Walk Stab Walk]] even though i didn't intend it to) to give it some variation. Then some phat beats for dave coolness and [[track:time-on-my-side|Time on My Side]] combined with [[track:cascade-beta|Cascade]] to give it max awesomeness, i guess you could see it as a strife theme for alpha Dave fighting those clowns on top of the "purple house".
 ---
 Section: Disc 2
 ---
@@ -218,12 +215,11 @@ URLs:
 Referenced Tracks:
 - track:aggrieve
 Commentary: |-
-<i>Frost Carter:</i> (composer, booklet commentary)
-This is, as I'm sure you noticed, a quick one. It didn't really take all that much effort. Honestly, it'll likely take longer to read this than to actually listen to the song, so I won't take anymore of your time.
+    <i>Frost Carter:</i> (composer, booklet commentary)
+    This is, as I'm sure you noticed, a quick one. It didn't really take all that much effort. Honestly, it'll likely take longer to read this than to actually listen to the song, so I won't take anymore of your time.
 ---
 Track: Velvet Pillow
-Directory: velvet-pillow
-Artists: 
+Artists:
 - Pascal van den Bos
 Cover Artists:
 - Méline Hamard
@@ -238,11 +234,10 @@ Referenced Tracks:
 - track:aggrieve
 - track:sburban-jungle
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-With this track i kinda wanted to remake a Strife! theme for Mom. The bass in the beginning is building the tension of Rose trying to sneak out of the house, and when [[track:aggrieve|Aggrieve]] starts playing you know she got busted. I also added parts of [[track:sburban-jungle|Sburban Jungle]] to foreshadow her entering the medium soon, and the guitar just makes everything 10x cooler. 
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    With this track i kinda wanted to remake a Strife! theme for Mom. The bass in the beginning is building the tension of Rose trying to sneak out of the house, and when [[track:aggrieve|Aggrieve]] starts playing you know she got busted. I also added parts of [[track:sburban-jungle|Sburban Jungle]] to foreshadow her entering the medium soon, and the guitar just makes everything 10x cooler.
 ---
 Track: More Real than Kraft Mayo
-Directory: more-real-than-kraft-mayo
 Artists:
 - Frost Carter
 Cover Artists:
@@ -253,11 +248,10 @@ Duration: '2:21'
 URLs:
 - https://www.youtube.com/watch?v=k_-P6O_n1co
 Commentary: |-
-<i>Frost Carter:</i> (composer, booklet commentary)
-This song just kinda exists. I don't really remember initially making it. Maybe it magically appeared one day, ascended from Heaven to change the world and herald the 2nd coming of Christ himself. Or maybe I made it in the middle of the night on 0 sleep and forgot. Whichever you perfer. I won't make the choice for you. I'm not your mom.
+    <i>Frost Carter:</i> (composer, booklet commentary)
+    This song just kinda exists. I don't really remember initially making it. Maybe it magically appeared one day, ascended from Heaven to change the world and herald the 2nd coming of Christ himself. Or maybe I made it in the middle of the night on 0 sleep and forgot. Whichever you perfer. I won't make the choice for you. I'm not your mom.
 ---
 Track: Petrichor
-Directory: petrichor
 Artists:
 - Baleish
 Cover Artists:
@@ -268,11 +262,12 @@ Duration: '3:06'
 URLs:
 - https://www.youtube.com/watch?v=TSnh-JprdQU
 Commentary: |-
-<i>Baleish:</i> (composer, booklet commentary)
-"Rooftop-shenanigans-with-Dirk" might as well be the title since that's what it is. I had an idea where I could make a song on FamiTracker and then master it on FL Studio, so I did! This idea turned out well, I just had to export each track on FamiTracker separately and then import them all to FL Studio and so I could just mix it as much as i wanted like some kind of evil scientist, but way less exciting...
+    <i>Baleish:</i> (composer, booklet commentary)
+    "Rooftop-shenanigans-with-Dirk" might as well be the title since that's what it is. I had an idea where I could make a song on FamiTracker and then master it on FL Studio, so I did! This idea turned out well, I just had to export each track on FamiTracker separately and then import them all to FL Studio and so I could just mix it as much as i wanted like some kind of evil scientist, but way less exciting...
 ---
 Track: Daydreamer
 Directory: daydreamer-stlap
+Always Reference By Directory: true
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -284,11 +279,10 @@ Duration: '2:14'
 URLs:
 - https://www.youtube.com/watch?v=JuRLjkv6zUU
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-This is what happens when you're scrolling through your Touhou soundfont trying to come up with ideas for an original track and you find a funny thing, i also used a fretless bass to have some of Jade's wackiness. Since she's a [[track:prospit-dreamers|Prospit dreamer]], i based this track on Prospit and it's dreamers. That's why this track sounds so dreamy and dissonant. I was also heavily influenced by Final Fantasy themes while making this. Overall i think it came out pretty much like how i wanted it to.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    This is what happens when you're scrolling through your Touhou soundfont trying to come up with ideas for an original track and you find a funny thing, i also used a fretless bass to have some of Jade's wackiness. Since she's a [[track:prospit-dreamers|Prospit dreamer]], i based this track on Prospit and it's dreamers. That's why this track sounds so dreamy and dissonant. I was also heavily influenced by Final Fantasy themes while making this. Overall i think it came out pretty much like how i wanted it to.
 ---
 Track: Delirious Biznasty
-Directory: delirious-biznasty
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -297,60 +291,58 @@ Duration: '2:01'
 URLs:
 - https://www.youtube.com/watch?v=v2FaG_2hRjM
 Lyrics: |-
-GameBro!
-	
-The GameBro is here and he's got the games
-All you other lamebrainers better feel the shame
-He can bend the rules, he's too cool for school
-And he's got just a few cheat codes for you
-There ain't nothing that'll ever hold this bad boy down
-That hat that he's wearing's like his personal crown
-He's got every game beat and skills that sweet
-But if you want in his crew, you gotta be elite
+    GameBro!
 
-Uh!
-Do it, do it, do it, do it!
-Uh!
-Alright!
+    The GameBro is here and he's got the games
+    All you other lamebrainers better feel the shame
+    He can bend the rules, he's too cool for school
+    And he's got just a few cheat codes for you
+    There ain't nothing that'll ever hold this bad boy down
+    That hat that he's wearing's like his personal crown
+    He's got every game beat and skills that sweet
+    But if you want in his crew, you gotta be elite
 
-It's GameBro!
-When you're out of quarters, he's got your back
-He never ever betray you, man, that's a fact
-Yo, he's your best friend, and never foe
-So, come on, and let's go!
+    Uh!
+    Do it, do it, do it, do it!
+    Uh!
+    Alright!
 
-The GameBro is here and he's got the games
-All you other lamebrainers better feel the shame
-He can bend the rules, he's too cool for school
-And he's got just a few cheat codes for you
-There ain't nothing that'll ever hold this bad boy down
-That hat that he's wearing's like his personal crown
-He's got every game beat and skills that sweet
-But if you want in his crew, you gotta be elite
+    It's GameBro!
+    When you're out of quarters, he's got your back
+    He never ever betray you, man, that's a fact
+    Yo, he's your best friend, and never foe
+    So, come on, and let's go!
 
-Alright bros, are you ready?
-It's time for the one, the only, GameBro!
-He's coming to your screen straight from the magazine
-The mix meister of Master Swords and mushrooms
-Are you sure you're ready for this?
-Well come on, get ready, get set, and here we go
+    The GameBro is here and he's got the games
+    All you other lamebrainers better feel the shame
+    He can bend the rules, he's too cool for school
+    And he's got just a few cheat codes for you
+    There ain't nothing that'll ever hold this bad boy down
+    That hat that he's wearing's like his personal crown
+    He's got every game beat and skills that sweet
+    But if you want in his crew, you gotta be elite
 
-Uh!
-Do it, do it, do it, do it!
-Uh!
-Alright!
+    Alright bros, are you ready?
+    It's time for the one, the only, GameBro!
+    He's coming to your screen straight from the magazine
+    The mix meister of Master Swords and mushrooms
+    Are you sure you're ready for this?
+    Well come on, get ready, get set, and here we go
 
+    Uh!
+    Do it, do it, do it, do it!
+    Uh!
+    Alright!
 Referenced Tracks:
 - Time on My Side
 - track:beatdown-strider-style
 Sampled Tracks:
 - track:gamebro-original-1990-mix
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-This is an idea that came from an emoji we have in our discord server, which is the deliriousbiznasty emoji. I wanted to make a song with that name based on the GameBro, so then FrostyMac suggested that i use the vocals from Jit's GameBro song and it worked out pretty fucking hella rad as fuck.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    This is an idea that came from an emoji we have in our discord server, which is the deliriousbiznasty emoji. I wanted to make a song with that name based on the GameBro, so then FrostyMac suggested that i use the vocals from Jit's GameBro song and it worked out pretty fucking hella rad as fuck.
 ---
 Track: Tranquil Downpour
-Directory: tranquil-downpour
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -365,8 +357,8 @@ Referenced Tracks:
 - track:doctor
 - Windswept Shale
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-I was messing around with a midi i made of Rob Scallon's "[[track:rain-rob-scallon|Rain]]", and i found out that if everything is a square, it sounds like a Cavestory song. So when i added "[[track:doctor|Doctor]]" into it, it got even better. The sweet drums and the high square from "[[track:windswept-shale|Windswept Shale]]" by Baleish finished it up and made the song sound as good as it does. Also the title is kind of a nudge at "Rain" if you haven't noticed yet (ahahah I'm so clever HEEHEEHOOHOO).
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    I was messing around with a midi i made of Rob Scallon's "[[track:rain-rob-scallon|Rain]]", and i found out that if everything is a square, it sounds like a Cavestory song. So when i added "[[track:doctor|Doctor]]" into it, it got even better. The sweet drums and the high square from "[[track:windswept-shale|Windswept Shale]]" by Baleish finished it up and made the song sound as good as it does. Also the title is kind of a nudge at "Rain" if you haven't noticed yet (ahahah I'm so clever HEEHEEHOOHOO).
 ---
 Section: Disc 3
 ---
@@ -383,11 +375,10 @@ Duration: '0:31'
 URLs:
 - https://www.youtube.com/watch?v=E4ZlBHrYie8
 Commentary: |-
-<i>Baleish:</i> (composer, booklet commentary)
-Chill beats + weird pads with spooky progressions = something that sounds like LoHAC or Dave or something else I don't know don't judge me! (also I pretty much just copied [[track:heat|Heat]] from the [[album:medium|medium album]] for this because that sounds Dave-y)
+    <i>Baleish:</i> (composer, booklet commentary)
+    Chill beats + weird pads with spooky progressions = something that sounds like LoHAC or Dave or something else I don't know don't judge me! (also I pretty much just copied [[track:heat|Heat]] from the [[album:medium|medium album]] for this because that sounds Dave-y)
 ---
 Track: Outrageously Awesome Hashrap Battle
-directory: outrageously-awesome-hashrap-battle
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -401,11 +392,10 @@ URLs:
 Referenced Tracks:
 - track:beatdown-strider-style
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-This track was inspired by Bro and Dave's battles, the beginning starts out slow and tense (Dave ascending to the roof, that's also what the strings are referencing) and then shit hits the fan. The beat becomes phatter and the Beatdown lead speeds up. I think this is what a typical battle with Bro would be like.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    This track was inspired by Bro and Dave's battles, the beginning starts out slow and tense (Dave ascending to the roof, that's also what the strings are referencing) and then shit hits the fan. The beat becomes phatter and the Beatdown lead speeds up. I think this is what a typical battle with Bro would be like.
 ---
 Track: Land of Crypts and Helium
-Directory: land-of-crypts-and-helium
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -418,11 +408,10 @@ Duration: '1:27'
 URLs:
 - https://www.youtube.com/watch?v=P5htg-xI20M
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-I wanted to make an eerie song for the land of crypts and helium, i was struggling to find a fitting instrument until i accidentally knocked over my acoustic guitar (which i can't play, why do i even have that) and i really liked the sound it made. And after adding delay and reverb to a Touhou guitar it was perfect. Very fitting for that planet i'd say. The spooky pads also help give it more of a spooky cryptic vibe in my opinion.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    I wanted to make an eerie song for the land of crypts and helium, i was struggling to find a fitting instrument until i accidentally knocked over my acoustic guitar (which i can't play, why do i even have that) and i really liked the sound it made. And after adding delay and reverb to a Touhou guitar it was perfect. Very fitting for that planet i'd say. The spooky pads also help give it more of a spooky cryptic vibe in my opinion.
 ---
 Track: Windswept Shale
-Directory: windswept-shale
 Artists:
 - Baleish
 Cover Artists:
@@ -438,11 +427,10 @@ URLs:
 Referenced Tracks:
 - track:heat
 Commentary: |-
-<i>Baleish:</i> (composer, booklet commentary)
-This song was kinda having an identity crisis since this was gonna be a song for LoWAS as you can see by the title & intro bit, but then I did the breakdown and the [[track:heat|Heat]] motif and it didn't seem like it would fit very well so i was just like "heck it." and thought this should be song about the Forge. Nothing else to say besides damn that bass makes me wet.
+    <i>Baleish:</i> (composer, booklet commentary)
+    This song was kinda having an identity crisis since this was gonna be a song for LoWAS as you can see by the title & intro bit, but then I did the breakdown and the [[track:heat|Heat]] motif and it didn't seem like it would fit very well so i was just like "heck it." and thought this should be song about the Forge. Nothing else to say besides damn that bass makes me wet.
 ---
 Track: Slammed 8y the Sun!!!!!!!!
-Directory: slammed-8y-the-sun
 Additional Names:
 - Slammed by the Sun!!!!!!!! (English, normalized)
 Artists:
@@ -459,12 +447,13 @@ Referenced Tracks:
 - Sunslammer
 - track:vriskas-theme
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun VRISKA GUITAR SUN!!!!!!!! 
-(Vriska ascends to god tier bluh)
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun VRISKA GUITAR SUN!!!!!!!!
+    (Vriska ascends to god tier bluh)
 ---
 Track: Wander
-Directory: wander-thomas-ferkol
+Directory: wander-stlap
+Always Reference By Directory: true
 Artists:
 - Thomas Ferkol
 Cover Artists:
@@ -483,11 +472,10 @@ URLs:
 Referenced Tracks:
 - track:explore
 Commentary: |-
-<i>Thomas Ferkol:</i> (composer, booklet commentary)
-Wander was the result of there not being enough [[track:explore|Explore]] remixes. Back around the time I joined the music team, I was listening to Explore and thought the orchestration of the synths would translate well to strings. I'd also probably been listening to old Apocalyptica at the time, resulting in a cello ensemble with plodding gritty drum loops. While Explore soars above the remains of the world, Wander is grounded and more subdued. The interlude of ambient jungle noises was partially to reflect the world reverting back to nature, and the distant atmosphere and distorted portions are sort of the echoes and ruins left behind.
+    <i>Thomas Ferkol:</i> (composer, booklet commentary)
+    Wander was the result of there not being enough [[track:explore|Explore]] remixes. Back around the time I joined the music team, I was listening to Explore and thought the orchestration of the synths would translate well to strings. I'd also probably been listening to old Apocalyptica at the time, resulting in a cello ensemble with plodding gritty drum loops. While Explore soars above the remains of the world, Wander is grounded and more subdued. The interlude of ambient jungle noises was partially to reflect the world reverting back to nature, and the distant atmosphere and distorted portions are sort of the echoes and ruins left behind.
 ---
 Track: Take a Stand!
-Directory: take-a-stand
 Artists:
 - Sunbent
 Contributors:
@@ -502,21 +490,21 @@ Art Tags:
 - Jade
 - Lord English
 - Victory Platform
-- Light
-- Breath
-- Time
-- Space
-- Caledfwlch
-- Pop-a-matic Vrillyhoo Hammer
-- Quills of Echidna
+# - Light
+# - Breath
+# - Time
+# - Space
+# - Caledfwlch
+# - Pop-a-matic Vrillyhoo Hammer
+# - Quills of Echidna
 Duration: '6:58'
 URLs:
 - https://www.youtube.com/watch?v=bM-xp_8g62M
 Referenced Tracks:
 - track:killed-by-br8k-spider
 Commentary: |-
-<i>Sunbent:</i> (composer, booklet commentary)
-A pretty long one, and i guess it's kind of a non cannon afterwards to [[flash:8087|collide]] in my mind. I refrained from using leomotifs because I honestly don't think this song needs it. Now if you watched collide, it never actually showed them killing lord English right? Well this is in my mind the battle theme to what happened there. If you want you can watch the YouTube theories but simply put, after collide vriska summons more powerful beta (and possibly alpha) kids out of her sburb house thingy. So basically it beta kids, vriska and the ghost army vs lord English. And thats the song. I considered calling it "collide v3" but i felt it was too obvious.
+    <i>Sunbent:</i> (composer, booklet commentary)
+    A pretty long one, and i guess it's kind of a non cannon afterwards to [[flash:8087|collide]] in my mind. I refrained from using leomotifs because I honestly don't think this song needs it. Now if you watched collide, it never actually showed them killing lord English right? Well this is in my mind the battle theme to what happened there. If you want you can watch the YouTube theories but simply put, after collide vriska summons more powerful beta (and possibly alpha) kids out of her sburb house thingy. So basically it beta kids, vriska and the ghost army vs lord English. And thats the song. I considered calling it "collide v3" but i felt it was too obvious.
 ---
 Track: LOWAS M.D.
 Directory: lowas-m-d
@@ -535,8 +523,8 @@ Referenced Tracks:
 - track:doctor
 - track:megalovania-halloween
 Commentary: |-
-<i>Frost Carter:</i> (composer, booklet commentary)
-This song has a truly awful name, I know. Just ignore that massive blunder on my part, and listen to the song itself. Like with most of my songs, I made this ages back, and, upon refinding it, I simply touched it up and pushed it out of the nest, where it, no doubt, landed on the ground with a thud in spectactular fashion. Oh well.
+    <i>Frost Carter:</i> (composer, booklet commentary)
+    This song has a truly awful name, I know. Just ignore that massive blunder on my part, and listen to the song itself. Like with most of my songs, I made this ages back, and, upon refinding it, I simply touched it up and pushed it out of the nest, where it, no doubt, landed on the ground with a thud in spectactular fashion. Oh well.
 ---
 Section: Disc 4
 ---
@@ -554,12 +542,11 @@ URLs:
 Referenced Tracks:
 - track:verdancy-bassline
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-I wanted to use the awesome [[track:verdancy-bassline|Verdancy bassline]] as a funny jingle, so i learned how to play it and improvised some parts and added a sick drumloop for that [[track:potential-verdancy|potential verdancy]] feel... Not much else to say on that... Here, have a Crab Apple.
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    I wanted to use the awesome [[track:verdancy-bassline|Verdancy bassline]] as a funny jingle, so i learned how to play it and improvised some parts and added a sick drumloop for that [[track:potential-verdancy|potential verdancy]] feel... Not much else to say on that... Here, have a Crab Apple.
 ---
 Track: Fetch The Bullet!
-Directory: fetch-the-bullet
-Artists: 
+Artists:
 - Pascal van den Bos
 Cover Artists:
 - Camelote
@@ -576,8 +563,8 @@ Referenced Tracks:
 - track:beatdown-strider-style
 - track:MeGaLoVania
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-This is an interesting one, Fetch the Bullet! Is based entirely on the flash [[flash:980|[S] Jade: Retrieve Package]] (specifically the old version). The song is paying its respects to the removed track [[track:mutiny|Mutiny]] which needed some love, it was removed for a reason but it's still a great (and one of my favourites) track. I also used alot of spacey synths to signify Bec traveling to space and teleporting all over the place and shit. And then [[track:MeGaLoVania|MeGaLoVania]] and [[track:beatdown-strider-style|Beatdown]] are in there for some reason. I also put in the Ultimate Guitar kit again for the reference to Jade knowing how to play guitar (man do i love that soundfont).
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    This is an interesting one, Fetch the Bullet! Is based entirely on the flash [[flash:980|[S] Jade: Retrieve Package]] (specifically the old version). The song is paying its respects to the removed track [[track:mutiny|Mutiny]] which needed some love, it was removed for a reason but it's still a great (and one of my favourites) track. I also used alot of spacey synths to signify Bec traveling to space and teleporting all over the place and shit. And then [[track:MeGaLoVania|MeGaLoVania]] and [[track:beatdown-strider-style|Beatdown]] are in there for some reason. I also put in the Ultimate Guitar kit again for the reference to Jade knowing how to play guitar (man do i love that soundfont).
 ---
 Track: Urban Forest
 Artists:
@@ -597,11 +584,10 @@ URLs:
 Referenced Tracks:
 - track:sburban-jungle
 Commentary: |-
-<i>CALIKID:</i> (composer, booklet commentary)
-The clock is ticking and you and your friends are *doomed*. Or are you? Who's to say? But you gotta act quick! The notorious song heard in the 13th flash of Homestuck. (copyrighted by Andrew Hussie) remixed and remastered by yours truly. Completed with fantastical arpeggios and and drops so massive you'll trip on your feet. Don't hesitate now, click that play button. (You know you want to.)
+    <i>CALIKID:</i> (composer, booklet commentary)
+    The clock is ticking and you and your friends are *doomed*. Or are you? Who's to say? But you gotta act quick! The notorious song heard in the 13th flash of Homestuck. (copyrighted by Andrew Hussie) remixed and remastered by yours truly. Completed with fantastical arpeggios and and drops so massive you'll trip on your feet. Don't hesitate now, click that play button. (You know you want to.)
 ---
 Track: Death by the Time to Gardenlovania (Bassline)
-Directory: death-by-the-time-to-gardenlovania-bassline
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -618,8 +604,8 @@ Referenced Tracks:
 - track:megalovania-halloween
 - track:verdancy-bassline
 Commentary: |-
-<i>Pascal van den Bos:</i> (composer, booklet commentary)
-I was originally just going to play [[track:gardener|Gardener]] as a cover, but then I realised that's completely unoriginal and i remembered i can play some other random songs. So i just mixed those in and improvised some parts of Gardener and you get this! Fun fact: i had to play this like 30 times over because i kept fucking up (wow that wasn't fun at all).
+    <i>Pascal van den Bos:</i> (composer, booklet commentary)
+    I was originally just going to play [[track:gardener|Gardener]] as a cover, but then I realised that's completely unoriginal and i remembered i can play some other random songs. So i just mixed those in and improvised some parts of Gardener and you get this! Fun fact: i had to play this like 30 times over because i kept fucking up (wow that wasn't fun at all).
 ---
 Track: Starsetter
 Directory: starsetter-stlap
@@ -635,8 +621,8 @@ URLs:
 Referenced Tracks:
 - track:moonsetter
 Commentary: |-
-<i>CALIKID:</i> (composer, booklet commentary)
-Ahh yes. The rain. Your friends. Your friends and the rain. But under an umbrella of course. Kick back and relax as you listen to this chill jam inspired by Toby Fox's [[track:moonsetter|Moonsetter]]. It's truly a masterpiece. The melody is so sweet that people can't help but make remixes of it, which is exactly what this is. A remix of just that. With ambience and a sick beat, this song fills every need fitted to *survive* on a barren planet that you made with your chums in a video game that may or may not destroy the world.
+    <i>CALIKID:</i> (composer, booklet commentary)
+    Ahh yes. The rain. Your friends. Your friends and the rain. But under an umbrella of course. Kick back and relax as you listen to this chill jam inspired by Toby Fox's [[track:moonsetter|Moonsetter]]. It's truly a masterpiece. The melody is so sweet that people can't help but make remixes of it, which is exactly what this is. A remix of just that. With ambience and a sick beat, this song fills every need fitted to *survive* on a barren planet that you made with your chums in a video game that may or may not destroy the world.
 ---
 Track: Endless Dreamers
 Artists:
@@ -654,8 +640,8 @@ Referenced Tracks:
 - Derse Dreamers
 - track:endless-climb
 Commentary: |-
-<i>CALIKID:</i> (composer, booklet commentary)
-I was originally planning on doing [[track:endless-climb|Endless Climb]] but somehow in the middle it changed to [[track:derse-dreamers|Derse Dreamers]] too so I decided to go with it. It's full of action and heavy saws. I thought it would be cool to add a bit of a mellow sound to the beginning though so I went with that. I hope you like it!
+    <i>CALIKID:</i> (composer, booklet commentary)
+    I was originally planning on doing [[track:endless-climb|Endless Climb]] but somehow in the middle it changed to [[track:derse-dreamers|Derse Dreamers]] too so I decided to go with it. It's full of action and heavy saws. I thought it would be cool to add a bit of a mellow sound to the beginning though so I went with that. I hope you like it!
 ---
 Track: Cue the Curtains
 Artists:
@@ -680,15 +666,15 @@ Art Tags:
 - The Condesce
 - Lord English
 - The Felt
-- Unbreakable Katana
-- Dragon Cane
-- Caledfwlch
-- Pop-a-matic Vrillyhoo Hammer
-- Quills of Echidna
-- Chainsaw
-- Fork
-- Homes Smell Ya Later
-- Flintlocks of Zillyhau
+# - Unbreakable Katana
+# - Dragon Cane
+# - Caledfwlch
+# - Pop-a-matic Vrillyhoo Hammer
+# - Quills of Echidna
+# - Chainsaw
+# - Fork
+# - Homes Smell Ya Later
+# - Flintlocks of Zillyhau
 - LoTaK
 - Derse
 - LoFaF
@@ -711,5 +697,5 @@ Referenced Tracks:
 - Even in Death
 - track:cascade-beta
 Commentary: |-
-<i>apatheticPianist:</i> (composer, booklet commentary)
-Somewhat ironically, this song actually came before [[track:8r8k-the-8ottle|8r8k the 8ottle]] - when I joined the album, a song themed around EOA6 / Collide was the first thing that came to mind, and this is the result! As you've probably noticed, it's separated pretty evenly into four parts: first Vriska vs. Lord English, then Terezi and the Striders vs. Lord Jack and Spades Slick, then the HIC fight, and finally an ending meant to call back (forward?) to Act 7. Also, giant thanks to PotatoBoss for mastering it and 8r8k the 8ottle - they definitely wouldn't have had that extra Homestuck kick without his help, hehe. Aside from that, nothing much else to say about it - it's a giant pile of motifs that I really enjoyed composing!
+    <i>apatheticPianist:</i> (composer, booklet commentary)
+    Somewhat ironically, this song actually came before [[track:8r8k-the-8ottle|8r8k the 8ottle]] - when I joined the album, a song themed around EOA6 / Collide was the first thing that came to mind, and this is the result! As you've probably noticed, it's separated pretty evenly into four parts: first Vriska vs. Lord English, then Terezi and the Striders vs. Lord Jack and Spades Slick, then the HIC fight, and finally an ending meant to call back (forward?) to Act 7. Also, giant thanks to PotatoBoss for mastering it and 8r8k the 8ottle - they definitely wouldn't have had that extra Homestuck kick without his help, hehe. Aside from that, nothing much else to say about it - it's a giant pile of motifs that I really enjoyed composing!

--- a/album/stable-time-loops-and-paradoxes.yaml
+++ b/album/stable-time-loops-and-paradoxes.yaml
@@ -5,6 +5,8 @@ URLs:
 - https://www.youtube.com/playlist?list=PLtcgklmZsk9C-zU_MOKHdizqkW8uhlATJ
 Cover Artists:
 - Culdhira
+# started by Celeste (until Delirious Biznasty, but Tranquil Downpour had just been started), continued & finished by Lilith
+# it's fair to say that it's from us both
 Art Tags:
 - John
 - Rose
@@ -43,7 +45,6 @@ Commentary: |-
     This is an arrangement of Showtime that I've had lying around for a while - and it happened to be perfect for the opening disc jingle, so here we are! I actually managed to knock this recording out in my first three tries,  which is kinda crazy... and that's really all there is to say on the matter.
 ---
 Track: Egbert's Kitchen
-Directory: egberts-kitchen-stlap
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -80,6 +81,8 @@ Commentary: |-
     This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from PotatoBoss, the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
 ---
 Track: Solicide
+Directory: solicide-stlap
+Always Reference By Directory: true
 Artists:
 - Baleish
 Cover Artists:
@@ -140,6 +143,7 @@ Referenced Tracks:
 - track:upward-movement-dave-owns
 - Another Jungle
 - track:MeGaLoVania
+#unsure of where Megalovania (or MeGaLoVania is referenced, but everything else should be fine
 Commentary: |-
     <i>apatheticPianist:</i> (composer, booklet commentary)
     As you've probably gathered from listening to it, this song is themed around the first five acts of Homestuck! It has a similar structure to [[track:cue-the-curtains|Cue the Curtains]], but with five parts instead of four (which is oddly appropriate, in retrospect - five parts, five acts): John, Rose, Dave and Jade, Bec Noir and Vriska's machinations that led to him, and finally the kids' ascensions and the Scratch. The title uses Vriska's quirk for two reasons: because she had a pretty big hand in the creation of Bec Noir... and also becasue she's "stealing the spotlight" from the Beta Kids. Anyways, a huge thanks to PotatoBoss for mastering this song, and I hope y'all enjoy it!
@@ -252,6 +256,8 @@ Commentary: |-
     This song just kinda exists. I don't really remember initially making it. Maybe it magically appeared one day, ascended from Heaven to change the world and herald the 2nd coming of Christ himself. Or maybe I made it in the middle of the night on 0 sleep and forgot. Whichever you perfer. I won't make the choice for you. I'm not your mom.
 ---
 Track: Petrichor
+Directory: petrichor-stlap
+Always Reference By Directory: true
 Artists:
 - Baleish
 Cover Artists:

--- a/album/stable-time-loops-and-paradoxes.yaml
+++ b/album/stable-time-loops-and-paradoxes.yaml
@@ -23,6 +23,7 @@ Groups:
 - Fandom
 Commentary: |-
     <i>Pascal van den Bos:</i> (booklet commentary)
+
     Hi there!, i'm PotatoBoss, i pretty much started this album, even though i never would have thought it'd get this big. Anyway thank you for downloading this album, and be sure to check out all the amazing artists and musicians if you have time, they all worked very hard and it would be much appreciated. Thanks!
 Additional Files:
 - Title: Album Booklet
@@ -42,7 +43,8 @@ Referenced Tracks:
 - track:showtime-original-mix
 Commentary: |-
     <i>apatheticPianist:</i> (composer, booklet commentary)
-    This is an arrangement of Showtime that I've had lying around for a while - and it happened to be perfect for the opening disc jingle, so here we are! I actually managed to knock this recording out in my first three tries,  which is kinda crazy... and that's really all there is to say on the matter.
+
+    This is an arrangement of [[track:showtime-original-mix|Showtime]] that I've had lying around for a while - and it happened to be perfect for the opening disc jingle, so here we are! I actually managed to knock this recording out in my first three tries,  which is kinda crazy... and that's really all there is to say on the matter.
 ---
 Track: Egbert's Kitchen
 Artists:
@@ -59,6 +61,7 @@ Referenced Tracks:
 - track:under-the-hat
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     For this track i went for the style of music i think Dad listens to, a jazzier version of [[track:under-the-hat|Under the Hat]] fit this idea. Also the chiptune breakdown in the middle is supposed to reference [[track:showtime-original-mix|the original Strife! theme for dad]]. So later with a bit of saxophone it worked! I think it came out pretty well, and i think this is what you'd hear whenever you walk into the kitchen when Dad is baking.
 ---
 Track: Penumbra Phantasm (Frosty Style)
@@ -78,7 +81,8 @@ Referenced Tracks:
 - track:penumbra-phantasm
 Commentary: |-
     <i>Frost Carter:</i> (composer, booklet commentary)
-    This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from PotatoBoss, the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
+
+    This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from [[artist:pascal-van-den-bos|PotatoBoss]], the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
 ---
 Track: Solicide
 Directory: solicide-stlap
@@ -104,6 +108,7 @@ Sampled Tracks:
 - Derse Dreamers
 Commentary: |-
     <i>Baleish:</i> (composer, booklet commentary)
+
     Y'know that feeling you get when you've been told by gods to blow up a sun twice the size of a universe? well if you have, i think it'd feel something like Solicide. So I was just spittin' some phat-tunes-y'all, y'know, some chill Dave song, when I was like... "Nah, this is just too spooky for Dave, but maybe spooky enough for Rose?" so I changed the idea from a song about Dave & Time to a song about Rose's (and Dave's kinda) mission to heck up the green sun. (P.S. you can't go wrong with hella' samples + at least 73 different phasers.) (P.P.S if y'all wanna see what this lit jam was like when it was just a simple "chill dave song" then too bad because the Instaudio link is dead R.I.P) (P.P.P.S lol nice name that wasn't used nerd) (P.P.P.P.S oh wait that was me...)
 ---
 Track: 8r8k the 8ottle
@@ -111,6 +116,7 @@ Additional Names:
 - Break the Bottle (English, normalized)
 Artists:
 - apatheticPianist
+Contributors:
 - Pascal van den Bos (mastering)
 Cover Artists:
 - Camelote
@@ -146,7 +152,8 @@ Referenced Tracks:
 #unsure of where Megalovania (or MeGaLoVania is referenced, but everything else should be fine
 Commentary: |-
     <i>apatheticPianist:</i> (composer, booklet commentary)
-    As you've probably gathered from listening to it, this song is themed around the first five acts of Homestuck! It has a similar structure to [[track:cue-the-curtains|Cue the Curtains]], but with five parts instead of four (which is oddly appropriate, in retrospect - five parts, five acts): John, Rose, Dave and Jade, Bec Noir and Vriska's machinations that led to him, and finally the kids' ascensions and the Scratch. The title uses Vriska's quirk for two reasons: because she had a pretty big hand in the creation of Bec Noir... and also becasue she's "stealing the spotlight" from the Beta Kids. Anyways, a huge thanks to PotatoBoss for mastering this song, and I hope y'all enjoy it!
+
+    As you've probably gathered from listening to it, this song is themed around the first five acts of Homestuck! It has a similar structure to [[track:cue-the-curtains|Cue the Curtains]], but with five parts instead of four (which is oddly appropriate, in retrospect - five parts, five acts): John, Rose, Dave and Jade, Bec Noir and Vriska's machinations that led to him, and finally the kids' ascensions and the Scratch. The title uses Vriska's quirk for two reasons: because she had a pretty big hand in the creation of Bec Noir... and also becasue she's "stealing the spotlight" from the Beta Kids. Anyways, a huge thanks to [[artist:pascal-van-den-bos|PotatoBoss]] for mastering this song, and I hope y'all enjoy it!
 ---
 Track: Me/Ga/Lo/Vania
 Directory: me-ga-lo-vania
@@ -163,7 +170,8 @@ Referenced Tracks:
 - track:megalovania-halloween
 Commentary: |-
     <i>Frost Carter:</i> (composer, booklet commentary)
-    It's funny, you can't seem to go two steps on the internet without stumbling across a remix of [[track:megalovania-halloween|one certain song]] that shall not be named. Y'know, that [[track:megalovania-undertale|one song]] that's associated with that [[track:sans|one character]] from that one game? Yeah, you know what I'm talking about. Well, I decided to add to the pile with this remix of the OG version of that song, complete with a sound effect from that other game that probably helped inspire that first game that I mentioned. Gosh, this commentary would probably look so ridicuolous to anyone who hasn't ever been on the internet.
+
+    It's funny, you can't seem to go two steps on the internet without stumbling across a remix of [[track:megalovania-undertale|one certain song]] that shall not be named. Y'know, that [[track:megalovania-ssbu|one song]] that's associated with that [[track:sans|one character]] from that [[album:undertale-soundtrack|one game]]? Yeah, you know what I'm talking about. Well, I decided to add to the pile with this remix of [[track:megalovania-halloween|the OG version of that song]], complete with a sound effect from that other game that probably helped inspire that first game that I mentioned. Gosh, this commentary would probably look so ridicuolous to anyone who hasn't ever been on the internet.
 ---
 Track: Hospitalized
 Directory: hospitalized-stlap
@@ -184,6 +192,7 @@ Referenced Tracks:
 - track:doctor
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     I was trying to create kind of a battle theme for a john dave team battle, the name hospitalized is another joke on [[track:doctor|doctor]] because doctor is partially in it. but this is something i'd imagine plays when john and dave are battling together. Fun fact (again): the sick lead is the Romantic Trumpet from Touhou with way too much chorus.
 ---
 Track: Temporal Virtuoso
@@ -201,6 +210,7 @@ Referenced Tracks:
 - Time on My Side
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     I really like to make dave songs, this song was inspired by a bass player on youtube named <a href="https://www.youtube.com/user/Davie504">Davie504</a>. I wrote the first bass parts with some squares (the square in the middle even sounds like [[track:walk-stab-walk-rande|Walk Stab Walk]] even though i didn't intend it to) to give it some variation. Then some phat beats for dave coolness and [[track:time-on-my-side|Time on My Side]] combined with [[track:cascade-beta|Cascade]] to give it max awesomeness, i guess you could see it as a strife theme for alpha Dave fighting those clowns on top of the "purple house".
 ---
 Section: Disc 2
@@ -213,6 +223,7 @@ Cover Artists:
 - Hilaletto
 Art Tags:
 - Rose
+- Horrorterrors
 Duration: '0:07'
 URLs:
 - https://www.youtube.com/watch?v=ZKLSeqvv2NY
@@ -220,6 +231,7 @@ Referenced Tracks:
 - track:aggrieve
 Commentary: |-
     <i>Frost Carter:</i> (composer, booklet commentary)
+
     This is, as I'm sure you noticed, a quick one. It didn't really take all that much effort. Honestly, it'll likely take longer to read this than to actually listen to the song, so I won't take anymore of your time.
 ---
 Track: Velvet Pillow
@@ -239,6 +251,7 @@ Referenced Tracks:
 - track:sburban-jungle
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     With this track i kinda wanted to remake a Strife! theme for Mom. The bass in the beginning is building the tension of Rose trying to sneak out of the house, and when [[track:aggrieve|Aggrieve]] starts playing you know she got busted. I also added parts of [[track:sburban-jungle|Sburban Jungle]] to foreshadow her entering the medium soon, and the guitar just makes everything 10x cooler.
 ---
 Track: More Real than Kraft Mayo
@@ -253,6 +266,7 @@ URLs:
 - https://www.youtube.com/watch?v=k_-P6O_n1co
 Commentary: |-
     <i>Frost Carter:</i> (composer, booklet commentary)
+
     This song just kinda exists. I don't really remember initially making it. Maybe it magically appeared one day, ascended from Heaven to change the world and herald the 2nd coming of Christ himself. Or maybe I made it in the middle of the night on 0 sleep and forgot. Whichever you perfer. I won't make the choice for you. I'm not your mom.
 ---
 Track: Petrichor
@@ -269,6 +283,7 @@ URLs:
 - https://www.youtube.com/watch?v=TSnh-JprdQU
 Commentary: |-
     <i>Baleish:</i> (composer, booklet commentary)
+
     "Rooftop-shenanigans-with-Dirk" might as well be the title since that's what it is. I had an idea where I could make a song on FamiTracker and then master it on FL Studio, so I did! This idea turned out well, I just had to export each track on FamiTracker separately and then import them all to FL Studio and so I could just mix it as much as i wanted like some kind of evil scientist, but way less exciting...
 ---
 Track: Daydreamer
@@ -286,7 +301,8 @@ URLs:
 - https://www.youtube.com/watch?v=JuRLjkv6zUU
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
-    This is what happens when you're scrolling through your Touhou soundfont trying to come up with ideas for an original track and you find a funny thing, i also used a fretless bass to have some of Jade's wackiness. Since she's a [[track:prospit-dreamers|Prospit dreamer]], i based this track on Prospit and it's dreamers. That's why this track sounds so dreamy and dissonant. I was also heavily influenced by Final Fantasy themes while making this. Overall i think it came out pretty much like how i wanted it to.
+
+    This is what happens when you're scrolling through your Touhou soundfont trying to come up with ideas for an original track and you find a funny thing, i also used a fretless bass to have some of Jade's wackiness. Since she's a Prospit dreamer, i based this track on Prospit and it's dreamers. That's why this track sounds so dreamy and dissonant. I was also heavily influenced by Final Fantasy themes while making this. Overall i think it came out pretty much like how i wanted it to.
 ---
 Track: Delirious Biznasty
 Artists:
@@ -346,7 +362,8 @@ Sampled Tracks:
 - track:gamebro-original-1990-mix
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
-    This is an idea that came from an emoji we have in our discord server, which is the deliriousbiznasty emoji. I wanted to make a song with that name based on the GameBro, so then FrostyMac suggested that i use the vocals from Jit's GameBro song and it worked out pretty fucking hella rad as fuck.
+
+    This is an idea that came from an emoji we have in our discord server, which is the deliriousbiznasty emoji. I wanted to make a song with that name based on the GameBro, so then [[artist:frost-carter|FrostyMac]] suggested that i use the vocals from [[track:gamebro-original-1990-mix|Jit's GameBro song]] and it worked out pretty fucking hella rad as fuck.
 ---
 Track: Tranquil Downpour
 Artists:
@@ -364,7 +381,8 @@ Referenced Tracks:
 - Windswept Shale
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
-    I was messing around with a midi i made of Rob Scallon's "[[track:rain-rob-scallon|Rain]]", and i found out that if everything is a square, it sounds like a Cavestory song. So when i added "[[track:doctor|Doctor]]" into it, it got even better. The sweet drums and the high square from "[[track:windswept-shale|Windswept Shale]]" by Baleish finished it up and made the song sound as good as it does. Also the title is kind of a nudge at "Rain" if you haven't noticed yet (ahahah I'm so clever HEEHEEHOOHOO).
+
+    I was messing around with a midi i made of Rob Scallon's [[track:rain-rob-scallon|"Rain"]], and i found out that if everything is a square, it sounds like a Cavestory song. So when i added [[track:doctor|"Doctor"]] into it, it got even better. The sweet drums and the high square from [[track:windswept-shale|"Windswept Shale"]] by Baleish finished it up and made the song sound as good as it does. Also the title is kind of a nudge at "Rain" if you haven't noticed yet (ahahah I'm so clever HEEHEEHOOHOO).
 ---
 Section: Disc 3
 ---
@@ -382,6 +400,7 @@ URLs:
 - https://www.youtube.com/watch?v=E4ZlBHrYie8
 Commentary: |-
     <i>Baleish:</i> (composer, booklet commentary)
+
     Chill beats + weird pads with spooky progressions = something that sounds like LoHAC or Dave or something else I don't know don't judge me! (also I pretty much just copied [[track:heat|Heat]] from the [[album:medium|medium album]] for this because that sounds Dave-y)
 ---
 Track: Outrageously Awesome Hashrap Battle
@@ -399,6 +418,7 @@ Referenced Tracks:
 - track:beatdown-strider-style
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     This track was inspired by Bro and Dave's battles, the beginning starts out slow and tense (Dave ascending to the roof, that's also what the strings are referencing) and then shit hits the fan. The beat becomes phatter and the Beatdown lead speeds up. I think this is what a typical battle with Bro would be like.
 ---
 Track: Land of Crypts and Helium
@@ -415,6 +435,7 @@ URLs:
 - https://www.youtube.com/watch?v=P5htg-xI20M
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     I wanted to make an eerie song for the land of crypts and helium, i was struggling to find a fitting instrument until i accidentally knocked over my acoustic guitar (which i can't play, why do i even have that) and i really liked the sound it made. And after adding delay and reverb to a Touhou guitar it was perfect. Very fitting for that planet i'd say. The spooky pads also help give it more of a spooky cryptic vibe in my opinion.
 ---
 Track: Windswept Shale
@@ -434,6 +455,7 @@ Referenced Tracks:
 - track:heat
 Commentary: |-
     <i>Baleish:</i> (composer, booklet commentary)
+
     This song was kinda having an identity crisis since this was gonna be a song for LoWAS as you can see by the title & intro bit, but then I did the breakdown and the [[track:heat|Heat]] motif and it didn't seem like it would fit very well so i was just like "heck it." and thought this should be song about the Forge. Nothing else to say besides damn that bass makes me wet.
 ---
 Track: Slammed 8y the Sun!!!!!!!!
@@ -454,6 +476,7 @@ Referenced Tracks:
 - track:vriskas-theme
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun Vriska Guitar Sun VRISKA GUITAR SUN!!!!!!!!
     (Vriska ascends to god tier bluh)
 ---
@@ -479,6 +502,7 @@ Referenced Tracks:
 - track:explore
 Commentary: |-
     <i>Thomas Ferkol:</i> (composer, booklet commentary)
+
     Wander was the result of there not being enough [[track:explore|Explore]] remixes. Back around the time I joined the music team, I was listening to Explore and thought the orchestration of the synths would translate well to strings. I'd also probably been listening to old Apocalyptica at the time, resulting in a cello ensemble with plodding gritty drum loops. While Explore soars above the remains of the world, Wander is grounded and more subdued. The interlude of ambient jungle noises was partially to reflect the world reverting back to nature, and the distant atmosphere and distorted portions are sort of the echoes and ruins left behind.
 ---
 Track: Take a Stand!
@@ -510,6 +534,7 @@ Referenced Tracks:
 - track:killed-by-br8k-spider
 Commentary: |-
     <i>Sunbent:</i> (composer, booklet commentary)
+
     A pretty long one, and i guess it's kind of a non cannon afterwards to [[flash:8087|collide]] in my mind. I refrained from using leomotifs because I honestly don't think this song needs it. Now if you watched collide, it never actually showed them killing lord English right? Well this is in my mind the battle theme to what happened there. If you want you can watch the YouTube theories but simply put, after collide vriska summons more powerful beta (and possibly alpha) kids out of her sburb house thingy. So basically it beta kids, vriska and the ghost army vs lord English. And thats the song. I considered calling it "collide v3" but i felt it was too obvious.
 ---
 Track: LOWAS M.D.
@@ -530,6 +555,7 @@ Referenced Tracks:
 - track:megalovania-halloween
 Commentary: |-
     <i>Frost Carter:</i> (composer, booklet commentary)
+
     This song has a truly awful name, I know. Just ignore that massive blunder on my part, and listen to the song itself. Like with most of my songs, I made this ages back, and, upon refinding it, I simply touched it up and pushed it out of the nest, where it, no doubt, landed on the ground with a thud in spectactular fashion. Oh well.
 ---
 Section: Disc 4
@@ -549,6 +575,7 @@ Referenced Tracks:
 - track:verdancy-bassline
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     I wanted to use the awesome [[track:verdancy-bassline|Verdancy bassline]] as a funny jingle, so i learned how to play it and improvised some parts and added a sick drumloop for that [[track:potential-verdancy|potential verdancy]] feel... Not much else to say on that... Here, have a Crab Apple.
 ---
 Track: Fetch The Bullet!
@@ -570,6 +597,7 @@ Referenced Tracks:
 - track:MeGaLoVania
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     This is an interesting one, Fetch the Bullet! Is based entirely on the flash [[flash:980|[S] Jade: Retrieve Package]] (specifically the old version). The song is paying its respects to the removed track [[track:mutiny|Mutiny]] which needed some love, it was removed for a reason but it's still a great (and one of my favourites) track. I also used alot of spacey synths to signify Bec traveling to space and teleporting all over the place and shit. And then [[track:MeGaLoVania|MeGaLoVania]] and [[track:beatdown-strider-style|Beatdown]] are in there for some reason. I also put in the Ultimate Guitar kit again for the reference to Jade knowing how to play guitar (man do i love that soundfont).
 ---
 Track: Urban Forest
@@ -591,6 +619,7 @@ Referenced Tracks:
 - track:sburban-jungle
 Commentary: |-
     <i>CALIKID:</i> (composer, booklet commentary)
+
     The clock is ticking and you and your friends are *doomed*. Or are you? Who's to say? But you gotta act quick! The notorious song heard in the 13th flash of Homestuck. (copyrighted by Andrew Hussie) remixed and remastered by yours truly. Completed with fantastical arpeggios and and drops so massive you'll trip on your feet. Don't hesitate now, click that play button. (You know you want to.)
 ---
 Track: Death by the Time to Gardenlovania (Bassline)
@@ -611,6 +640,7 @@ Referenced Tracks:
 - track:verdancy-bassline
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
+
     I was originally just going to play [[track:gardener|Gardener]] as a cover, but then I realised that's completely unoriginal and i remembered i can play some other random songs. So i just mixed those in and improvised some parts of Gardener and you get this! Fun fact: i had to play this like 30 times over because i kept fucking up (wow that wasn't fun at all).
 ---
 Track: Starsetter
@@ -628,6 +658,7 @@ Referenced Tracks:
 - track:moonsetter
 Commentary: |-
     <i>CALIKID:</i> (composer, booklet commentary)
+
     Ahh yes. The rain. Your friends. Your friends and the rain. But under an umbrella of course. Kick back and relax as you listen to this chill jam inspired by Toby Fox's [[track:moonsetter|Moonsetter]]. It's truly a masterpiece. The melody is so sweet that people can't help but make remixes of it, which is exactly what this is. A remix of just that. With ambience and a sick beat, this song fills every need fitted to *survive* on a barren planet that you made with your chums in a video game that may or may not destroy the world.
 ---
 Track: Endless Dreamers
@@ -647,11 +678,13 @@ Referenced Tracks:
 - track:endless-climb
 Commentary: |-
     <i>CALIKID:</i> (composer, booklet commentary)
+
     I was originally planning on doing [[track:endless-climb|Endless Climb]] but somehow in the middle it changed to [[track:derse-dreamers|Derse Dreamers]] too so I decided to go with it. It's full of action and heavy saws. I thought it would be cool to add a bit of a mellow sound to the beginning though so I went with that. I hope you like it!
 ---
 Track: Cue the Curtains
 Artists:
 - apatheticPianist
+Contributors:
 - Pascal van den Bos (mastering)
 Cover Artists:
 - SoulofWoods
@@ -704,4 +737,5 @@ Referenced Tracks:
 - track:cascade-beta
 Commentary: |-
     <i>apatheticPianist:</i> (composer, booklet commentary)
-    Somewhat ironically, this song actually came before [[track:8r8k-the-8ottle|8r8k the 8ottle]] - when I joined the album, a song themed around EOA6 / Collide was the first thing that came to mind, and this is the result! As you've probably noticed, it's separated pretty evenly into four parts: first Vriska vs. Lord English, then Terezi and the Striders vs. Lord Jack and Spades Slick, then the HIC fight, and finally an ending meant to call back (forward?) to Act 7. Also, giant thanks to PotatoBoss for mastering it and 8r8k the 8ottle - they definitely wouldn't have had that extra Homestuck kick without his help, hehe. Aside from that, nothing much else to say about it - it's a giant pile of motifs that I really enjoyed composing!
+
+    Somewhat ironically, this song actually came before [[track:8r8k-the-8ottle|8r8k the 8ottle]] - when I joined the album, a song themed around EOA6 / Collide was the first thing that came to mind, and this is the result! As you've probably noticed, it's separated pretty evenly into four parts: first Vriska vs. Lord English, then Terezi and the Striders vs. Lord Jack and Spades Slick, then the HIC fight, and finally an ending meant to call back (forward?) to Act 7. Also, giant thanks to [[artist:pascal-van-den-bos|PotatoBoss]] for mastering it and 8r8k the 8ottle - they definitely wouldn't have had that extra Homestuck kick without his help, hehe. Aside from that, nothing much else to say about it - it's a giant pile of motifs that I really enjoyed composing!

--- a/artists.yaml
+++ b/artists.yaml
@@ -3656,6 +3656,13 @@ URLs:
 - https://www.facebook.com/GlassesBlu/
 - https://www.furaffinity.net/user/glassesblu/
 ---
+Artist: Glaze
+Context Notes: |-
+    Alias of [[artist:woodentoaster]].
+URLs:
+- https://twitter.com/GlazeArchives
+- https://open.spotify.com/artist/7J1NAfiNw9FD5T18Mx0LdR
+---
 Artist: glazelazer
 Dead URLs:
 - https://glazelazer.tumblr.com/
@@ -6252,6 +6259,10 @@ Artist: Metal Slug
 ---
 Artist: Metallica
 ---
+Artist: Metawulf
+Dead URLs:
+- https://metawulf.bandcamp.com
+---
 Artist: METIANULL
 Aliases:
 - ritsukage
@@ -8329,6 +8340,14 @@ Artist: Santana
 ---
 Artist: Santigold
 ---
+Artist: Sanxion7
+Aliases:
+- Saxxon Fox
+URLs:
+- https://sanxion7.bandcamp.com
+- https://www.youtube.com/saxxonpike
+- https://blog.purplepa.ws
+---
 Artist: Saori Kodama
 Aliases:
 - Saori Codama
@@ -10331,6 +10350,13 @@ Artist: WitchyMaya15
 Artist: Wolfgang Amadeus Mozart
 ---
 Artist: Wolfgang Boss
+---
+Artist: WoodenToaster
+URLs:
+- https://www.youtube.com/user/WoodenToaster
+- https://twitter.com/WoodenToaster
+- https://www.facebook.com/pages/WoodenToaster/280642235307371
+- https://open.spotify.com/artist/3J7yYhgRjwEL6S6eGpcMg9
 ---
 Artist: WorldEndWonder
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -1476,6 +1476,8 @@ URLs:
 Aliases:
 - Cametek
 ---
+Artist: Camelote
+---
 Artist: Camilla Hakelind
 ---
 Artist: Camille Saint-Saëns
@@ -2118,6 +2120,8 @@ URLs:
 - https://twitter.com/Crystalrina_
 Dead URLs:
 - https://crystalrina.tumblr.com/
+---
+Artist: Cue
 ---
 Artist: Cuil
 ---
@@ -4178,6 +4182,8 @@ Dead URLs:
 ---
 Artist: Imogen Heap
 ---
+Artist: Imperial Nyx
+---
 Artist: Indolentjellyfish
 URLs:
 - https://indolentjellyfish.tumblr.com/
@@ -6218,6 +6224,8 @@ URLs:
 - https://gamebanana.com/members/1777973
 - https://linktr.ee/melogomee
 ---
+Artist: Méline Hamard
+---
 Artist: Melomane
 URLs:
 - https://melomane.bandcamp.com/album/solresol
@@ -7168,6 +7176,15 @@ Aliases:
 - Muhammad Shahid Nazir
 - £1 Fish Man
 ---
+Artist: OrangeKrro
+Aliases:
+- Krro
+- Kiko
+- CaPrIcOrNbReAd
+URLs:
+- https://soundcloud.com/orangekrro
+- https://www.instagram.com/orange_krro/
+---
 Artist: The Originals
 ---
 Artist: Oscar Oberheim
@@ -7278,6 +7295,8 @@ URLs:
 - https://twitter.com/potatomoosik
 - http://potatoboss.net/
 ---
+Artist: Pastel Colors
+---
 Artist: Pat Enright
 ---
 Artist: PatManDX
@@ -7313,6 +7332,15 @@ URLs:
 - https://paultuttlestarr.bandcamp.com/
 ---
 Artist: Paul Williams
+---
+Artist: Paula Zotter
+Aliases:
+- Paula-Zotter
+URLs:
+- https://www.deviantart.com/paula-zotter
+- https://www.instagram.com/paulazotter1895/
+- https://paula-zotter.tumblr.com
+- https://twitter.com/paula_zotter
 ---
 Artist: Paulina Lepiz
 ---
@@ -8052,6 +8080,11 @@ Artist: Rob Little
 Artist: Rob Pereyda
 URLs:
 - https://twitter.com/rpereyda
+---
+Artist: Rob Scallon
+URLs:
+- https://www.youtube.com/@robscallon
+- https://twitter.com/RobScallon
 ---
 Artist: Rob Thomas
 ---
@@ -9170,6 +9203,8 @@ URLs:
 - https://sukkanen.tumblr.com/
 - https://twitter.com/sugarsukka
 - https://www.sukka.pink/
+---
+Artist: Sunbent
 ---
 Artist: sunil_b
 ---
@@ -10614,6 +10649,12 @@ URLs:
 ---
 Artist: zts
 ---
+Artist: Zoe Stanley
+URLs:
+- https://twitter.com/zoestanleyarts
+- http://zoestanleyarts.deviantart.com/
+- https://zoestanleyarts.tumblr.com
+---
 Artist: Zoey
 Aliases:
 - Vriska Did Nothing Wrong
@@ -10795,6 +10836,8 @@ Artist: Boris
 ---
 Artist: catastrophicGenesis
 ---
+Artist: catharticGhost
+---
 Artist: ceruleantrafficlights
 URLs:
 - https://ceruleantrafficlights.tumblr.com/
@@ -10886,6 +10929,8 @@ URLs:
 - https://ctset.tumblr.com/
 - https://twitter.com/ctset
 - http://www.ctset.com/ 
+---
+Artist: cup
 ---
 Artist: Dani Calzone
 Aliases:
@@ -10983,6 +11028,12 @@ URLs:
 - https://expirequiem.tumblr.com/
 - https://strifekind.carrd.co/
 - https://www.instagram.com/expirequiem/
+---
+Artist: frummpets
+Aliases:
+- nyanbuttcheeks
+URLs:
+- https://www.instagram.com/frummpets/
 ---
 Artist: Ka
 URLs:

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -3782,7 +3782,7 @@ Flash: 'Cool and Vast Error: [S] ackjack: kil merrit forr runing yuor cavv exdep
 Directory: ackjack-kil-merrit
 Date: December 9, 2019
 Featured Tracks:
-- Starsetter
+- track:starsetter-canmt
 URLs:
 - https://mspfa.com/?s=31973&p=135
 - https://www.youtube.com/watch?v=HQCRO8-_e8g

--- a/groups.yaml
+++ b/groups.yaml
@@ -108,6 +108,13 @@ URLs:
 Description: |-
     Sharing some of the first unofficial albums, the Homestuck Gaiden was a home for albums not accepted or marked for [[group:official]] release.
 ---
+Group: The Paradox Music Team
+Directory: paradox-music-team
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com
+Description: |-
+    (Stub group, needs description)
+---
 Group: Unofficial MSPA Fans
 URLs:
 - https://unofficialmspafans.bandcamp.com/

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -526,6 +526,7 @@ Content: |-
     - moved [[track:a-new-day]] from "Other works originating outside of Homestuck" to "Music from video games" (thanks, Morris!)
     - changed sheet music blueprint for [[track:narrative-command]] into proper sheet music file, instead of just linking from commentary
     - removed fan-made, unofficial artworks from [[album:pesterquest-soundtrack]] and unreleased Pesterquest tracks (for now)
+    - changed directory of [[track:starsetter-canmt]] from <code>starsetter</code> to <code>starsetter-canmt</code>
     - changed directory of [[track:on-repeat]] from <code>on-repeat-intermission</code> to <code>on-repeat</code>
     - changed directory of [[track:revelations-vast-error]] from <code>revelations-bonus</code> to <code>revelations-vast-error</code>
     - changed directory of [[track:gone-vast-error]] from <code>gone-bonus</code> to <code>gone-vast-error</code>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -32,8 +32,8 @@ Content: |-
     - added [[album:oceanfables-ethological]] by [[artist:witchs-cadence]]! (thanks, Niklink!)
     - added [[album:i-miss-you-earthbound-2012]]! (thanks, Jebb!)
     - added [[album:fatebreak-volume-1]]! (thanks, Jebb!)
-    - added [[album:alternate-hues-and-melodies]]! (thanks, Lilith!)
     - added [[album:from-beta-to-alpha]] by [[artist:christian-michael-poynter]]! (thanks, Lilith!)
+    - added [[album:induction]]! (thanks, Lilith!)
     - added [[album:ebichahan]] by [[group:jamie-paige]]! (thanks, penultimateApogee!)
     - added [[album:archive]] (original 2016 release) by [[group:michael-guy-bowman]]! (thanks, Morris!)
     - added [[album:super-smash-bros-ultimate]]! (thanks, Morris!)
@@ -49,6 +49,9 @@ Content: |-
         - added [[album:perils-of-probability]]!
         - added [[album:magnum-opus]]!
         - added [[album:fighting-further]] by [[artist:rainy]]!
+    - added two albums from [[group:paradox-music-team]]!
+        - added [[album:stable-time-loops-and-paradoxes]]! (thanks, Lilith, Celeste!)
+        - added [[album:alternate-hues-and-melodies]]! (thanks, Lilith!)
     - added albums from [[group:svert]], by [[artist:gryotharian]] and [[artist:scorpyus]]! (thanks, Jebb!)
         - added [[album:svert-ost-volume-one]]!
         - added [[album:experience]]!


### PR DESCRIPTION
Adds the following albums:

- [x] Induction by Svix
- [x] Stable Time Loops and Paradoxes by The Paradox Music Team! (courtesy of Celeste and me)

and other misc additions and changes (which seem kinda larger than before... huh):

- [x] adds Fin (from Induction) as a referenced track to Trepidation from Homestuck Vol. 9 in [hsmusic-data/homestuck-vol9.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/homestuck-vol9.yaml) 
- [x] replaces My Hibernation in [hsmusic-data/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml) with the original (and as such, is referenced by My Hibernation (Induction), since that one's a remake and its album would now be a part of the wiki) (changed the My Hibernation reference in Havoc to be the original too) in [hsmusic-data/homestuck-vol8.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/homestuck-vol8.yaml) 
- [x] adds Flying Battery Zone Act 2 to [hsmusic-data/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml) because of Fin (Induction)'s referenced tracks (previously, this said Flying Battery Zone Act 1, but upon re-listening, turns out it was Flying Battery Zone Act 2, my bad (but Flying Battery Zone Act 1 will stay available in [hsmusic-data/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml))
- [x] adds Rain (Rob Scallion) to [hsmusic-data/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml) because of Tranquil Downpour's referenced tracks
- [x] adds WoodenToaster, Glaze, Sanxion7, Metawulf, cup, melodic-co, Camelote, Méline Hamard, Pastel Colors, Paula Zotter, OrangeKrro, catharticGhost, Sunbent, Zoe Stanley, Imperial Nyx, Cue, Rob Scallion, and frummpets in [hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml)
- [x] adds Egbert's Kitchen (Cosmic Caretakers) directory name as `egberts-kitchen-cosmic-caretakers` since it originated from Stable Time Loops and Paradoxes [hsmusic-data/cosmic-caretakers.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/cosmic-caretakers.yaml); now includes an "Originally Released As" as well

- [x] removes Temporal Virtuoso, More Real than Kraft Mayo since their parent album is added as a result of this pull request from [hsmusic-data/more-homestuck-fandom.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/more-homestuck-fandom.yaml)

Merge alongside media PR: [hsmusic/hsmusic-media#35](https://github.com/hsmusic/hsmusic-media/pull/35)