### PR TITLE
Flash sides

### DIFF
--- a/flashes.yaml
+++ b/flashes.yaml
@@ -1,8 +1,10 @@
+Side: Side 1 (Acts 1-5)
+Directory: s1
+Color: '#4ac925'
+---
 Act: Act 1 - The Note Desolation Plays
 Directory: a1
 Color: '#7799ff'
-Jump: Side 1 (Acts 1-5)
-Jump Color: '#4ac925'
 ---
 Date: April 16, 2009
 Featured Tracks:
@@ -877,11 +879,13 @@ Featured Tracks:
 Flash: '[S] Begin intermission 2.'
 Page: '4111'
 ---
+Side: Side 2 (Acts 6-7)
+Directory: s2
+Color: '#3796c6'
+---
 Act: Act 6 Act 1 - Through Broken Glass
 Directory: a6a1
 Color: '#7799ff'
-Jump: Side 2 (Acts 6-7)
-Jump Color: '#3796c6'
 ---
 Date: November 11, 2011
 URLs:
@@ -1603,12 +1607,13 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '8130'
 ---
+Side: Additional Canon
+Color: '#f2a400'
+---
 Act: Hiveswap
 Directory: hiveswap
 Color: '#33cc77'
 List Terminology: Games in this series
-Jump: Additional Canon
-Jump Color: '#f2a400'
 ---
 Flash: Hiveswap Act 1
 Directory: hiveswap-act1
@@ -2237,12 +2242,13 @@ Featured Tracks:
 - Embittered Shore
 Flash: Just Go Ahead Now
 ---
+Side: Fan Adventures
+Color: '#c466ff'
+---
 Act: Cool and New Web Comic
 Directory: cool-and-new-web-comic
 Color: '#00cde0'
 List Terminology: Flashes in this story
-Jump: Fan Adventures
-Jump Color: '#c466ff'
 ---
 Flash: '{s]every one; enter'
 Directory: every-one-enter
@@ -3947,12 +3953,13 @@ URLs:
 - https://mspfa.com/?s=50076&p=212
 - https://www.youtube.com/watch?v=F41HZ9ZkzMM
 ---
+Side: Fan Games & More
+Color: '#32c7fe'
+---
 Act: Sunday Night Strifin'
 Directory: sunday-night-strifin
 Color: '#FFFF00'
 List Terminology: Mods in this section
-Jump: Fan Games & More
-Jump Color: '#32c7fe'
 ---
 Flash: 'Act 1: Beatdown, Strider Style'
 Directory: act-1-sunday-night-strifin

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -1,6 +1,7 @@
 Side: Side 1 (Acts 1-5)
 Directory: s1
 Color: '#4ac925'
+List Terminology: Flashes in this act
 ---
 Act: Act 1 - The Note Desolation Plays
 Directory: a1
@@ -882,6 +883,7 @@ Page: '4111'
 Side: Side 2 (Acts 6-7)
 Directory: s2
 Color: '#3796c6'
+List Terminology: Flashes in this act
 ---
 Act: Act 6 Act 1 - Through Broken Glass
 Directory: a6a1
@@ -2244,11 +2246,11 @@ Flash: Just Go Ahead Now
 ---
 Side: Fan Adventures
 Color: '#c466ff'
+List Terminology: Flashes in this story
 ---
 Act: Cool and New Web Comic
 Directory: cool-and-new-web-comic
 Color: '#00cde0'
-List Terminology: Flashes in this story
 ---
 Flash: '{s]every one; enter'
 Directory: every-one-enter
@@ -2476,7 +2478,6 @@ URLs:
 Act: Karkat Goes to a Convention
 Directory: karkat-goes-to-a-convention
 Color: '#7c7e81'
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Karkat: Greet friends!'
 Directory: karkat-greet-friends
