### PR TITLE
Showtime (Svix Mix) and Keytar Fox

### DIFF
--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -11,6 +11,10 @@ Cover Art File Extension: png
 Color: '#009a85'
 Groups:
 - Beyond
+Additional Files:
+- Title: Keytar Fox SWF
+  Description: >-
+    Flash file for [[flash:keytar-fox]], which includes a short snippet of what would eventually become [[track:trepidation]].
 Commentary: |-
     <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/album/induction))
 

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -2012,6 +2012,8 @@ Art Tags:
 - John
 - John's dad
 - Earth
+Referenced Tracks:
+- track:showtime-svix-mix
 Commentary: |-
     <i>Svix:</i> (composer, booklet commentary)
 

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -2017,25 +2017,13 @@ Referenced Tracks:
 Commentary: |-
     <i>Svix:</i> (composer, booklet commentary)
 
-    I created the first version of my Showtime remix back in September 2009 shortly after I started getting into Homestuck, it seemed to go down well and a few months later I was invited to be part of the official music team.
+    I created [[album:showtime-svix-mix|the first version]] of my Showtime remix back in September 2009 shortly after I started getting into Homestuck, it seemed to go down well and a few months later I was invited to be part of the official music team.
 
     Since then I feel that I have improved significantly and so I've given the old remix a quick reworking. Whilst I think that structurally the track is a little too similar to [[track:showtime-original-mix|the original]] and if I were to make another remix I would do things quite differently, this piece was the one which began to outline my chiptune style which I've since developed with my other Homestuck tracks. My main influences with chiptune are from the SID and Yamaha chips found in the C64 and Sega Mega Drive respectively, and as such many synth and percussive elements from each can be heard in my work.
 
     <i>fueledbyanimation:</i> (track artist, booklet commentary)
 
     To fit a remix of one of my favorite Homestuck themes, I wanted to make the Strife scene between Dad and John in my own style, while still holding somewhat true to the original. A remix of the art as well as the song.
