### PR TITLE
Album addition: Synthetica!

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -320,6 +320,30 @@ URLs:
 Referenced Tracks:
 - WELCOME TO THE CITY
 ---
+Track: Crystalline
+Directory: crystalline-soluslunes
+Always Reference By Directory: true
+Artists:
+- SolusLunes
+Duration: '1:05'
+URLs:
+- https://www.newgrounds.com/audio/listen/77781
+Commentary: |-
+    <i>SolusLunes:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/77781))
+    Ambient, discovery -ish music loop. Imagine you're seeing the universe born...
+---
+Track: Crystalline Shards
+Artists:
+- SolusLunes
+Duration: '4:14'
+URLs:
+- https://www.newgrounds.com/audio/listen/79451
+Referenced Tracks:
+- track:crystalline-soluslunes
+Commentary: |-
+    <i>SolusLunes:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/79451))
+    Longer, more crystally. Tempo tricks, instrumentation at its best. Apocalyptic feeling too
+---
 Track: Emmy
 Artists:
 - Circlejourney
@@ -25344,6 +25368,15 @@ Lyrics: |-
     Let me take you to flavortown
     Let me take you to flavortown
     Oh let me take ya, oh let me take you to flavortown
+---
+Track: Happiness
+Directory: happiness-dj-splatta
+Always Reference By Directory: true
+Artists:
+- Dj Splatta
+Duration: '2:04'
+URLs:
+- https://www.youtube.com/watch?v=oW55rfa0XMU
 ---
 Track: Happy Happy Christmas
 # Also known as 'it is a mystery'

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -330,6 +330,7 @@ URLs:
 - https://www.newgrounds.com/audio/listen/77781
 Commentary: |-
     <i>SolusLunes:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/77781))
+    
     Ambient, discovery -ish music loop. Imagine you're seeing the universe born...
 ---
 Track: Crystalline Shards
@@ -342,6 +343,7 @@ Referenced Tracks:
 - track:crystalline-soluslunes
 Commentary: |-
     <i>SolusLunes:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/79451))
+    
     Longer, more crystally. Tempo tricks, instrumentation at its best. Apocalyptic feeling too
 ---
 Track: Emmy

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -330,7 +330,7 @@ URLs:
 - https://www.newgrounds.com/audio/listen/77781
 Commentary: |-
     <i>SolusLunes:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/77781))
-    
+
     Ambient, discovery -ish music loop. Imagine you're seeing the universe born...
 ---
 Track: Crystalline Shards
@@ -343,7 +343,7 @@ Referenced Tracks:
 - track:crystalline-soluslunes
 Commentary: |-
     <i>SolusLunes:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/79451))
-    
+
     Longer, more crystally. Tempo tricks, instrumentation at its best. Apocalyptic feeling too
 ---
 Track: Emmy

--- a/album/synthetica.yaml
+++ b/album/synthetica.yaml
@@ -8,7 +8,7 @@ Color: '#4f84f5'
 Groups:
 - Beyond
 Commentary: |-