@@ -2654,7 +2655,6 @@ URLs:
 Act: Loftlocked
 Directory: loftlocked
 Color: '#fdc500'
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Ella: Quick! Calm yourself with a haunting piano refrain!'
 Directory: ella-quick-calm-yourself
@@ -2805,7 +2805,6 @@ URLs:
 Act: Alternate Session
 Directory: alternate-session
 Color: '#029cfd'
-List Terminology: Flashes in this story
 ---
 # Multi-page flash
 Flash: '[S] Johnsprite: Speak to your denizen.'
@@ -2873,7 +2872,6 @@ URLs:
 Act: Double Death of the Author
 Directory: double-death-of-the-author
 Color: '#cec2b6'
-List Terminology: Flashes in this story
 ---
 Flash: '[S] >TEREZI: B3 TH3 4C3 4TTORN3Y'
 Directory: terezi-be-the-ace-attorney
@@ -2965,7 +2963,6 @@ URLs:
 Act: 'Jailbreak^2: Beyond Canon'
 Directory: jailbreak-2-beyond-canon
 Color: '#ffffff'
-List Terminology: Flashes in this story
 ---
 Flash: '[TITLE SCREEN]'
 Directory: title-screen-jailbreak-2
@@ -3170,7 +3167,6 @@ URLs:
 Act: The Fan Adventure Known as "Homestuck"
 Directory: the-fan-adventure-known-as-homestuck
 Color: '#4ac925'
-List Terminology: Flashes in this story
 ---
 Flash: '[S] ==>'
 Directory: next-not-homestuck
@@ -3327,7 +3323,6 @@ URLs:
 Act: Nightfall
 Color: '#146e98'
 Directory: nightfall
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Liz: STRIFE!'
 Directory: liz-strife
@@ -3356,7 +3351,6 @@ URLs:
 Act: Mr. Tambourine Man
 Color: '#4453fc'
 Directory: mr-tambourine-man
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Dave: Strife!'
 Directory: dave-strife-mr-tambourine-man
@@ -3391,7 +3385,6 @@ URLs:
 Act: Hexane Universe
 Color: '#dc0067'
 Directory: hexane
-List Terminology: Flashes in this story
 ---
 Flash: '[S] 0001, 0002, 0003, Amoria: Behold glory of Bloody Hell.'
 Directory: behold-glory-of-bloody-hell
@@ -3429,7 +3422,6 @@ URLs:
 Act: The Crow Strider AU
 Color: '#ff0000'
 Directory: the-crow-strider-au
-List Terminology: Flashes in this story
 ---
 Flash: '[S]Heir of grief: PLAY'
 Directory: heir-of-grief-play
@@ -3462,7 +3454,6 @@ URLs:
 Act: 'Sburb: Refresh'
 Color: '#b57a41'
 Directory: sburb-refresh
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Jeff: STRIFE!'
 Directory: jeff-strife
@@ -3575,7 +3566,6 @@ URLs:
 Act: Le me playing Sburb
 Color: '#ffffff'
 Directory: le-me-playing-sburb
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Step 3: Enter le game.'
 Directory: step-3-enter-le-game
@@ -3625,7 +3615,6 @@ URLs:
 Act: Act 8
 Color: '#fbae20'
 Directory: act-8
-List Terminology: Flashes in this story
 ---
 Flash: '[S]Start'
 Directory: start-act8
@@ -3660,7 +3649,6 @@ URLs:
 Act: HeavenSent
 Color: '#de0093'
 Directory: heaven-sent
-List Terminology: Flashes in this story
 ---
 Flash: '[S] Horrible Start'
 Directory: horrible-start


### PR DESCRIPTION
Corresponding data PR for hsmusic/hsmusic-wiki#453. Swaps out `Jump`-related fields with the new `Side` documents, adds "Flashes in this act" `List Terminology` to the first two sides (which were hard-coded to use this message previously), and makes stories in "Fan Adventures" inherit "Flashes in this story" `List Terminology`, rather than repeating and specifying that string on every act.