-
-    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/2768815/))
-
-    "Your DAD wields a dreaded ARTIFACT OF CONFECTION. He stands between you and the mail.
-
-    There is only one way to settle this.
-
-    STRIFE!"
-
-    Remix of the battle theme from Homestuck, an amazingly quirky and hilarious story based on old text input adventure games. Original can be found [here](https://homestuck.bandcamp.com/track/showtime-original-mix-3).
-
-    <3 Chiptune.
 ---
 Track: Ugly Story
 Artists:

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -1999,6 +1999,7 @@ Commentary: |-
     Also, towards the end, please imagine Jake doing that thing where he jumps in the air shooting both pistols at once.
 ---
 Track: Showtime (Svix Mix)
+Directory: showtime-svix-mix-lofam2
 Artists:
 - Svix
 Duration: '2:51'

--- a/album/showtime-svix-mix-original.yaml
+++ b/album/showtime-svix-mix-original.yaml
@@ -1,0 +1,34 @@
+Album: Showtime (Svix Mix)
+Directory: showtime-svix-mix-original
+Date: September 9, 2009
+Artists:
+- Svix
+URLs:
+- https://www.youtube.com/watch?v=dodzDnjmY9Q
+Art Tags:
+- John's dad
+- Earth
+Cover Artists:
+- Svix
+Cover Art File Extension: png
+Color: '#909090'
+Groups:
+- Fandom
+Commentary: |-
+    <i>Svix:</i> ([Bandcamp about blurb](https://web.archive.org/web/20120425114028/http://svix.bandcamp.com/track/showtime-svix-mix))
+
+    "Your DAD wields a dreaded ARTIFACT OF CONFECTION. He stands between you and the mail.
+
+    There is only one way to settle this.
+
+    STRIFE!"
+    
+    <i>Svix:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120425114028/http://svix.bandcamp.com/track/showtime-svix-mix))
+    
+    Original by [[Malcolm Brown]]: [[https://homestuck.bandcamp.com/track/showtime-original-mix-3|homestuck.bandcamp.com/track/showtime-original-mix]]
+---
+Track: Showtime (Svix Mix)
+Directory: showtime-svix-mix-original
+Duration: '2:46'
+URLs:
+- https://www.youtube.com/watch?v=dodzDnjmY9Q

--- a/album/showtime-svix-mix.yaml
+++ b/album/showtime-svix-mix.yaml
@@ -30,3 +30,5 @@ Track: Showtime (Svix Mix)
 Duration: '2:46'
 URLs:
 - https://www.youtube.com/watch?v=dodzDnjmY9Q
+Referenced Tracks:
+- Showtime (Original Mix)

--- a/album/showtime-svix-mix.yaml
+++ b/album/showtime-svix-mix.yaml
@@ -32,3 +32,15 @@ URLs:
 - https://www.youtube.com/watch?v=dodzDnjmY9Q
 Referenced Tracks:
 - Showtime (Original Mix)
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/2768815/))
+
+    "Your DAD wields a dreaded ARTIFACT OF CONFECTION. He stands between you and the mail.
+
+    There is only one way to settle this.
+
+    STRIFE!"
+
+    Remix of the battle theme from Homestuck, an amazingly quirky and hilarious story based on old text input adventure games. Original can be found [here](https://homestuck.bandcamp.com/track/showtime-original-mix-3).
+
+    <3 Chiptune.

--- a/album/showtime-svix-mix.yaml
+++ b/album/showtime-svix-mix.yaml
@@ -21,9 +21,9 @@ Commentary: |-
     There is only one way to settle this.
 
     STRIFE!"
-    
+
     <i>Svix:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120425114028/http://svix.bandcamp.com/track/showtime-svix-mix))
-    
+
     Original by [[artist:malcolm-brown]]: [homestuck.bandcamp.com/track/showtime-original-mix](https://homestuck.bandcamp.com/track/showtime-original-mix-3)
 ---
 Track: Showtime (Svix Mix)

--- a/album/showtime-svix-mix.yaml
+++ b/album/showtime-svix-mix.yaml
@@ -1,5 +1,4 @@
 Album: Showtime (Svix Mix)
-Directory: showtime-svix-mix-original
 Date: September 9, 2009
 Artists:
 - Svix
@@ -25,10 +24,9 @@ Commentary: |-
     
     <i>Svix:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120425114028/http://svix.bandcamp.com/track/showtime-svix-mix))
     
-    Original by [[Malcolm Brown]]: [[https://homestuck.bandcamp.com/track/showtime-original-mix-3|homestuck.bandcamp.com/track/showtime-original-mix]]
+    Original by [[artist:malcolm-brown]]: [homestuck.bandcamp.com/track/showtime-original-mix](https://homestuck.bandcamp.com/track/showtime-original-mix-3)
 ---
 Track: Showtime (Svix Mix)
-Directory: showtime-svix-mix-original
 Duration: '2:46'
 URLs:
 - https://www.youtube.com/watch?v=dodzDnjmY9Q

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -4632,6 +4632,53 @@ Contributors:
 - Alice Flare (echidna voice)
 - garbageGothic (jade voice)
 ---
+Flash: Keytar Fox
+Directory: keytar-fox
+Date: January 23, 2012
+Featured Tracks:
+- Trepidation
+Contributors:
+- Svix (art, animation, music)
+URLs:
+- https://www.youtube.com/watch?v=IjvyG8GyWBI
+Commentary: |-
+    <i>Svix:</i> ([YouTube description](https://www.youtube.com/watch?v=IjvyG8GyWBI))
+
+    A little animation experiment to a short loop of music as a break between art commissions and album work.
+
+    Music produced in FL Studio<br>
+    Art drawn in Sai, Photoshop<br>
+    Animated in Flash<br>
+    Rendered in Vegas
+
+    B]
+
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    Also included as an SWF file with [[album:induction]], released a couple months later.
+
+    [[track:trepidation]] and the outro of [[track:fin-induction]] share a melody ([Fin, 4:10](https://youtu.be/8UFXoZfWagQ?t=250)), but the production order isn't entirely clear. This flash contains the very beginning of Trepidation, and is the earliest release of anything to do with this melody, published on Svix's YouTube in January 2012. Fin is the bonus track on Induction and was released with the album in March (and later on YouTube [in May](https://www.youtube.com/watch?v=8UFXoZfWagQ)). Finally, the full track Trepidation was included on [[album:homestuck-vol-9]], released in June 2012.
+
+    Although the twenty second snippet of Trepidation in this flash is the earliest release of all, a comment Svix wrote on Fin suggests a full-length track, presumably Trepidation, was arranged/extended from Fin's outro:
+
+    <i>Svix:</i> ([YouTube comments](https://www.youtube.com/watch?v=8UFXoZfWagQ&lc=Ugz6McVPlAYqktC2hUl4AaABAg) for [[track:fin-induction]])
+
+    > Nice mixture of different tracks. It looks and sounds like it should be playing along with a MegaMan game or some other old arcade game.
+    >
+    > And is that a bit of Timeless Miracle I hear in there?
+
+    Thanks, I'm not sure who Timeless Miracle are though so I guess that's coincidence!
+
+    > It's a nice one.  Here's the spot: @4:10 in "Fin" is the part I'm referring to.
+    >
+    > And it's similar to Timeless Miracle's ["Curse of the Werewolf"](https://www.youtube.com/watch?v=MnkWRz5cXgk).  The part in their song is repeated.
+
+    Ah right, I've actually turned that part into a whole track for my new EP :]
+
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    Since Fin is the bonus track from Induction already, it's possible the "new EP" could have been a planned project that wasn't properly released. Of course, Trepidation was included on Homestuck Vol. 9, so the full track still saw release.
+---
 Act: More games
 Directory: more-games
 Color: '#32c7fe'

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -291,7 +291,6 @@ Content: |-
         - added commentary from [[artist:dawn-davis]] (Tumblr) to [[track:skaian-starstorm]]
         - added commentary from [[artist:riki-tsuji]] (Tumblr) to [[track:jackbot]]
         - added commentary from [[artist:catboss]] (Tumblr) to [[track:guns-blazing]]
-        - added commentary from [[artist:svix]] (FurAffinity) to [[track:showtime-svix-mix-lofam2]]
         - added commentary from [[artist:piskomil]] (Tumblr) to [[track:warweary-villein]]
         - added commentary from [[artist:catboss]] (Tumblr) to [[track:theme-of-the-slam-jam]]
         - added commentary from [[artist:robert-j-lake]] (Tumblr) to [[track:john-do-the-windy-thing]] and [[track:lullaby-of-the-furthest-ring-feb-21]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -33,7 +33,6 @@ Content: |-
     - added [[album:i-miss-you-earthbound-2012]]! (thanks, Jebb!)
     - added [[album:fatebreak-volume-1]]! (thanks, Jebb!)
     - added [[album:from-beta-to-alpha]] by [[artist:christian-michael-poynter]]! (thanks, Lilith!)
-    - added [[album:induction]] by [[artist:svix]]! (thanks, Lilith!)
     - added [[album:glitch]] by [[artist:andrew-huo]]! (thanks, Niklink!)
     - added [[album:ebichahan]] by [[group:jamie-paige]]! (thanks, penultimateApogee!)
     - added [[album:unbeatable-demo-tapes]]! (thanks, Morris!)
@@ -132,6 +131,9 @@ Content: |-
         - added [[album:vertigo]]!
         - added [[album:spiritwake]]!
         - added [[album:vivid-spectrum]], featuring [[artist:marcy-nabors]]!
+    - added solo releases by [[artist:svix]]! (thanks, Lilith!)
+        - added [[album:showtime-svix-mix]]!
+        - added [[album:induction]]!
     - added solo albums by [[group:xszelor]]! (thanks, Jebb!)
         - added [[album:face-of-oglogoth-cover-lp]]!
         - added [[album:empress]]!

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -291,7 +291,7 @@ Content: |-
         - added commentary from [[artist:dawn-davis]] (Tumblr) to [[track:skaian-starstorm]]
         - added commentary from [[artist:riki-tsuji]] (Tumblr) to [[track:jackbot]]
         - added commentary from [[artist:catboss]] (Tumblr) to [[track:guns-blazing]]
-        - added commentary from [[artist:svix]] (FurAffinity) to [[track:showtime-svix-mix]]
+        - added commentary from [[artist:svix]] (FurAffinity) to [[track:showtime-svix-mix-lofam2]]
         - added commentary from [[artist:piskomil]] (Tumblr) to [[track:warweary-villein]]
         - added commentary from [[artist:catboss]] (Tumblr) to [[track:theme-of-the-slam-jam]]
         - added commentary from [[artist:robert-j-lake]] (Tumblr) to [[track:john-do-the-windy-thing]] and [[track:lullaby-of-the-furthest-ring-feb-21]]
@@ -680,6 +680,7 @@ Content: |-
     - removed SoundCloud close-matches, marked as original releases, for [[track:i-have-some-ideas]], [[track:blood-on-their-hands]], [[track:in-the-loop]], and [[track:love-song]] (now entered as additional names)
     - removed SoundCloud original releases for [[track:studio-space]], [[track:homestead]] and [[track:misbegotten]] (now entered as additional names)
     - removed "Last Battle (VS Rival)" and "The Good, the Bad and the Ugly" from [[album:references-beyond-homestuck]] which were not being used anywhere on the wiki
+    - changed directory of [[track:showtime-svix-mix-lofam2]] from <code>showtime-svix-mix</code> to <code>showtime-svix-mix-lofam2</code>
     - changed directory of [[track:starsetter-canmt]] from <code>starsetter</code> to <code>starsetter-canmt</code>
     - changed directory of [[track:on-repeat]] from <code>on-repeat-intermission</code> to <code>on-repeat</code>
     - changed directory of [[track:revelations-vast-error]] from <code>revelations-bonus</code> to <code>revelations-vast-error</code>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -401,6 +401,7 @@ Content: |-
     - fixed [[track:land-of-sand-and-rails]] referencing "When Johnny Comes Marching Home" (thanks, Celeste!)
     - fixed [[track:he-is-already-here]] not referencing [[track:clubbed-to-death-kurayamino-variation]]
     - fixed [[track:the-note-desolation-plays]] not referencing [[track:presentiment]]
+    - fixed [[track:showtime-svix-mix-lofam2]] ([[album:lofam2]]) referencing [[track:showtime-original-mix]] instead of [[track:showtime-svix-mix]] ([[album:showtime-svix-mix|single]])
     - fixed [[track:lullaby-of-the-furthest-ring]] not referencing [[track:lullaby-of-the-furthest-ring-feb-21]] (thanks, Lilith!)
     - fixed [[track:meteor-corridor]] not referencing [[track:crank-that]] (thanks, Grace!)
     - fixed [[track:harlecoaster-lame-and-old]] sampling [[track:harlecoaster]] instead of the other way around, and moved references [[track:harlequin]] and [[track:rollercoaster-tycoon-theme]] from [[track:harlecoaster]] to [[track:harlecoaster-lame-and-old]] (thanks, Rosetta Leijonde!)


### PR DESCRIPTION
Development:

- Resolves #446.
- Resolves #449.
- Merge alongside hsmusic/hsmusic-media#42.

Showtime (Svix Mix) is based on a file previously written and committed by Lilith — see [#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1205543231392055317) and #416.

Keytar Fox is semi-arbitrarily placed at the bottom of "Fan Animations". It's really not a Homestuck work, but there's not a better placement at the moment, and it makes a convenient spot to include wiki editor commentary (hsmusic/hsmusic-wiki#456) about the apparent release order of Trepidation (from Homestuck Vol. 9).