-    <i>nal1200:</i> ([Newgrounds news post, excerpt](https://electronicep.newgrounds.com/news/post/262303))
+    <i>nal1200:</i> ([Newgrounds news post](https://electronicep.newgrounds.com/news/post/262303), excerpt)
 
     <b>Synthetica EP News!</b>
 
@@ -35,11 +35,9 @@ Commentary: |-
 
     I'd like to thank everyone that purchases the EP, and i'd like to put out a special thanks to everyone that's helped promote it.
 
-    Be sure to tune in to Radiogrounds as well for some great NG music, as well as much, much more. The DJs there are local users here on NG, and I must say it's by far the best radio station EVAR!
+    Be sure to tune in to [Radiogrounds](https://web.archive.org/web/20090424111800/http://radiogrounds.com/) as well for some great NG music, as well as much, much more. The DJs there are local users here on NG, and I must say it's by far the best radio station EVAR!
 
-    <i>nal1200:</i>
-
-    ([Synthetica demo track](https://www.newgrounds.com/audio/listen/212058))
+    <i>nal1200:</i> ([Newgrounds demo track description](https://www.newgrounds.com/audio/listen/212058), excerpt)
 
     A demo track for the Audio Portal's Electronic EP: Syntethica!
 
@@ -122,13 +120,13 @@ Commentary: |-
 
     This song comes off my recent "Exposure" release. You can buy it on Amazon/iTunes, or you could listen to it here for free :P
 
-    (dead MySpace link)
+    ([dead MySpace link](https://myspace.com/quarldnb))
 
     EDIT: It's 2021 now and I can't believe this linked to a myspace page. Have a recent ["remaster"](https://www.newgrounds.com/audio/listen/997824) download, free.
 
-    <i>Quarl:</i> (composer, [Newgrounds description, remaster, excerpt](https://www.newgrounds.com/audio/listen/997824))
+    <i>Quarl:</i> (composer, [Newgrounds remaster description](https://www.newgrounds.com/audio/listen/997824), excerpt)
 
-    Yet another remaster nobody asked for. Originally written circa 2008, I took this down at some point because I thought I was going to be rich and famous or some shit. Not a single label wanted this however. As a result this was reuploaded at some point but then I took it down again after somebody used it in a <b>really shitty hentai game</b> circa 2010. Truth be told, I'm far more mature now and would be honored if somebody used this in their shitty hentai game. No really, go for it. I'll even provide the <b><i>sex noises</i></b> if you <b>ask nicely.</b>
+    Yet another remaster nobody asked for. Originally written circa 2008, I took this down at some point because I thought I was going to be rich and famous or some shit. Not a single label wanted this however. As a result this was reuploaded at some point but then I took it down again after somebody used it in a <b>really shitty hentai game</b> circa 2010. Truth be told, I'm far more mature now and would be honored if somebody used this in their shitty hentai game. No really, go for it. I'll even provide the <b><i>sex noises</i></b> if you <b>ask nicely.</b> ([dead Shopify link](https://cdn.shopify.com/s/files/1/0265/3475/products/3295_largeview_06d4bdc2-ed06-4061-b87f-9ceca33ca248.jpeg?v=1475254019))
 
     The original 2008 rsn file was so much fun to look at. I'm surprised there was even a back up after crashing my PC so many times. I've lost plenty of other song files over the years. It was surprisingly clean to look at. Added some new sounds to this version but I didn't want to over do it. This track was good enough as it was when it was written. Mostly just boosting levels and adding some fidelity. Opted to keep that subby bass intro, sorry if you listen in on lofi speakers and can't pick up that bass.
 
@@ -148,10 +146,14 @@ Track: Happiness (BeatSource Remix)
 Artists:
 - BeatSource
 URLs:
-- https://www.youtube.com/watch?v=AXJ_ixUQEjM #this upload and another one are missing 40 seconds of the total duration, it's the best I could find
+- https://www.youtube.com/watch?v=AXJ_ixUQEjM
 Referenced Tracks:
 - track:happiness-dj-splatta
 Duration: '3:45'
+Commentary: |-
+    <i>Lilithtreasure:</i> (wiki editor)
+
+    this upload and another one are missing 40 seconds of the total duration, it's the best I could find
 ---
 Track: Adrenaline
 Artists:

--- a/album/synthetica.yaml
+++ b/album/synthetica.yaml
@@ -12,6 +12,8 @@ Commentary: |-
 
     <b>Synthetica EP News!</b>
 
+    You can purchase the album from the iTunes store by clicking ([dead iTunes link](http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewAlbum?i=302881548&id=302881543&s=143441)) <b>here!</b>
+
     Check out the Electronic EP project "Synthetica!"
 
     Because this is a collaborative effort of many Newgrounds Audio Artists, I strongly encourage you to check out everyone's material. A list of artists is as follows:
@@ -126,7 +128,7 @@ Commentary: |-
 
     <i>Quarl:</i> (composer, [Newgrounds remaster description](https://www.newgrounds.com/audio/listen/997824), excerpt)
 
-    Yet another remaster nobody asked for. Originally written circa 2008, I took this down at some point because I thought I was going to be rich and famous or some shit. Not a single label wanted this however. As a result this was reuploaded at some point but then I took it down again after somebody used it in a <b>really shitty hentai game</b> circa 2010. Truth be told, I'm far more mature now and would be honored if somebody used this in their shitty hentai game. No really, go for it. I'll even provide the <b><i>sex noises</i></b> if you <b>ask nicely.</b> ([dead Shopify link](https://cdn.shopify.com/s/files/1/0265/3475/products/3295_largeview_06d4bdc2-ed06-4061-b87f-9ceca33ca248.jpeg?v=1475254019))
+    Yet another remaster nobody asked for. Originally written circa 2008, I took this down at some point because I thought I was going to be rich and famous or some shit. Not a single label wanted this however. As a result this was reuploaded at some point but then I took it down again after somebody used it in a <b>really shitty hentai game</b> circa 2010. Truth be told, I'm far more mature now and would be honored if somebody used this in their shitty hentai game. No really, go for it. I'll even provide the <b><i>sex noises</i></b> if you <b>ask nicely.</b> ([dead Shopify image link](https://cdn.shopify.com/s/files/1/0265/3475/products/3295_largeview_06d4bdc2-ed06-4061-b87f-9ceca33ca248.jpeg?v=1475254019))
 
     The original 2008 rsn file was so much fun to look at. I'm surprised there was even a back up after crashing my PC so many times. I've lost plenty of other song files over the years. It was surprisingly clean to look at. Added some new sounds to this version but I didn't want to over do it. This track was good enough as it was when it was written. Mostly just boosting levels and adding some fidelity. Opted to keep that subby bass intro, sorry if you listen in on lofi speakers and can't pick up that bass.
 
@@ -153,7 +155,7 @@ Duration: '3:45'
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor)
 
-    this upload and another one are missing 40 seconds of the total duration, it's the best I could find
+    this upload and [another one](https://www.youtube.com/watch?v=FDDhQUGVvfA) are missing 40 seconds of the total duration, it's the best I could find.
 ---
 Track: Adrenaline
 Artists:

--- a/album/synthetica.yaml
+++ b/album/synthetica.yaml
@@ -1,0 +1,205 @@
+Album: Synthetica
+Directory: synthetica
+Date: January 6, 2009
+Cover Artists:
+- Unknown Artist
+Cover Art File Extension: jpg
+Color: '#4f84f5'
+Groups:
+- Beyond
+Commentary: |-
+    <i>nal1200:</i> ([Newgrounds news post, excerpt](https://electronicep.newgrounds.com/news/post/262303))
+
+    <b>Synthetica EP News!</b>
+
+    Check out the Electronic EP project "Synthetica!"
+
+    Because this is a collaborative effort of many Newgrounds Audio Artists, I strongly encourage you to check out everyone's material. A list of artists is as follows:
+
+    [[artist:mrmilkcarton]]<br>
+    [[artist:soluslunes|SolusLunes (Solus Lotus)]]<br>
+    [[artist:nal1200]] ft. [[artist:lira-yin|LiraLei (Lira Yin)]]<br>
+    [[artist:quarl|Quarl (Ruqal)]]<br>
+    [[artist:env|Envy (~EnV~)]]<br>
+    [[artist:smurfbeatz]]<br>
+    [[artist:beatsource|Ethalyn (BeatSource)]]<br>
+    [[artist:renoakrhythm]]<br>
+    [[artist:synthetic-music-apparatus|SMA (Synthetic Music Apparatus)]]<br>
+    [[artist:kr1z]]<br>
+    [[artist:hoxon|Helixmusic (Helix)]]<br>
+    [[artist:f-777|F-777 (Jesse Valentine)]]<br>
+    [[artist:arka-9|Danredda (DaNReD)]]<br>
+    [[artist:digitalpulse|Shadow6X6 (Astrix)]]<br>
+    [[artist:pervok|Zenon]]<br>
+    [[artist:redmoon|Bahdshah (Redmoon Deejay)]]
+
+    I'd like to thank everyone that purchases the EP, and i'd like to put out a special thanks to everyone that's helped promote it.
+
+    Be sure to tune in to Radiogrounds as well for some great NG music, as well as much, much more. The DJs there are local users here on NG, and I must say it's by far the best radio station EVAR!
+
+    <i>nal1200:</i>
+
+    ([Synthetica demo track](https://www.newgrounds.com/audio/listen/212058))
+
+    A demo track for the Audio Portal's Electronic EP: Syntethica!
+
+    We are proud to present to you a demo track featuring a clip of each song submitted to Newgrounds Audio Portal project titled "Synthetica."
+
+    This project, which includes songs from 16 renown artists, is available for the purchase on iTunes, AmazonMP3, and other digital music providers for only $9.99.
+
+    [[artist:mrmilkcarton|MrMilkcarton]]<br>
+    [[artist:soluslunes|Solus Lotus (SolusLunes)]]<br>
+    [[artist:nal1200]] ft. [[artist:lira-yin|Lira Yin (Liralei)]]<br>
+    [[artist:quarl|Ruqal (Quarl)]]<br>
+    [[artist:env|Envy]]<br>
+    [[artist:smurfbeatz]]<br>
+    [[artist:beatsource|Beatsource]]<br>
+    [[artist:renoakrhythm]]<br>
+    [[artist:synthetic-music-apparatus|Synthetic Music Apparatus (SMA)]]<br>
+    [[artist:kr1z]]<br>
+    [[artist:hoxon|Helix]]<br>
+    [[artist:f-777|Jesse Valentine (F-777)]]<br>
+    [[artist:arka-9|Danred (danredda)]]<br>
+    [[artist:digitalpulse|Astrix (Astrix33)]]<br>
+    [[artist:pervok|Zenon]]<br>
+    [[artist:redmoon|Redmoon Deejay (Bahdshah)]]<br>
+
+    We appreciate the support and all of those who continue to make our magical dreams come true! :3
+---
+Track: Miles Away
+Artists:
+- Mrmilkcarton
+Duration: '5:54'
+---
+Track: Crystalline
+Directory: crystalline-synthetica
+Additional Names:
+- Name: >-
+    Crystalline (Final)
+  Annotation: >-
+    [Newgrounds](https://www.newgrounds.com/audio/listen/288975)
+Artists:
+- SolusLunes
+URLs:
+- https://www.newgrounds.com/audio/listen/288975
+Referenced Tracks:
+- Crystalline Shards
+Duration: '4:19'
+Commentary: |-
+    <i>SolusLunes:</i> (composer, [Newgrounds description](https://www.newgrounds.com/audio/listen/288975))
+
+    This is the [[album:synthetica]] version of [[track:crystalline-soluslunes]], and since it's been what, a year or so since we've sold any more albums, you can has FOR FREE!
+
+    Yes.
+
+    What.
+
+    I love having rights to my music.
+
+    But if you liked this, go download teh album Synthetica- sold anywhere on the interwebs where music is sold.
+---
+Track: A Moonless Blue
+Artists:
+- nal1200
+Contributors:
+- Lira Yin (vocals)
+URLs:
+- https://www.youtube.com/watch?v=nfMEJ9_DSuk
+Duration: '4:14'
+Commentary: |-
+    <i>Lira Yin:</i> (vocals, [YouTube description](https://www.youtube.com/watch?v=nfMEJ9_DSuk), excerpt)
+
+    This chillout lounge track was my first released feature! Finished January 2009 & released on the [[album:synthetica|Synthetica EP]] by Newgrounds artists on iTunes in February.
+---
+Track: Paroxysm
+Artists:
+- Quarl
+URLs:
+- https://www.youtube.com/watch?v=u_5iWAHbjMA
+Duration: '4:25'
+Commentary: |-
+    <i>Quarl:</i> (composer, [YouTube description](https://www.youtube.com/watch?v=u_5iWAHbjMA), excerpt)
+
+    This song comes off my recent "Exposure" release. You can buy it on Amazon/iTunes, or you could listen to it here for free :P
+
+    (dead MySpace link)
+
+    EDIT: It's 2021 now and I can't believe this linked to a myspace page. Have a recent ["remaster"](https://www.newgrounds.com/audio/listen/997824) download, free.
+
+    <i>Quarl:</i> (composer, [Newgrounds description, remaster, excerpt](https://www.newgrounds.com/audio/listen/997824))
+
+    Yet another remaster nobody asked for. Originally written circa 2008, I took this down at some point because I thought I was going to be rich and famous or some shit. Not a single label wanted this however. As a result this was reuploaded at some point but then I took it down again after somebody used it in a <b>really shitty hentai game</b> circa 2010. Truth be told, I'm far more mature now and would be honored if somebody used this in their shitty hentai game. No really, go for it. I'll even provide the <b><i>sex noises</i></b> if you <b>ask nicely.</b>
+
+    The original 2008 rsn file was so much fun to look at. I'm surprised there was even a back up after crashing my PC so many times. I've lost plenty of other song files over the years. It was surprisingly clean to look at. Added some new sounds to this version but I didn't want to over do it. This track was good enough as it was when it was written. Mostly just boosting levels and adding some fidelity. Opted to keep that subby bass intro, sorry if you listen in on lofi speakers and can't pick up that bass.
+
+    Over the decades I've come to accept for obscurity as an artist but this track will always have a special place in my spleen. I hope that it may one day gain a special place in your spleen too.
+---
+Track: Andas
+Artists:
+- EnV
+Duration: '3:48'
+---
+Track: Keys of A Piano
+Artists:
+- Smurfbeatz
+Duration: '4:46'
+---
+Track: Happiness (BeatSource Remix)
+Artists:
+- BeatSource
+URLs:
+- https://www.youtube.com/watch?v=AXJ_ixUQEjM #this upload and another one are missing 40 seconds of the total duration, it's the best I could find
+Referenced Tracks:
+- track:happiness-dj-splatta
+Duration: '3:45'
+---
+Track: Adrenaline
+Artists:
+- RenoakRhythm
+Duration: '3:24'
+---
+Track: Say I Am You
+Artists:
+- Synthetic Music Apparatus
+Duration: '4:27'
+---
+Track: Morning Light (OM)
+Artists:
+- Kr1z
+Duration: '6:59'
+---
+Track: Destiny
+Directory: destiny-synthetica
+Always Reference By Directory: true
+Artists:
+- Hoxon
+Contributors:
+- Elaine Sharp
+Duration: '2:57'
+---
+Track: Saying Goodbye
+Artists:
+- F-777
+URLs:
+- https://www.youtube.com/watch?v=fxZQEfOCOmM
+Duration: '3:26'
+---
+Track: Audio Hallucination
+Artists:
+- Arka-9
+Duration: '5:24'
+---
+Track: Estrayed
+Artists:
+- DigitalPulse
+Duration: '3:01'
+---
+Track: Unending Tribulation
+Artists:
+- PERVOK
+Duration: '5:50'
+---
+Track: Iceferno
+Artists:
+- RedMoon
+Duration: '6:10'

--- a/artists.yaml
+++ b/artists.yaml
@@ -3299,6 +3299,15 @@ URLs:
 - https://twitter.com/metroidhat
 - http://www.metroidhat.com/
 ---
+Artist: F-777
+Aliases:
+- Jesse Valentine
+URLs:
+- http://f-777.newgrounds.com
+- https://jessevalentinemusic.bandcamp.com
+- http://www.youtube.com/jessevalentinemusic
+- https://open.spotify.com/artist/4c7ssQj66cEGMq6viiJdTZ
+---
 Artist: F-ZERO
 ---
 Artist: Fabricio Podestá
@@ -5376,7 +5385,7 @@ Artist: Klaus Doldinger
 Artist: Knife Party
 ---
 Artist: Knil
-URLs:
+Dead URLs:
 - https://twitter.com/Knil57122843
 ---
 Artist: koba
@@ -6770,6 +6779,12 @@ URLs:
 - https://twitter.com/MrCheeze_
 - https://mrcheeze.github.io/
 ---
+Artist: Mrmilkcarton
+URLs:
+- https://mrmilkcarton.newgrounds.com
+- https://soundcloud.com/mrmilkcarton
+- https://open.spotify.com/artist/13FmQUEWBmZGUdlVTcBlzl
+---
 Artist: MrWeebl
 Aliases:
 - Mr. Weebl
@@ -7803,6 +7818,14 @@ URLs:
 Artist: Pylon
 ---
 Artist: Quad City DJ's
+---
+Artist: Quarl
+Aliases:
+- Ruqal
+URLs:
+- https://quarl.newgrounds.com
+- https://quarl.bandcamp.com
+- https://www.youtube.com/@QuarlMusic
 ---
 Artist: Quasar Nebula
 URLs:
@@ -9167,6 +9190,7 @@ URLs:
 Artist: SolusLunes
 Aliases:
 - Jared Micks
+- Solus Lotus
 URLs:
 - https://soluslunes.newgrounds.com/
 Context Notes: |-

--- a/artists.yaml
+++ b/artists.yaml
@@ -629,7 +629,7 @@ URLs:
 ---
 Artist: Arka-9
 Aliases:
-- Danred
+- DaNReD
 - danredda
 - Daniel Redfearn
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -767,10 +767,12 @@ Artist: DigitalPulse
 Aliases:
 - Astrix33
 - Astrix
+- Shadow6X6
 URLs:
 - https://digitalpulse.newgrounds.com
 Dead URLs:
 - https://astrix33.newgrounds.com
+- https://shadow6x6.newgrounds.com #Shadow6X6 newgrounds page, nothing of interest
 ---
 Artist: Astroblur
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -4208,9 +4208,14 @@ URLs:
 Dead URLs:
 - https://twitter.com/helenaruthmusic
 ---
-Artist: Helix
+Artist: Hoxon
+Aliases:
+- Helix
+- HelixMusic
+URLs:
+- https://hoxon.newgrounds.com
 Dead URLs:
-- https://helix.newgrounds.com #newgrounds page, there's nothing here. not sure why.
+- https://helixmusic.newgrounds.com #newgrounds page, account no longer in use
 ---
 Artist: Hellen Jo
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -627,6 +627,20 @@ URLs:
 - https://sadgi.tumblr.com/
 - https://twitter.com/sadgisadgisadgi
 ---
+Artist: Arka-9
+Aliases:
+- Danred
+- danredda
+- Daniel Redfearn
+URLs:
+- https://danredda.newgrounds.com
+- https://www.youtube.com/@sadclownairraid
+- https://arka-9.bandcamp.com
+- https://soundcloud.com/arka-9
+- https://open.spotify.com/user/arka-9
+- https://www.facebook.com/ArkA9.Music
+- https://www.arka-9.com
+---
 Artist: ARM
 Aliases:
 - Ude-san
@@ -748,6 +762,15 @@ URLs:
 - https://twitter.com/astralplain_
 - https://www.youtube.com/@astralplainalt
 - https://gamebanana.com/members/2333015
+---
+Artist: DigitalPulse
+Aliases:
+- Astrix33
+- Astrix
+URLs:
+- https://digitalpulse.newgrounds.com
+Dead URLs:
+- https://astrix33.newgrounds.com
 ---
 Artist: Astroblur
 URLs:
@@ -1037,6 +1060,14 @@ Aliases:
 - ビートまりお
 ---
 Artist: Beats Antique
+---
+Artist: BeatSource
+Aliases:
+- Ethalyn
+URLs:
+- https://ethalyn.newgrounds.com
+Dead URLs:
+- https://beatsource.newgrounds.com #old newgrounds page, still up, moved to ethalyn
 ---
 Artist: Beast72
 ---
@@ -2775,6 +2806,11 @@ Artist: DJ Snake
 ---
 Artist: DJ Splash Drip
 ---
+Artist: Dj Splatta
+Aliases:
+- SplatterClock
+- DJ Splatter
+---
 Artist: DJMax
 ---
 Artist: DMX
@@ -3062,6 +3098,8 @@ Artist: Eikichi Kawasaki
 ---
 Artist: El Chombo
 ---
+Artist: Elaine Sharp
+---
 Artist: Elaine Wang
 Aliases:
 - orngjce223
@@ -3211,6 +3249,17 @@ URLs:
 - https://twitter.com/entropicbias`
 - https://john.drr.ac
 - https://www.instagram.com/egbutt/
+---
+Artist: EnV
+Aliases:
+- Envy
+- ~EnV~
+URLs:
+- https://envy.newgrounds.com
+- https://envmusic1.bandcamp.com/
+- https://soundcloud.com/envyofficial
+- https://twitter.com/envmusicks
+- https://www.facebook.com/envmusicofficial
 ---
 Artist: Enya
 Aliases:
@@ -4158,6 +4207,10 @@ URLs:
 - https://www.facebook.com/helenaruthmusic
 Dead URLs:
 - https://twitter.com/helenaruthmusic
+---
+Artist: Helix
+Dead URLs:
+- https://helix.newgrounds.com #newgrounds page, there's nothing here. not sure why.
 ---
 Artist: Hellen Jo
 ---
@@ -5471,6 +5524,12 @@ Artist: Kow Otani
 ---
 Artist: koykoy13
 ---
+Artist: Kr1z
+URLs:
+- https://kr1z.newgrounds.com/
+Dead URLs:
+- https://www.youtube.com/user/2kriz #YouTube, barely any activity, still accessible
+---
 Artist: Kris Flacke
 Aliases:
 - Astartus
@@ -5777,6 +5836,22 @@ Dead URLs:
 - https://vrissprites.tumblr.com/
 ---
 Artist: LiquidVoid
+---
+Artist: Lira Yin
+Aliases:
+- Liralei
+URLs:
+- https://www.youtube.com/lirayin
+- https://soundcloud.com/lirayin
+- http://lira.fyi/ #Tumblr
+- https://twitter.com/lirayin
+- https://open.spotify.com/artist/7v3FyP3Ac0y82otzZqWm9v
+- https://music.apple.com/us/artist/lira-yin/304395857
+- https://www.facebook.com/lirayin
+- https://bsky.app/profile/lirayin.bsky.social
+- https://linktr.ee/lirayin
+Dead URLs:
+- https://liralei.newgrounds.com #Newgrounds, not active, still accessible
 ---
 Artist: LISA
 ---
@@ -6850,6 +6925,14 @@ URLs:
 Dead URLs:
 - https://twitter.com/xLuDrawsx
 ---
+Artist: nal1200
+Aliases:
+- Ansible Adams
+URLs:
+- https://nal1200.newgrounds.com
+- https://open.spotify.com/artist/3kmpJzCRZh3I74zGz3tiZq
+- https://music.apple.com/us/artist/ansible-adams/1565362143
+---
 Artist: Naofumi Hataya
 URLs:
 - https://twitter.com/hatayatoday
@@ -7593,6 +7676,14 @@ Artist: Perry Sullivan
 ---
 Artist: Persona
 ---
+Artist: PERVOK
+Aliases:
+- Zenon
+URLs:
+- https://pervok.newgrounds.com/
+- http://pervokative.bandcamp.com/
+- https://soundcloud.com/pervokative
+---
 Artist: Peter Adams
 ---
 Artist: Peter Allen
@@ -8119,6 +8210,17 @@ Artist: Rebecca Shoichet
 ---
 Artist: Red Hot Chili Peppers
 ---
+Artist: RedMoon
+Aliases:
+- RedMoonDJ
+- RedMoon Deejay Bahdshah
+- Bahdshah
+- Redmoon Deejay #Synthetica EP alias
+URLs:
+- https://bahdshah.newgrounds.com
+- https://www.youtube.com/@RedMoonDJ/
+- https://open.spotify.com/artist/2zwLoBaOsn1egprJgHljml
+---
 Artist: Red Pen
 URLs:
 - https://reddpenn.tumblr.com/
@@ -8147,6 +8249,10 @@ Artist: Rennie Kingsley
 URLs:
 - https://twitter.com/wrenstarling
 - https://www.weavecomic.com/
+---
+Artist: RenoakRhythm
+URLs:
+- https://renoakrhythm.newgrounds.com
 ---
 Artist: Renka
 ---
@@ -9089,6 +9195,10 @@ Dead URLs:
 - https://deferretted.tumblr.com/
 - https://nocchiosvices.tumblr.com/
 ---
+Artist: Smurfbeatz
+Dead URLs:
+- https://smurfbeatz.newgrounds.com
+---
 Artist: SnapCube
 URLs:
 - https://www.youtube.com/@SnapCube
@@ -9581,6 +9691,12 @@ URLs:
 - https://sympolite.bandcamp.com/
 ---
 Artist: Synthesizer V ANRI
+---
+Artist: Synthetic Music Apparatus
+Aliases:
+- SMA
+URLs:
+- https://sma.newgrounds.com
 ---
 Artist: System of a Down
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -7924,6 +7924,8 @@ URLs:
 - https://quarl.newgrounds.com
 - https://quarl.bandcamp.com
 - https://www.youtube.com/@QuarlMusic
+Dead URLs:
+- https://myspace.com/quarldnb
 ---
 Artist: Quasar Nebula
 URLs:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -38,6 +38,7 @@ Content: |-
     - added [[album:ebichahan]] by [[group:jamie-paige]]! (thanks, penultimateApogee!)
     - added [[album:unbeatable-demo-tapes]]! (thanks, Morris!)
     - added [[album:archive]] (original 2016 release) by [[group:michael-guy-bowman]]! (thanks, Morris!)
+    - added [[album:synthetica]]! (thanks, Lilith!)
     - added [[album:super-smash-bros-ultimate]]! (thanks, Morris!)
     - added [[album:made-up-yume-nikkis]]!
     - added proper albums for tracks that were previously under [[album:unreleased-tracks]]:


### PR DESCRIPTION
**_aaaaaa YEEEEE YES YES YES YES YES_**

excitement aside, this adds 
- [x] the Synthetica album (albeit not all of the tracks have listening links, only a couple of them do) from January 6, 2009, headed by nal1200; musicians include former Homestuck Music Team Member, SolusLunes, and 14 other artists  as well as 2 contributors; neither of which have ever been on the wiki prior.
- [x] also adds SolusLunes' [Crystalline (the original)](https://www.newgrounds.com/audio/listen/77781) and [Crystalline Shards](https://www.newgrounds.com/audio/listen/79451) in [hsmusic-data/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml), as well as Dj Splatta's Happiness (referenced by BeatSource's remix of said track)
- [x] various (Synthetica) artists (as well as various aliases, and two contributors) added in [hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/artists.yaml) as a part of this addition, including:
- Kr1z
- F-777 (yes, really)
- Synthetic Music Apparatus
- Smurfbeatz
- DigitalPulse (Astrix)
- nal1200
- PERVOK (Zenon)
- RedMoon (Bahdshah, Redmoon Deejay)
- Arka-9 (DaNReD)
- Mrmilkcarton
- Quarl
- RenoakRhythm
- EnV
- Hoxon (Helix)
- BeatSource
- Elaine Sharp
- Lira Yin

Also added (while not a Synthetica artist, their track, Happiness, was referenced by BeatSource's remix of said track.):
- Dj Splatta (SplatterClock, Dj Splatter)

Also changes the URLs field underneath Knil's entry in [hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/artists.yaml) to Dead URLs, since the twitter link is dead

Merge alongside media PR: [hsmusic/hsmusic-media#38](https://github.com/hsmusic/hsmusic-media/pull/38)