### PR TITLE
Variety of pre-release fixes and improvements

### DIFF
--- a/album/agents-of-reality.yaml
+++ b/album/agents-of-reality.yaml
@@ -9,7 +9,7 @@ Artists:
 Cover Artists:
 - Tycoon
 Cover Art File Extension: png
-Wallpaper Style: 'opacity: 0.7;'
+Wallpaper Style: 'opacity: 0.65;'
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Tycoon

--- a/album/assorted-mythological-textbooks-and-strange-beasts.yaml
+++ b/album/assorted-mythological-textbooks-and-strange-beasts.yaml
@@ -7,6 +7,14 @@ Artists:
 - Thyme
 Cover Artists:
 - Thyme
+Wallpaper Artists:
+- Thyme
+- Niklink (edits for wiki)
+Wallpaper Style: |-
+    opacity: 0.45;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+Wallpaper File Extension: png
 Cover Art File Extension: png
 Art Tags:
 - Rose

--- a/album/brostuck.yaml
+++ b/album/brostuck.yaml
@@ -12,8 +12,8 @@ Banner Artists:
 - doctoroftime
 Wallpaper Artists:
 - doctoroftime
-- Jebb (edits for wiki)
-Banner Dimensions: 1100x203
+- Niklink (edits for wiki)
+Banner Dimensions: 1100x180
 Banner File Extension: png
 Color: '#b0fb12'
 Art Tags:

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -1,5 +1,4 @@
 Album: Catch 322
-Directory: catch-322
 Date: August 13, 2019
 Date Added: October 25, 2023
 URLs:

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -3,7 +3,7 @@ Date: August 13, 2019
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/catch-322
-- https://music.deconreconstruction.com/albums/catch-322
+# - https://music.deconreconstruction.com/albums/catch-322
 Cover Artists:
 - ragnarozzy
 Cover Art File Extension: png
@@ -26,7 +26,7 @@ Sampled Tracks:
 - SFX from Rhythm Heaven
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it
-- https://music.deconreconstruction.com/albums/catch-322?track=minute-to-win-it
+# - https://music.deconreconstruction.com/albums/catch-322?track=minute-to-win-it
 ---
 Track: Arcjec's Theme
 Duration: '3:03'
@@ -36,7 +36,7 @@ Cover Artists:
 - Ojajy
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme
-- https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme
+# - https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme
 ---
 Track: Falling Upward
 Duration: '3:49'
@@ -46,7 +46,7 @@ Cover Artists:
 - Max O'Keefe
 URLs:
 - https://vasterror.bandcamp.com/track/falling-upward
-- https://music.deconreconstruction.com/albums/catch-322?track=falling-upward
+# - https://music.deconreconstruction.com/albums/catch-322?track=falling-upward
 ---
 Track: Todd Howard
 Duration: '5:32'
@@ -56,7 +56,7 @@ Cover Artists:
 - Unknown Artist
 URLs:
 - https://vasterror.bandcamp.com/track/todd-howard
-- https://music.deconreconstruction.com/albums/catch-322?track=todd-howard
+# - https://music.deconreconstruction.com/albums/catch-322?track=todd-howard
 ---
 Track: Taz's Theme
 Duration: '2:04'
@@ -66,7 +66,7 @@ Cover Artists:
 - ghostpotion
 URLs:
 - https://vasterror.bandcamp.com/track/tazs-theme
-- https://music.deconreconstruction.com/albums/catch-322?track=tazs-theme
+# - https://music.deconreconstruction.com/albums/catch-322?track=tazs-theme
 ---
 Track: The Eternal Siren
 Duration: '3:51'
@@ -76,7 +76,7 @@ Cover Artists:
 - Conjunx
 URLs:
 - https://vasterror.bandcamp.com/track/the-eternal-siren
-- https://music.deconreconstruction.com/albums/catch-322?track=the-eternal-siren
+# - https://music.deconreconstruction.com/albums/catch-322?track=the-eternal-siren
 ---
 Track: Dirty Days, Spotless Nights
 Duration: '2:36'
@@ -88,7 +88,7 @@ Art Tags:
 - 'cw: body horror'
 URLs:
 - https://vasterror.bandcamp.com/track/dirty-days-spotless-nights
-- https://music.deconreconstruction.com/albums/catch-322?track=dirty-days-spotless-nights
+# - https://music.deconreconstruction.com/albums/catch-322?track=dirty-days-spotless-nights
 ---
 Track: Show's Over
 Duration: '2:13'
@@ -98,7 +98,7 @@ Cover Artists:
 - Mikkynga
 URLs:
 - https://vasterror.bandcamp.com/track/shows-over
-- https://music.deconreconstruction.com/albums/catch-322?track=shows-over
+# - https://music.deconreconstruction.com/albums/catch-322?track=shows-over
 ---
 Track: Murrit's Theme
 Duration: '2:49'
@@ -128,7 +128,7 @@ Sampled Tracks:
 - Dialogue from The Truman Show
 URLs:
 - https://vasterror.bandcamp.com/track/murrits-theme
-- https://music.deconreconstruction.com/albums/catch-322?track=murrits-theme
+# - https://music.deconreconstruction.com/albums/catch-322?track=murrits-theme
 ---
 Track: Pursuit of Happiness
 Duration: '2:00'
@@ -139,7 +139,7 @@ Cover Artists:
 - Spruik
 URLs:
 - https://vasterror.bandcamp.com/track/pursuit-of-happiness
-- https://music.deconreconstruction.com/albums/catch-322?track=pursuit-of-happiness
+# - https://music.deconreconstruction.com/albums/catch-322?track=pursuit-of-happiness
 ---
 Track: Anywhere Can Be Paradise
 Duration: '3:18'
@@ -149,7 +149,7 @@ Cover Artists:
 - Daytura
 URLs:
 - https://vasterror.bandcamp.com/track/anywhere-can-be-paradise
-- https://music.deconreconstruction.com/albums/catch-322?track=anywhere-can-be-paradise
+# - https://music.deconreconstruction.com/albums/catch-322?track=anywhere-can-be-paradise
 ---
 Track: Loch And Quay
 Duration: '2:52'
@@ -159,7 +159,7 @@ Cover Artists:
 - spicyapplejam
 URLs:
 - https://vasterror.bandcamp.com/track/loch-and-quay
-- https://music.deconreconstruction.com/albums/catch-322?track=loch-and-quay
+# - https://music.deconreconstruction.com/albums/catch-322?track=loch-and-quay
 ---
 Track: Albion's Theme
 Duration: '4:16'
@@ -171,7 +171,7 @@ Referenced Tracks:
 - Magnificat
 URLs:
 - https://vasterror.bandcamp.com/track/albions-theme
-- https://music.deconreconstruction.com/albums/catch-322?track=albions-theme
+# - https://music.deconreconstruction.com/albums/catch-322?track=albions-theme
 ---
 Track: Lite-Brite
 Duration: '1:36'
@@ -181,7 +181,7 @@ Cover Artists:
 - floralmarsupial
 URLs:
 - https://vasterror.bandcamp.com/track/lite-brite
-- https://music.deconreconstruction.com/albums/catch-322?track=lite-brite
+# - https://music.deconreconstruction.com/albums/catch-322?track=lite-brite
 ---
 Track: Psychymify
 Duration: '4:54'
@@ -192,7 +192,7 @@ Cover Artists:
 - big chalupa
 URLs:
 - https://vasterror.bandcamp.com/track/psychymify
-- https://music.deconreconstruction.com/albums/catch-322?track=psychymify
+# - https://music.deconreconstruction.com/albums/catch-322?track=psychymify
 ---
 Track: Laivan's Theme
 Duration: '2:21'
@@ -202,7 +202,7 @@ Cover Artists:
 - Chumi
 URLs:
 - https://vasterror.bandcamp.com/track/laivans-theme
-- https://music.deconreconstruction.com/albums/catch-322?track=laivans-theme
+# - https://music.deconreconstruction.com/albums/catch-322?track=laivans-theme
 ---
 Track: Cathode Ray
 Duration: '4:55'
@@ -217,7 +217,7 @@ Sampled Tracks:
 - DOOR STUCK! DOOR STUCK!
 URLs:
 - https://vasterror.bandcamp.com/track/cathode-ray
-- https://music.deconreconstruction.com/albums/catch-322?track=cathode-ray
+# - https://music.deconreconstruction.com/albums/catch-322?track=cathode-ray
 ---
 Track: I'm Right Here
 Duration: '3:45'
@@ -227,7 +227,7 @@ Cover Artists:
 - Sparaze
 URLs:
 - https://vasterror.bandcamp.com/track/im-right-here
-- https://music.deconreconstruction.com/albums/catch-322?track=im-right-here
+# - https://music.deconreconstruction.com/albums/catch-322?track=im-right-here
 ---
 Track: Ellsee's Theme
 Duration: '2:20'
@@ -237,7 +237,7 @@ Cover Artists:
 - Crystalrina
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme
-- https://music.deconreconstruction.com/albums/catch-322?track=ellsees-theme
+# - https://music.deconreconstruction.com/albums/catch-322?track=ellsees-theme
 ---
 Track: Courage
 Duration: '4:42'
@@ -249,7 +249,7 @@ Cover Artists:
 - Deer
 URLs:
 - https://vasterror.bandcamp.com/track/courage
-- https://music.deconreconstruction.com/albums/catch-322?track=courage
+# - https://music.deconreconstruction.com/albums/catch-322?track=courage
 ---
 Track: Another Happy Ending
 Duration: '3:22'
@@ -263,7 +263,7 @@ Referenced Tracks:
 - THE ENIGMA OF THE BARTMAN.
 URLs:
 - https://vasterror.bandcamp.com/track/another-happy-ending
-- https://music.deconreconstruction.com/albums/catch-322?track=another-happy-ending
+# - https://music.deconreconstruction.com/albums/catch-322?track=another-happy-ending
 ---
 Section: Bonus tracks
 ---
@@ -284,7 +284,7 @@ Cover Artists:
 - Vast Error
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-the-black-depths
-- https://music.deconreconstruction.com/albums/catch-322?track=bonus-the-black-depths
+# - https://music.deconreconstruction.com/albums/catch-322?track=bonus-the-black-depths
 ---
 Section: Download-only tracks
 ---

--- a/album/celestial.yaml
+++ b/album/celestial.yaml
@@ -19,6 +19,7 @@ Wallpaper Artists:
 - YU NAGABA
 - Morris (edits for wiki)
 Wallpaper File Extension: png
+Wallpaper Style: 'opacity: 0.65;'
 Commentary: |-
     <i>Morris:</i> (wiki editor)
     This song is used as the credits to [[album:pokemon-scarlet-violet-super-music-collection|Pokémon Scarlet & Pokémon Violet]].

--- a/album/corporate-holiday-hits.yaml
+++ b/album/corporate-holiday-hits.yaml
@@ -3,7 +3,7 @@ Date: December 25, 2020
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/corporate-holiday-hits
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits
 Cover Artists:
 - Dani Calzone
 Cover Art File Extension: png
@@ -21,7 +21,7 @@ Artists:
 Duration: '02:10'
 URLs:
 - https://vasterror.bandcamp.com/track/eve
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=eve
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=eve
 ---
 Track: 'Joy To This Rotten, Desolate Carcass Of A World'
 Artists:
@@ -29,7 +29,7 @@ Artists:
 Duration: '03:55'
 URLs:
 - https://vasterror.bandcamp.com/track/joy-to-this-rotten-desolate-carcass-of-a-world
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=joy-to-this-rotten-desolate-carcass-of-a-world
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=joy-to-this-rotten-desolate-carcass-of-a-world
 ---
 Track: Holiday Shopping
 Artists:
@@ -37,7 +37,7 @@ Artists:
 Duration: '02:46'
 URLs:
 - https://vasterror.bandcamp.com/track/holiday-shopping
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=holiday-shopping
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=holiday-shopping
 ---
 Track: No Rest For The Wicked
 Artists:
@@ -45,7 +45,7 @@ Artists:
 Duration: '02:11'
 URLs:
 - https://vasterror.bandcamp.com/track/no-rest-for-the-wicked-2
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=holiday-shopping
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=holiday-shopping
 ---
 Track: Hearts In The Wrong Place
 Artists:
@@ -53,7 +53,7 @@ Artists:
 Duration: '02:02'
 URLs:
 - https://vasterror.bandcamp.com/track/hearts-in-the-wrong-place
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=hearts-in-the-wrong-place
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=hearts-in-the-wrong-place
 ---
 Track: Last Yulepassing
 Artists:
@@ -111,7 +111,7 @@ Lyrics: |-
     and we’ll be okay
 URLs:
 - https://vasterror.bandcamp.com/track/last-yulepassing-2
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=last-yulepassing
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=last-yulepassing
 ---
 Track: Seasonal Contentment
 Artists:
@@ -119,7 +119,7 @@ Artists:
 Duration: '02:03'
 URLs:
 - https://vasterror.bandcamp.com/track/seasonal-contentment-2
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=seasonal-contentment
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=seasonal-contentment
 ---
 Track: Corporate Merriment Jingle 32
 Artists:
@@ -130,7 +130,7 @@ Referenced Tracks:
 - Last Christmas
 URLs:
 - https://vasterror.bandcamp.com/track/corporate-merriment-jingle-32
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=corporate-merriment-jingle-32
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=corporate-merriment-jingle-32
 ---
 Track: 'RECALL: A Winter Long Past'
 Artists:
@@ -167,7 +167,7 @@ Lyrics: |-
     Remembering how the season shone when you were still here
 URLs:
 - https://vasterror.bandcamp.com/track/recall-a-winter-long-past-2
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=recall-a-winter-long-past
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=recall-a-winter-long-past
 ---
 Track: Dawn
 Directory: dawn-vast-error
@@ -177,4 +177,4 @@ Artists:
 Duration: '04:11'
 URLs:
 - https://vasterror.bandcamp.com/track/dawn
-- https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=dawn
+# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=dawn

--- a/album/corporate-holiday-hits.yaml
+++ b/album/corporate-holiday-hits.yaml
@@ -1,5 +1,4 @@
 Album: Corporate Holiday Hits
-Directory: corporate-holiday-hits
 Date: December 25, 2020
 Date Added: October 25, 2023
 URLs:

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -1,5 +1,4 @@
 Album: 'Dead Shufflers: Anything Goes'
-Directory: dead-shufflers-anything-goes
 Date: May 23, 2020
 Date Added: October 25, 2023
 URLs:

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -3,7 +3,7 @@ Date: May 23, 2020
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/dead-shufflers-anything-goes
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes
 Cover Artists:
 - eddieDraws
 Cover Art File Extension: png
@@ -25,7 +25,7 @@ Cover Artists:
 Duration: '03:16'
 URLs:
 - https://vasterror.bandcamp.com/track/overlook
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=overlook
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=overlook
 ---
 Track: Hound Dog
 Directory: hound-dog-vast-error
@@ -70,7 +70,7 @@ Lyrics: |-
 Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/hound-dog
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=hound-dog
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=hound-dog
 ---
 Track: Lucky Sevens
 Artists:
@@ -84,7 +84,7 @@ Referenced Tracks:
 - Luck Be a Lady
 URLs:
 - https://vasterror.bandcamp.com/track/lucky-sevens
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lucky-sevens
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lucky-sevens
 ---
 Track: Call It A Reraise
 Artists:
@@ -94,7 +94,7 @@ Cover Artists:
 Duration: '01:48'
 URLs:
 - https://vasterror.bandcamp.com/track/call-it-a-reraise
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=call-it-a-reraise
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=call-it-a-reraise
 ---
 Track: Skullheart Duskwalk
 Artists:
@@ -104,7 +104,7 @@ Cover Artists:
 Duration: '02:512'
 URLs:
 - https://vasterror.bandcamp.com/track/skullheart-duskwalk
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=skullheart-duskwalk
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=skullheart-duskwalk
 ---
 Track: Path Of The Righteous Man
 Artists:
@@ -148,7 +148,7 @@ Lyrics: |-
 Duration: '03:22'
 URLs:
 - https://vasterror.bandcamp.com/track/path-of-the-righteous-man
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=path-of-the-righteous-man
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=path-of-the-righteous-man
 ---
 Track: Fraudulent Quartet
 Artists:
@@ -158,7 +158,7 @@ Cover Artists:
 Duration: '02:08'
 URLs:
 - https://vasterror.bandcamp.com/track/fraudulent-quartet
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=fraudulent-quartet
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=fraudulent-quartet
 ---
 Track: 'INTERMISSION: Mimesiswing'
 Directory: mimesiswing
@@ -169,7 +169,7 @@ Referenced Tracks:
 - SWING, SWING, SWING
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-mimesiswing
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=intermission-mimesiswing
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=intermission-mimesiswing
 ---
 Track: Dismantled
 Directory: dismantled-vast-error
@@ -186,7 +186,7 @@ Referenced Tracks:
 Duration: '03:22'
 URLs:
 - https://vasterror.bandcamp.com/track/dismantled
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=dismantled
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=dismantled
 ---
 Track: Lovecraft
 Directory: lovecraft-vast-error
@@ -200,7 +200,7 @@ Art Tags:
 Duration: '01:32'
 URLs:
 - https://vasterror.bandcamp.com/track/lovecraft
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lovecraft
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lovecraft
 ---
 Track: Money For Nothing
 Artists:
@@ -242,7 +242,7 @@ Lyrics: |-
     Oh-woah-oh, warm, soft cash
 URLs:
 - https://vasterror.bandcamp.com/track/money-for-nothing
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=money-for-nothing
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=money-for-nothing
 ---
 Track: Disciplinary Action
 Artists:
@@ -252,7 +252,7 @@ Cover Artists:
 Duration: '02:00'
 URLs:
 - https://vasterror.bandcamp.com/track/disciplinary-action
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=disciplinary-action
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=disciplinary-action
 ---
 Track: Guess My Name
 Artists:
@@ -262,7 +262,7 @@ Cover Artists:
 Duration: '03:16'
 URLs:
 - https://vasterror.bandcamp.com/track/guess-my-name
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=guess-my-name
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=guess-my-name
 ---
 Track: Made For Spades
 Artists:
@@ -317,7 +317,7 @@ Lyrics: |-
 Duration: '04:18'
 URLs:
 - https://vasterror.bandcamp.com/track/made-for-spades
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=made-for-spades
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=made-for-spades
 ---
 Track: Pale Imitation
 Artists:
@@ -327,7 +327,7 @@ Cover Artists:
 Duration: '05:10'
 URLs:
 - https://vasterror.bandcamp.com/track/pale-imitation
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=pale-imitation
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=pale-imitation
 ---
 Section: Bonus tracks
 ---
@@ -353,4 +353,4 @@ Referenced Tracks:
 Duration: '00:43'
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-dear-pesky-shufflers
-- https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=bonus-dear-pesky-shufflers
+# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=bonus-dear-pesky-shufflers

--- a/album/desynced-vol-1.yaml
+++ b/album/desynced-vol-1.yaml
@@ -12,6 +12,10 @@ Wallpaper Artists:
 - artist:dizzims
 - Jebb (edits for wiki)
 Wallpaper File Extension: png
+Wallpaper Style: |-
+    opacity: 0.6;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Art Tags:
 - Kate (Desynced)
 Color: '#ce3381'

--- a/album/desynced-vol-1.yaml
+++ b/album/desynced-vol-1.yaml
@@ -7,6 +7,7 @@ URLs:
 Cover Artists:
 - artist:dizzims
 Cover Art File Extension: png
+Track Art File Extension: png
 Wallpaper Artists:
 - artist:dizzims
 - Jebb (edits for wiki)
@@ -42,6 +43,7 @@ Duration: '1:10'
 URLs:
 - https://desynced.bandcamp.com/track/cutest-companion
 - https://www.youtube.com/watch?v=nbmazT8201M
+Cover Art File Extension: jpg
 Cover Artists:
 - Phos
 Art Tags:
@@ -76,6 +78,7 @@ Duration: '2:32'
 URLs:
 - https://desynced.bandcamp.com/track/temporal-guardian
 - https://www.youtube.com/watch?v=clrX3zdsX94
+Cover Art File Extension: jpg
 Cover Artists:
 - Jules
 Art Tags:
@@ -491,6 +494,7 @@ Duration: '4:10'
 URLs:
 - https://desynced.bandcamp.com/track/lunar-dance
 - https://www.youtube.com/watch?v=SJIvrlQuDHA
+Cover Art File Extension: jpg
 Cover Artists:
 - Phos
 Art Tags:

--- a/album/desynced-vol-2.yaml
+++ b/album/desynced-vol-2.yaml
@@ -12,6 +12,7 @@ Wallpaper Artists:
 - artist:dizzims
 - Jebb (edits for wiki)
 Wallpaper File Extension: png
+Wallpaper Style: 'opacity: 0.55;'
 Art Tags:
 - Earth
 - Moon (Desynced)

--- a/album/desynced-vol-2.yaml
+++ b/album/desynced-vol-2.yaml
@@ -7,6 +7,7 @@ URLs:
 Cover Artists:
 - artist:dizzims
 Cover Art File Extension: png
+Track Art File Extension: png
 Wallpaper Artists:
 - artist:dizzims
 - Jebb (edits for wiki)
@@ -340,6 +341,7 @@ Duration: '2:06'
 URLs:
 - https://desynced.bandcamp.com/track/temporal-guardian-electro-swing-remix
 - https://www.youtube.com/watch?v=eZ1Cp6QE_vg
+Cover Art File Extension: jpg
 Cover Artists:
 - Jules
 Art Tags:
@@ -540,6 +542,7 @@ Duration: '3:38'
 URLs:
 - https://desynced.bandcamp.com/track/pugnae-pythonissam
 - https://www.youtube.com/watch?v=wZONu3nHFoQ
+Cover Art File Extension: jpg
 Cover Artists:
 - serpaz
 Art Tags:

--- a/album/dwellers-empty-path-ost.yaml
+++ b/album/dwellers-empty-path-ost.yaml
@@ -21,6 +21,9 @@ Cover Art File Extension: png
 Wallpaper File Extension: png
 Banner File Extension: png
 Wallpaper Style: 'opacity: 0.65;'
+Banner Style: |-
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Color: '#86C06C'
 Groups:
 - Toby Fox

--- a/album/dwellers-empty-path-ost.yaml
+++ b/album/dwellers-empty-path-ost.yaml
@@ -16,14 +16,19 @@ Wallpaper Artists:
 - Jebb (edits for wiki)
 Banner Artists:
 - Temmie Chang
-Banner Dimensions: 975x180
+Banner Dimensions: 1100x180
 Cover Art File Extension: png
 Wallpaper File Extension: png
 Banner File Extension: png
+Wallpaper Style: 'opacity: 0.65;'
 Color: '#86C06C'
 Groups:
 - Toby Fox
 - Beyond
+Additional Files:
+- Title: Bandcamp Banner
+  Files:
+  - banner.png
 Commentary: |-
      <i>Dweller's Empty Path:</i> ([Bandcamp about blurb](https://dwellersemptypath.bandcamp.com/album/dwellers-empty-path-ost))
 

--- a/album/election-season.yaml
+++ b/album/election-season.yaml
@@ -12,6 +12,7 @@ Wallpaper Artists:
 - artist:dizzims
 - Niklink (edits for wiki)
 Wallpaper File Extension: png
+Wallpaper Style: 'opacity: 0.45;'
 Art Tags:
 - Jack Noir (Desynced)
 - Chester Newman (Desynced)

--- a/album/election-season.yaml
+++ b/album/election-season.yaml
@@ -7,6 +7,7 @@ URLs:
 Cover Artists:
 - artist:dizzims
 Cover Art File Extension: png
+Track Art File Extension: png
 Wallpaper Artists:
 - artist:dizzims
 - Niklink (edits for wiki)

--- a/album/empyreal-rhapsody.yaml
+++ b/album/empyreal-rhapsody.yaml
@@ -1,5 +1,4 @@
 Album: Empyreal Rhapsody
-Directory: empyreal-rhapsody
 Date: October 12, 2021
 Date Added: October 25, 2023
 URLs:

--- a/album/empyreal-rhapsody.yaml
+++ b/album/empyreal-rhapsody.yaml
@@ -3,7 +3,7 @@ Date: October 12, 2021
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/empyreal-rhapsody
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody
 Artists:
 - Kal-la-kal-la
 Cover Artists:
@@ -24,7 +24,7 @@ Sampled Tracks:
 - Who Has Seen The Wind? - Written by Christina Rossetti
 URLs:
 - https://vasterror.bandcamp.com/track/phantazein
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=phantazein
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=phantazein
 ---
 Track: Anesidora
 Duration: '04:12'
@@ -33,7 +33,7 @@ Referenced Tracks:
 - Rhapsody In Blue
 URLs:
 - https://vasterror.bandcamp.com/track/anesidora
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=anesidora
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=anesidora
 ---
 Track: Inertia
 Directory: inertia-empyreal-rhapsody
@@ -41,13 +41,13 @@ Always Reference By Directory: true
 Duration: '03:47'
 URLs:
 - https://vasterror.bandcamp.com/track/inertia
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=inertia
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=inertia
 ---
 Track: Cacoethes
 Duration: '04:10'
 URLs:
 - https://vasterror.bandcamp.com/track/cacoethes
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=cacoethes
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=cacoethes
 ---
 Track: Grotesquerie
 Duration: '05:27'
@@ -58,19 +58,19 @@ Sampled Tracks:
 - The Ballad of Reading Gaol - Written by Oscar Wilde
 URLs:
 - https://vasterror.bandcamp.com/track/grotesquerie
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=grotesquerie
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=grotesquerie
 ---
 Track: Lacedaemonia
 Duration: '05:16'
 URLs:
 - https://vasterror.bandcamp.com/track/lacedaemonia
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=lacedaemonia
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=lacedaemonia
 ---
 Track: Terminal Iteration
 Duration: '04:49'
 URLs:
 - https://vasterror.bandcamp.com/track/terminal-iteration
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=terminal-iteration
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=terminal-iteration
 ---
 Track: Eigenstate
 Duration: '04:38'
@@ -81,7 +81,7 @@ Sampled Tracks:
 - To Be Or Not To Be - Excerpt from "Hamlet", read by Goran Visnjic in "ER"
 URLs:
 - https://vasterror.bandcamp.com/track/eigenstate
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=eigenstate
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=eigenstate
 ---
 Track: Archon
 Duration: '03:59'
@@ -102,7 +102,7 @@ Lyrics: |-
     DROWN
 URLs:
 - https://vasterror.bandcamp.com/track/archon
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=archon
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=archon
 ---
 Track: Tributary
 Directory: tributary-empyreal-rhapsody
@@ -122,7 +122,7 @@ Lyrics: |-
     You can't live well in your own skin
 URLs:
 - https://vasterror.bandcamp.com/track/tributary
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=tributary
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=tributary
 ---
 Track: Ringlorn
 Duration: '04:29'
@@ -143,16 +143,16 @@ Lyrics: |-
     Down to the mist-wrought towns where dreams go to die
 URLs:
 - https://vasterror.bandcamp.com/track/ringlorn
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=ringlorn
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=ringlorn
 ---
 Track: Pativedha
 Duration: '02:41'
 URLs:
 - https://vasterror.bandcamp.com/track/pativedha
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=pativedha
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=pativedha
 ---
 Track: Chrysalis
 Duration: '04:15'
 URLs:
 - https://vasterror.bandcamp.com/track/chrysalis
-- https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=chrysalis
+# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=chrysalis

--- a/album/farewell-to-all-the-fish.yaml
+++ b/album/farewell-to-all-the-fish.yaml
@@ -13,7 +13,6 @@ Groups:
 - Fandom
 - Beyond
 Cover Art File Extension: png
-# TODO: replace external links with wiki links as these albums get added
 Commentary: |-
     <i>artist:kobacat:</i> (Bandcamp about blurb)
 

--- a/album/faux-dramatica.yaml
+++ b/album/faux-dramatica.yaml
@@ -13,7 +13,7 @@ Groups:
 - Fandom
 URLs:
 - https://vasterror.bandcamp.com/album/faux-dramatica
-- https://music.deconreconstruction.com/albums/faux-dramatica
+# - https://music.deconreconstruction.com/albums/faux-dramatica
 Commentary: |-
     <i>Vast Error:</i>
     "We are, all of us, haunted — pursued down dim corridors by beasts who knew our names before birth. Wouldn't you like to stop running? Wouldn't you like the nightmares to end?"
@@ -29,7 +29,7 @@ Art Tags:
 - 'cw: eye horror'
 URLs:
 - https://vasterror.bandcamp.com/track/lament-for-a-dying-planet
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=lament-for-a-dying-planet
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=lament-for-a-dying-planet
 ---
 Track: Too Slow
 Duration: 4:35
@@ -42,7 +42,7 @@ Sampled Tracks:
 - Killing In The Name
 URLs:
 - https://vasterror.bandcamp.com/track/too-slow
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=too-slow
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=too-slow
 ---
 Track: Sillygoofysillygoofy (Ft. Andrea Libman)
 Directory: sillygoofysillygoofy
@@ -63,7 +63,7 @@ Sampled Tracks:
 - "Half-Life: Alyx but the Gnome is TOO AWARE"
 URLs:
 - https://vasterror.bandcamp.com/track/sillygoofysillygoofy-ft-andrea-libman
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=sillygoofysillygoofy-ft-andrea-libman
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=sillygoofysillygoofy-ft-andrea-libman
 Lyrics: |-
     (WOWIE ZOWIE! That whole thing was exhilarating! But oh no! It seems like this party is about to die down! We're going to have to fix that now! Heeheehahahaha!)
 ---
@@ -76,7 +76,7 @@ Sampled Tracks:
 - "audio from Super Smash Bros. For Wii U"
 URLs:
 - https://vasterror.bandcamp.com/track/carnage-carnival
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=carnage-carnival
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=carnage-carnival
 ---
 Track: Dustcatcher Redux (Ft. Pylon)
 Directory: dustcatcher-redux
@@ -93,7 +93,7 @@ Sampled Tracks:
 - Randy Savage Promo on Hulk Hogan (1989)
 URLs:
 - https://vasterror.bandcamp.com/track/dustcatcher-redux-ft-pylon
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=dustcatcher-redux-ft-pylon
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=dustcatcher-redux-ft-pylon
 ---
 Track: Bite The Hand That Feeds You
 Duration: 4:21
@@ -116,7 +116,7 @@ Sampled Tracks:
 - 'The End of Evangelion - TV Spot #1'
 URLs:
 - https://vasterror.bandcamp.com/track/bite-the-hand-that-feeds-you
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=bite-the-hand-that-feeds-you
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=bite-the-hand-that-feeds-you
 ---
 Track: Turncoat
 Directory: turncoat-faux-dramatica
@@ -133,7 +133,7 @@ Art Tags:
 - 'cw: blood (abstract)'
 URLs:
 - https://vasterror.bandcamp.com/track/turncoat
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=turncoat
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=turncoat
 ---
 Track: Requiem For A Dying Planet (Ft. The Emek Hefer Choir)
 Directory: requiem-for-a-dying-planet
@@ -156,7 +156,7 @@ Sampled Tracks:
 - 'The End of Evangelion - TV Spot #1'
 URLs:
 - https://vasterror.bandcamp.com/track/requiem-for-a-dying-planet-ft-the-emek-hefer-choir
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=requiem-for-a-dying-planet-ft-the-emek-hefer-choir
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=requiem-for-a-dying-planet-ft-the-emek-hefer-choir
 ---
 Track: Naught
 Directory: naught-faux-dramatica
@@ -172,7 +172,7 @@ Art Tags:
 - 'cw: blood'
 URLs:
 - https://vasterror.bandcamp.com/track/naught
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=naught
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=naught
 ---
 Section: Bonus track
 ---
@@ -215,4 +215,4 @@ Sampled Tracks:
 - Dexter's Laboratory Theme Song
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-cognito-hazard-ft-eddie-deezen
-- https://music.deconreconstruction.com/albums/faux-dramatica?track=bonus-cognito-hazard-ft-eddie-deezen
+# - https://music.deconreconstruction.com/albums/faux-dramatica?track=bonus-cognito-hazard-ft-eddie-deezen

--- a/album/fighting-further.yaml
+++ b/album/fighting-further.yaml
@@ -1,5 +1,4 @@
 Album: Fighting Further
-Directory: fighting-further
 Date: November 4, 2023
 Date Added: April 13, 2024
 URLs:

--- a/album/fighting-further.yaml
+++ b/album/fighting-further.yaml
@@ -312,7 +312,7 @@ Contributors:
 - Tee-Vee (lead, rhythm, bass guitars)
 - Marcie Hobbs (Mimesis voice-over & co-writing)
 Cover Artists:
-- diz
+- dizzims.
 Duration: '13:22'
 URLs:
 - https://vasterror.bandcamp.com/track/go-beyond-and-fight-further-ft-tee-vee-and-nezumiva

--- a/album/fnf-colors-and-mayhem-vol-1.yaml
+++ b/album/fnf-colors-and-mayhem-vol-1.yaml
@@ -17,6 +17,7 @@ Wallpaper Artists:
 - Aubbie
 Cover Art File Extension: png
 Wallpaper File Extension: png
+Wallpaper Style: 'opacity: 0.45;'
 ---
 Section: Colors
 ---

--- a/album/friendsymphony.yaml
+++ b/album/friendsymphony.yaml
@@ -3,6 +3,7 @@ Date: November 30, 2020
 Date Added: January 12, 2021
 URLs:
 - https://unofficialmspafans.bandcamp.com/album/friendsymphony
+- https://www.youtube.com/playlist?list=PLkHKl1tLvgY9_ax_jeagXANlpdeI1QXQU
 Cover Artists:
 - Knil
 Color: '#d0289f'
@@ -49,6 +50,7 @@ Artists:
 Duration: 0:56
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/discone
+- https://www.youtube.com/watch?v=xCFHNZiB4po
 Referenced Tracks:
 - Theme
 ---
@@ -58,6 +60,7 @@ Artists:
 Duration: '2:25'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/spare-friendship-maam
+- https://www.youtube.com/watch?v=_e5DhMeGkZE
 Cover Artists:
 - Knil
 Art Tags:
@@ -69,6 +72,7 @@ Artists:
 Duration: '4:05'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/here-on-alternia
+- https://www.youtube.com/watch?v=p45VXcpOMdA
 Cover Artists:
 - star-nomad
 Art Tags:
@@ -87,6 +91,7 @@ Duration: '2:01'
 Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/today-i-put-jelly-on-this-hot-god
+- https://www.youtube.com/watch?v=DNrpSVWW51A
 Cover Artists:
 - Chesswanderlust-sama
 - Makin
@@ -102,6 +107,7 @@ Duration: '3:20'
 Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/scrubbing-until-morning
+- https://www.youtube.com/watch?v=fN6trU8Ushw
 Cover Artists:
 - shu
 Art Tags:
@@ -115,6 +121,7 @@ Duration: '1:41'
 Color: '#eb0000'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/gravediggers-dirge
+- https://www.youtube.com/watch?v=crv_KkVE_mA
 Cover Artists:
 - Jas
 Art Tags:
@@ -128,6 +135,7 @@ Duration: '2:21'
 Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dreams-of-flight
+- https://www.youtube.com/watch?v=1_MIFM-ZZjI
 Cover Artists:
 - Chesswanderlust-sama
 ---
@@ -138,6 +146,7 @@ Duration: '2:36'
 Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/desert-daring
+- https://www.youtube.com/watch?v=o32upb1ineU
 Cover Artists:
 - shu
 Art Tags:
@@ -152,6 +161,7 @@ Duration: '3:29'
 Color: '#c36100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/beneath-the-night-sky-so-dark
+- https://www.youtube.com/watch?v=SkVq9BXIK0Q
 Cover Artists:
 - Chesswanderlust-sama
 Art Tags:
@@ -168,6 +178,7 @@ Color: '#c36100'
 URLs:
 - >-
     https://unofficialmspafans.bandcamp.com/track/hi-everyone-antony-fntano-here-alternias-busiest-music-nerd-and-its-time-for-a-review-of-the-new-chixie-roixmr-album
+- https://www.youtube.com/watch?v=slq2C1zPoCs
 Cover Artists:
 - Chesswanderlust-sama
 Art Tags:
@@ -187,6 +198,7 @@ Duration: '2:15'
 Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/its-hard-being-famous-its-hard-and-nobody-understands
+- https://www.youtube.com/watch?v=TNEOorA7ZnE
 Cover Artists:
 - ZowerLemon
 Art Tags:
@@ -203,6 +215,7 @@ Duration: '2:51'
 Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/leech
+- https://www.youtube.com/watch?v=Ygqisb3Lq6U
 Cover Artists:
 - Cratmang
 Art Tags:
@@ -216,6 +229,7 @@ Duration: '2:18'
 Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/assault-and-battery
+- https://www.youtube.com/watch?v=rrtAHgVVMwY
 Cover Artists:
 - Nova
 Art Tags:
@@ -231,6 +245,7 @@ Duration: '2:05'
 Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/carefree-consternation
+- https://www.youtube.com/watch?v=rMfF7xeKDuA
 Cover Artists:
 - Chesswanderlust-sama
 Art Tags:
@@ -248,6 +263,7 @@ Duration: '4:00'
 Color: '#a1a100'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/optic-duelist
+- https://www.youtube.com/watch?v=JMHJcREr2KQ
 Cover Artists:
 - MarbleMint
 Art Tags:
@@ -276,6 +292,7 @@ Duration: '3:45'
 Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/marvelous-marauder
+- https://www.youtube.com/watch?v=U1-BT0mClUE
 Cover Artists:
 - Chesswanderlust-sama
 Referenced Tracks:
@@ -290,6 +307,7 @@ Duration: '1:37'
 Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/no-kills-you
+- https://www.youtube.com/watch?v=RIobJpwDCrM
 Cover Artists:
 - Nova
 Art Tags:
@@ -303,6 +321,7 @@ Duration: '2:29'
 Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/caught-in-the-facts
+- https://www.youtube.com/watch?v=p8kBZI3_TMc
 Cover Artists:
 - Awkward
 Art Tags:
@@ -318,6 +337,7 @@ Duration: '2:33'
 Color: '#588a00'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/paradox-pariah
+- https://www.youtube.com/watch?v=2RAk4UhwSKo
 Cover Artists:
 - shu
 Art Tags:
@@ -333,6 +353,7 @@ Duration: '3:02'
 Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/mother-to-many
+- https://www.youtube.com/watch?v=Jl-ZlD88JuM
 Cover Artists:
 - Chesswanderlust-sama
 Art Tags:
@@ -347,6 +368,7 @@ Duration: '3:10'
 Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/improved-acumen
+- https://www.youtube.com/watch?v=CHXRrarTzP0
 Cover Artists:
 - Awkward
 Art Tags:
@@ -359,6 +381,7 @@ Duration: '2:30'
 Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/owo
+- https://www.youtube.com/watch?v=4lb64aGSOsI
 Cover Artists:
 - Nova
 Art Tags:
@@ -372,6 +395,7 @@ Duration: '3:46'
 Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/we-waste-time-jaded
+- https://www.youtube.com/watch?v=pA6GlN1Sliw
 Cover Artists:
 - Chesswanderlust-sama
 Art Tags:
@@ -397,6 +421,7 @@ Duration: '3:13'
 Color: '#008f48'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/naive-harmony
+- https://www.youtube.com/watch?v=DxXkL9D7eCE
 Cover Artists:
 - wumby
 Art Tags:
@@ -409,6 +434,7 @@ Duration: '3:28'
 Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/legal-fees-pending
+- https://www.youtube.com/watch?v=N3IWILF254k
 Cover Artists:
 - Awkward
 Art Tags:
@@ -422,6 +448,7 @@ Duration: '3:37'
 Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/exhausted-hope
+- https://www.youtube.com/watch?v=02bGEPUeKfU
 Cover Artists:
 - Elanor Pam
 Art Tags:
@@ -437,6 +464,7 @@ Duration: '3:50'
 Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/bullet-brain
+- https://www.youtube.com/watch?v=yXvBlyGj32c
 Cover Artists:
 - Awkward
 Art Tags:
@@ -450,6 +478,7 @@ Duration: '3:32'
 Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/teleports-behind-you
+- https://www.youtube.com/watch?v=vj3KRSzOn0E
 Cover Artists:
 - star-nomad
 Art Tags:
@@ -462,6 +491,7 @@ Duration: '3:09'
 Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/lonely-little-gremlin-girl
+- https://www.youtube.com/watch?v=ooZNUVRr1kY
 Cover Artists:
 - Chesswanderlust-sama
 ---
@@ -472,6 +502,7 @@ Duration: '2:18'
 Color: '#008b8b'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/middleclass-daydream
+- https://www.youtube.com/watch?v=mcrH6UdIID0
 Cover Artists:
 - Tipsy
 Art Tags:
@@ -496,6 +527,7 @@ Duration: '2:55'
 Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/zillow-for-evil-lairs
+- https://www.youtube.com/watch?v=V5eNoskiSDw
 Cover Artists:
 - Shadok
 Art Tags:
@@ -509,6 +541,7 @@ Duration: '2:32'
 Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/chelicerae
+- https://www.youtube.com/watch?v=GgvL2AqYams
 Cover Artists:
 - Cratmang
 Art Tags:
@@ -521,6 +554,7 @@ Duration: '3:29'
 Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/pop-pills-get-girls
+- https://www.youtube.com/watch?v=kwSOd0kN41A
 Cover Artists:
 - Chesswanderlust-sama
 Referenced Tracks:
@@ -535,6 +569,7 @@ Duration: '2:46'
 Color: '#3796c6'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/blatant-plagiarism
+- https://www.youtube.com/watch?v=DVVP_a28q_4
 Cover Artists:
 - Awkward
 Art Tags:
@@ -549,6 +584,7 @@ Duration: '6:01'
 Color: '#487aef'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/dumbass-terminal
+- https://www.youtube.com/watch?v=pEfkto01GK8
 Cover Artists:
 - shu
 Art Tags:
@@ -569,6 +605,7 @@ Duration: '1:13'
 Color: '#487aef'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/growing-up
+- https://www.youtube.com/watch?v=K1oCApJCR1U
 Cover Artists:
 - Chesswanderlust-sama
 ---
@@ -580,6 +617,7 @@ Duration: '1:59'
 Color: '#487aef'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/worst-fri-end
+- https://www.youtube.com/watch?v=NGwY3_ehitI
 Cover Artists:
 - Gryotharian
 - Chesswanderlust-sama
@@ -593,6 +631,7 @@ Duration: '2:56'
 Color: '#487aef'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sesquipedalian-loquaciousness
+- https://www.youtube.com/watch?v=GjlNiHE_g0c
 Cover Artists:
 - Chesswanderlust-sama
 - Makin
@@ -606,6 +645,7 @@ Duration: '2:26'
 Color: '#487aef'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/suplexes-piano
+- https://www.youtube.com/watch?v=02lPlHwW4v8
 Cover Artists:
 - Chesswanderlust-sama
 ---
@@ -616,6 +656,7 @@ Duration: '2:31'
 Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/sleeping-in-the-cheerful-siss-hair
+- https://www.youtube.com/watch?v=jfBbsWK-LCA
 Cover Artists:
 - Sigourney Martin
 Art Tags:
@@ -628,6 +669,7 @@ Duration: '2:18'
 Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/general-clownery
+- https://www.youtube.com/watch?v=Y9CRL9w8XgE
 Cover Artists:
 - Chesswanderlust-sama
 Art Tags:
@@ -640,6 +682,7 @@ Duration: '3:00'
 Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/phantasmagoria
+- https://www.youtube.com/watch?v=HGkOE3hCZiw
 Cover Artists:
 - ZowerLemon
 Art Tags:
@@ -658,6 +701,7 @@ Duration: '4:02'
 Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-show-must-go-on
+- https://www.youtube.com/watch?v=Bqgfzcz-pQk
 Cover Artists:
 - DSNAKE
 Art Tags:
@@ -671,6 +715,7 @@ Duration: '3:36'
 Color: '#a34bff'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/youre-the-whole-circus
+- https://www.youtube.com/watch?v=mBTSMMStp_U
 Cover Artists:
 - Chesswanderlust-sama
 Referenced Tracks:
@@ -683,6 +728,7 @@ Artists:
 Duration: '4:22'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/the-puppetmaster
+- https://www.youtube.com/watch?v=n6Py4Vgj-bo
 Cover Artists:
 - CyberSoulgem
 Art Tags:

--- a/album/funkstuck-24.yaml
+++ b/album/funkstuck-24.yaml
@@ -20,6 +20,7 @@ Wallpaper Style: |-
     background-size: auto;
 Color: '#c96cda'
 Groups:
+- James Roach
 - group:official
 Art Tags:
 - Battlefield

--- a/album/homestuck-vol-6.yaml
+++ b/album/homestuck-vol-6.yaml
@@ -142,6 +142,7 @@ Referenced Tracks:
 - Penumbra Phantasm
 - An Unbreakable Union
 - Courser
+- track:sburban-jungle
 - track:carefree-action
 - Homestuck Anthem
 Sheet Music Files:

--- a/album/magnum-opus.yaml
+++ b/album/magnum-opus.yaml
@@ -3,7 +3,7 @@ Date: March 22, 2023
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/magnum-opus
-- https://music.deconreconstruction.com/albums/magnum-opus
+# - https://music.deconreconstruction.com/albums/magnum-opus
 Cover Artists:
 - ghastaboo
 Cover Art File Extension: png

--- a/album/magnum-opus.yaml
+++ b/album/magnum-opus.yaml
@@ -1,5 +1,4 @@
 Album: Magnum Opus
-Directory: magnum-opus
 Date: March 22, 2023
 Date Added: April 13, 2024
 URLs:

--- a/album/midworld-merriment.yaml
+++ b/album/midworld-merriment.yaml
@@ -70,6 +70,8 @@ URLs:
 - https://nightslights.bandcamp.com/track/lotsa-presents
 ---
 Track: Wieczna Zimny
+Additional Names:
+- Eternal Cold (English)
 Artists:
 - leiirue
 Duration: '1:52' 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1872,7 +1872,7 @@ Duration: '2:38'
 URLs:
 - https://soundcloud.com/kdmanderson/the-land-of-wind-and-shade
 Commentary: |-
-    <i>KDMAnderson:</i> (composer, [SoundCloud](https://soundcloud.com/kdmanderson/the-land-of-wind-and-shade))
+    <i>KDMAnderson:</i> ([SoundCloud](https://soundcloud.com/kdmanderson/the-land-of-wind-and-shade))
 
     This is sort of a tribute tune to the Webcomic "MS Paint Adventures". It's very fresh; I recorded it almost as soon as I finished writing it. I slathered on Phasers, Chorus, Reverb and Echo to support the dreamy feel of the piece. It's played almost entirely with harmonics. Altered Tuning, too. ;)
     Enjoy!

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1064,6 +1064,21 @@ Duration: 0:28
 URLs:
 - https://hsmusic.wiki/media/misc/archive/Where%20making%20this%20hapen.mp3
 ---
+Track: Wily Espionage
+Directory: wily-espionage-original
+Always Reference By Directory: True
+Artists:
+- Thomas Ferkol
+Duration: '3:13'
+URLs:
+- https://hsmusic.wiki/media/misc/archive/Wily%20Espionage.mp3
+Commentary: |-
+    <i>Thomas Ferkol:</i> (composer, [Tumblr](https://eidolonorpheus.tumblr.com/post/39968495349/wily-espionage-going-places))
+
+    Going places?
+
+    <small>#wip #roxy lalonde #derse</small>
+---
 Track: You're So Rad
 Artists:
 - Malcolm Brown

--- a/album/namco-high-official-soundtrack.yaml
+++ b/album/namco-high-official-soundtrack.yaml
@@ -9,6 +9,7 @@ Cover Artists:
 - Ahvia
 - Namco High
 Cover Art File Extension: png
+Wallpaper Style: 'opacity: 0.45;'
 Wallpaper Artists:
 - Ahvia
 - Quasar Nebula (edits for wiki)

--- a/album/p-s.yaml
+++ b/album/p-s.yaml
@@ -177,6 +177,8 @@ Artists:
 Duration: '3:49'
 URLs:
 - https://casualsunday.bandcamp.com/track/wily-espionage
+Referenced Tracks:
+- track:wily-espionage-original
 ---
 Track: Apexhalation
 Additional Names:

--- a/album/perils-of-probability.yaml
+++ b/album/perils-of-probability.yaml
@@ -4,7 +4,7 @@ Date: October 31, 2022
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/perils-of-probability-the-technicolor-terror-from-beyond-the-hyperthetical
-- https://music.deconreconstruction.com/albums/perils-of-probability-the-technicolor-terror-from-beyond-the-hyperthetical
+# - https://music.deconreconstruction.com/albums/perils-of-probability-the-technicolor-terror-from-beyond-the-hyperthetical
 Cover Artists:
 - rurichoo
 Cover Art File Extension: png

--- a/album/pesterquest-soundtrack.yaml
+++ b/album/pesterquest-soundtrack.yaml
@@ -451,7 +451,7 @@ URLs:
 - https://www.youtube.com/watch?v=MDqXkGBFPg0
 Referenced Tracks:
 - it's a cover of 'made of time'
-- track:MeGaLoVania
+- track:megalovania-undertale
 - track:nuclear-james-roach
 Commentary: |-
     <i>James Roach:</i> ([SoundCloud](https://soundcloud.com/jamesroachmusic/pesterquest-aradias-theme-yeah-it-is))

--- a/album/pesterquest-soundtrack.yaml
+++ b/album/pesterquest-soundtrack.yaml
@@ -11,6 +11,10 @@ Artists:
 Groups:
 - James Roach
 - group:official
+Wallpaper Artists:
+- Andrew Hussie
+Wallpaper Style: 'opacity: 0.6;'
+Wallpaper File Extension: png
 Art Tags:
 - Feferi
 - Nepeta

--- a/album/pokemon-scarlet-violet-super-music-collection.yaml
+++ b/album/pokemon-scarlet-violet-super-music-collection.yaml
@@ -19,6 +19,7 @@ Groups:
 - Beyond
 Wallpaper Artists:
 - GAME FREAK
+Wallpaper Style: 'opacity: 0.45;'
 Commentary: |-
     <i>Toby Fox:</i> ([UNDERTALE / DELTARUNE NEWSLETTER - ISSUE 1 (Winter Season)](https://toby.fangamer.com/newsletters/winter22/), excerpt)
 

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -21,6 +21,7 @@ Wallpaper Artists:
 - GAME FREAK
 Wallpaper Style: |-
     background-position: top center;
+    opacity: 0.45;
 ---
 Section: Disc 1
 Color: '#00a2e7'

--- a/album/psycholonials-ep-1.yaml
+++ b/album/psycholonials-ep-1.yaml
@@ -5,17 +5,20 @@ Date: February 3, 2021
 Date Added: February 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -31,6 +34,7 @@ Originally Released As: Star I Never Caught
 Duration: '3:50'
 URLs:
 - https://psycholonials.bandcamp.com/track/summer-that-never-was-2
+- https://www.youtube.com/watch?v=ZfpzN5pxRC0
 - https://open.spotify.com/track/64mI4TSiB8uu3lJmThh2Pm
 ---
 Track: Morning Ritual
@@ -38,10 +42,12 @@ Originally Released As: Puzzle I Never Solved
 Duration: '2:47'
 URLs:
 - https://psycholonials.bandcamp.com/track/morning-ritual-2
+- https://www.youtube.com/watch?v=9SxGZAFQMug
 - https://open.spotify.com/track/3U73BkOHYfS4kWaePTQAxm
 ---
 Track: What's Wasting Me
 Duration: '2:35'
 URLs:
 - https://psycholonials.bandcamp.com/track/whats-wasting-me-2
+- https://www.youtube.com/watch?v=VQ4nWcC_BfA
 - https://open.spotify.com/track/6ER6SK5NgOBN1qmzYOcL13

--- a/album/psycholonials-ep-2.yaml
+++ b/album/psycholonials-ep-2.yaml
@@ -5,17 +5,20 @@ Date: February 17, 2021
 Date Added: February 18, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -31,6 +34,7 @@ Originally Released As: Sigh I Never Breathed
 Duration: '2:21'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-cold-hand-2
+- https://www.youtube.com/watch?v=eoFJUDK4hTU
 - https://open.spotify.com/track/0UhtxV3zRVSMNKGzrWFNuv
 ---
 Track: Together
@@ -40,6 +44,7 @@ Sampled Tracks:
 Duration: '2:04'
 URLs:
 - https://psycholonials.bandcamp.com/track/together-2
+- https://www.youtube.com/watch?v=-4ipCjnE5Ik
 - https://open.spotify.com/track/5fAqAdxpZcLjDnaRlD5f60
 ---
 Track: The Influencer
@@ -47,6 +52,7 @@ Originally Released As: Woman I Never Met
 Duration: '2:26'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-influencer-2
+- https://www.youtube.com/watch?v=JXxXzClDTG4
 - https://open.spotify.com/track/7rDTdq4EptIIaxfHczQQoj
 ---
 Track: Just Dreams
@@ -54,6 +60,7 @@ Originally Released As: People I Never Knew
 Duration: '3:10'
 URLs:
 - https://psycholonials.bandcamp.com/track/just-dreams-2
+- https://www.youtube.com/watch?v=-AolKyTr454
 - https://open.spotify.com/track/3KQG73E12y5Wl1Vo7WG7cb
 ---
 Track: I Have Some Ideas
@@ -69,4 +76,5 @@ Additional Names:
 Duration: '4:10'
 URLs:
 - https://psycholonials.bandcamp.com/track/i-have-some-ideas-2
+- https://www.youtube.com/watch?v=HO4qa2AkgkQ
 - https://open.spotify.com/track/4ITOGr1ByM1c35aKrvujYX

--- a/album/psycholonials-ep-3.yaml
+++ b/album/psycholonials-ep-3.yaml
@@ -5,17 +5,20 @@ Date: February 24, 2021
 Date Added: February 24, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -31,6 +34,7 @@ Originally Released As: track:requiem-labyrinths-heart
 Duration: '4:36'
 URLs:
 - https://psycholonials.bandcamp.com/track/time-is-helpless-2
+- https://www.youtube.com/watch?v=XJfeMmYLyWQ
 - https://open.spotify.com/track/4k75TPmKhhBHkrkrGgJdqb
 ---
 Track: Through The Play
@@ -38,6 +42,7 @@ Originally Released As: track:pleas-labyrinths-heart
 Duration: '3:13'
 URLs:
 - https://psycholonials.bandcamp.com/track/through-the-play-2
+- https://www.youtube.com/watch?v=8yKmwXr1HMA
 - https://open.spotify.com/track/3f4fancHgYFJGviyktVNLa
 ---
 Track: Just Almost
@@ -45,4 +50,5 @@ Originally Released As: Song I Never Played
 Duration: '1:37'
 URLs:
 - https://psycholonials.bandcamp.com/track/just-almost-2
+- https://www.youtube.com/watch?v=SupWvnw8y20
 - https://open.spotify.com/track/3gawxtrEZGg0nk9Xh31wNw

--- a/album/psycholonials-ep-4.yaml
+++ b/album/psycholonials-ep-4.yaml
@@ -5,17 +5,20 @@ Date: March 3, 2021
 Date Added: March 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -33,6 +36,7 @@ Referenced Tracks:
 - Misbegotten
 URLs:
 - https://psycholonials.bandcamp.com/track/outlaw-2
+- https://www.youtube.com/watch?v=I2bHYiMU4G0
 - https://open.spotify.com/track/4S4Oyq95eiOypptWqDeEM7
 ---
 Track: A Screaming Inside
@@ -40,6 +44,7 @@ Originally Released As: Dante
 Duration: '2:14'
 URLs:
 - https://psycholonials.bandcamp.com/track/a-screaming-inside-2
+- https://www.youtube.com/watch?v=-hFL0mwgSFQ
 - https://open.spotify.com/track/0gnd9GNrY41ejYwqb5CNwq
 ---
 Track: Breakthroughs
@@ -48,6 +53,7 @@ Always Reference By Directory: true
 Duration: '2:14'
 URLs:
 - https://psycholonials.bandcamp.com/track/breakthroughs-2
+- https://www.youtube.com/watch?v=BR4uk06kTxc
 - https://open.spotify.com/track/5cr7lxn0RXTj51HEJrsBbQ
 ---
 Track: Nervous Energy
@@ -55,10 +61,12 @@ Originally Released As: A Romance of Protons and Neutrons
 Duration: '4:28'
 URLs:
 - https://psycholonials.bandcamp.com/track/nervous-energy-2
+- https://www.youtube.com/watch?v=ICo1B-MvK9k
 - https://open.spotify.com/track/54G0LScgF65Ch7bHWXmsrk
 ---
 Track: Now And Forever
 Duration: '3:59'
 URLs:
 - https://psycholonials.bandcamp.com/track/now-and-forever-2
+- https://www.youtube.com/watch?v=qdL_FKg1bJA
 - https://open.spotify.com/track/6O9NbaWMGQU9zJyvvb7vBW

--- a/album/psycholonials-ep-5.yaml
+++ b/album/psycholonials-ep-5.yaml
@@ -5,17 +5,20 @@ Date: March 10, 2021
 Date Added: April 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -30,6 +33,7 @@ Track: In The Works
 Duration: '4:22'
 URLs:
 - https://psycholonials.bandcamp.com/track/in-the-works-2
+- https://www.youtube.com/watch?v=Uhusl2R6kc0
 - https://open.spotify.com/track/1KTM56IDeOhMOBv8HmEOy8
 ---
 Track: Ephemeral Muse
@@ -37,6 +41,7 @@ Originally Released As: track:harrigan-we-are-all-satellites
 Duration: '4:46'
 URLs:
 - https://psycholonials.bandcamp.com/track/ephemeral-muse-2
+- https://www.youtube.com/watch?v=fcHxSRUjhE0
 - https://open.spotify.com/track/3wMjNIOUK2EAONoA3sX36D
 ---
 Track: Blood On Their Hands
@@ -48,4 +53,5 @@ Additional Names:
 Duration: '2:46'
 URLs:
 - https://psycholonials.bandcamp.com/track/blood-on-their-hands-2
+- https://www.youtube.com/watch?v=T_mm3VN6MaE
 - https://open.spotify.com/track/40wqV55Nz2PFOB5agcwnNR

--- a/album/psycholonials-ep-6.yaml
+++ b/album/psycholonials-ep-6.yaml
@@ -5,17 +5,20 @@ Date: March 24, 2021
 Date Added: April 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -31,6 +34,7 @@ Originally Released As: Cruel Ulysses
 Duration: '2:21'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-administrator-2
+- https://www.youtube.com/watch?v=Kbxeois4TMc
 - https://open.spotify.com/track/2kHU4sux0wCzD2c7NQeda2
 ---
 Track: Means Of Conquest
@@ -38,10 +42,12 @@ Originally Released As: Country I Never Saw
 Duration: '3:55'
 URLs:
 - https://psycholonials.bandcamp.com/track/means-of-conquest-2
+- https://www.youtube.com/watch?v=mA_GA8UcW6w
 - https://open.spotify.com/track/59ESzKgMAGKbwK69rwRyJi
 ---
 Track: Twelve Clown Salute
 Duration: '2:19'
 URLs:
 - https://psycholonials.bandcamp.com/track/twelve-clown-salute-2
+- https://www.youtube.com/watch?v=Pnafd9DQt54
 - https://open.spotify.com/track/5QXXZqeSSE8Ue4KUzo3gMN

--- a/album/psycholonials-ep-7.yaml
+++ b/album/psycholonials-ep-7.yaml
@@ -5,17 +5,20 @@ Date: March 31, 2021
 Date Added: April 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -30,6 +33,7 @@ Track: The March
 Duration: '2:46'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-march-2
+- https://www.youtube.com/watch?v=RSd3eMV7B58
 - https://open.spotify.com/track/1CuKshuD0soQDmBxRr3tTh
 Referenced Tracks:
 - Voice I Never Heard
@@ -39,10 +43,12 @@ Originally Released As: track:miranda-we-are-all-satellites
 Duration: '3:25'
 URLs:
 - https://psycholonials.bandcamp.com/track/such-a-shame-2
+- https://www.youtube.com/watch?v=IqTodCDs2P4
 - https://open.spotify.com/track/1XksnO0m84cUh7PFuhiSsT
 ---
 Track: Break This
 Duration: '1:21'
 URLs:
 - https://psycholonials.bandcamp.com/track/break-this-2
+- https://www.youtube.com/watch?v=nfDlmMBkXDE
 - https://open.spotify.com/track/1ZaBg1nL9hJ8uVLfJEuFtk

--- a/album/psycholonials-ep-8.yaml
+++ b/album/psycholonials-ep-8.yaml
@@ -5,17 +5,20 @@ Date: April 13, 2021
 Date Added: May 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -35,6 +38,7 @@ Additional Names:
 Duration: '2:38'
 URLs:
 - https://psycholonials.bandcamp.com/track/in-the-loop-2
+- https://www.youtube.com/watch?v=a783i3zuHZk
 - https://open.spotify.com/track/3ILu9zH2LuB9e3CP6SfxTZ
 ---
 Track: 'Flare: Insurrection Remix'
@@ -42,10 +46,12 @@ Originally Released As: Flare (Green Sun Remix)
 Duration: '4:08'
 URLs:
 - https://psycholonials.bandcamp.com/track/flare-insurrection-remix-2
+- https://www.youtube.com/watch?v=70Fn7AMT-WY
 - https://open.spotify.com/track/3fPWLONmFI8UBJgZUyqONb
 ---
 Track: 'Summer That Never Was: Firebrand Remix'
 Duration: '3:55'
 URLs:
 - https://psycholonials.bandcamp.com/track/summer-that-never-was-firebrand-remix-2
+- https://www.youtube.com/watch?v=9L73_6sSHB0
 - https://open.spotify.com/track/7iASFeTxfN8Hv7xH2lrf4t

--- a/album/psycholonials-ep-9.yaml
+++ b/album/psycholonials-ep-9.yaml
@@ -5,17 +5,20 @@ Date: April 20, 2021 12:00:00
 Date Added: May 12, 2021
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#f51806'
 Groups:
 - Psycholonials
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -30,12 +33,14 @@ Track: Fix This
 Duration: '1:54'
 URLs:
 - https://psycholonials.bandcamp.com/track/fix-this-2
+- https://www.youtube.com/watch?v=e-lT9rykPt4
 - https://open.spotify.com/track/0qy3cn12yEIMAP4Tev55Kw
 ---
 Track: Edge Of Dawn
 Duration: '4:33'
 URLs:
 - https://psycholonials.bandcamp.com/track/edge-of-dawn-2
+- https://www.youtube.com/watch?v=qKIcIc457pQ
 - https://open.spotify.com/track/3wgateK1DRUbM2pgLbWJbL
 Referenced Tracks:
 - track:shoreline-labyrinths-heart
@@ -46,6 +51,7 @@ Always Reference By Directory: true
 Duration: '1:47'
 URLs:
 - https://psycholonials.bandcamp.com/track/threshold-2
+- https://www.youtube.com/watch?v=EUy9aIOkT3Y
 - https://open.spotify.com/track/1HNcbJcICXmCNXFcFJNTKa
 ---
 Track: We Were Right About Everything
@@ -53,18 +59,21 @@ Originally Released As: track:lunatic-we-are-all-satellites
 Duration: '5:51'
 URLs:
 - https://psycholonials.bandcamp.com/track/we-were-right-about-everything-2
+- https://www.youtube.com/watch?v=K9X4zKUTwUY
 - https://open.spotify.com/track/2d8q0b4wRtdWpJl3Hm5VFD
 ---
 Track: Feeling I Can't Shake
 Duration: '2:26'
 URLs:
 - https://psycholonials.bandcamp.com/track/feeling-i-cant-shake-2
+- https://www.youtube.com/watch?v=kZqwz7tzlv0
 - https://open.spotify.com/track/6Gi8uMvQnxKVR3Nc1Bw0o9
 ---
 Track: Zhen
 Duration: '2:42'
 URLs:
 - https://psycholonials.bandcamp.com/track/zhen-2
+- https://www.youtube.com/watch?v=oZqFjUxIOWQ
 - https://open.spotify.com/track/69gFF5kuyCSJdBiRntGPFL
 ---
 Track: The Successor
@@ -72,6 +81,7 @@ Originally Released As: track:forgotten-labyrinths-heart
 Duration: '4:22'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-successor-2
+- https://www.youtube.com/watch?v=SfbhgsTkeVw
 - https://open.spotify.com/track/2nGoAZvwC4m9juSN2rD2H9
 ---
 Track: Love Song
@@ -83,12 +93,14 @@ Additional Names:
 Duration: '3:54'
 URLs:
 - https://psycholonials.bandcamp.com/track/love-song-2
+- https://www.youtube.com/watch?v=VbEBQnWlC50
 - https://open.spotify.com/track/51KqiAops6wegL9HBWNZI3
 ---
 Track: 'Ephemeral Muse: Final Remix'
 Duration: '4:08'
 URLs:
 - https://psycholonials.bandcamp.com/track/ephemeral-muse-final-remix-2
+- https://www.youtube.com/watch?v=icM0NtYYw5s
 - https://open.spotify.com/track/3oIQx0z9rNmEew41Ruxinb
 Referenced Tracks:
 - track:harrigan-we-are-all-satellites

--- a/album/psycholonials.yaml
+++ b/album/psycholonials.yaml
@@ -5,9 +5,11 @@ Date: April 20, 2021 12:00:01
 Date Added: May 12, 2021
 URLs:
 - https://psycholonials.bandcamp.com/album/psycholonials
+- https://www.youtube.com/playlist?list=OLAK5uy_lTL6fk9GCYnvxc37bE4M2NXURZuPl-N5U
 - https://open.spotify.com/album/54DlaXME5Gtkb1TCMsPott
 Cover Artists:
 - Andrew Hussie
+Cover Art File Extension: png
 Color: '#82a8d5'
 Groups:
 - Psycholonials
@@ -15,11 +17,13 @@ Groups:
 - Beyond
 Banner Artists:
 - Andrew Hussie
+- Niklink (edits for wiki)
 Banner Dimensions: 1100x180
 Banner File Extension: png
 Wallpaper Style: |-
     opacity: 0.65;
     image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper File Extension: png
 Wallpaper Artists:
 - Andrew Hussie
@@ -28,6 +32,14 @@ Additional Files:
 - Title: Bandcamp Banner
   Files:
   - banner.png
+Commentary: |-
+    <i>Andrew Hussie:</i> ([Bandcamp about blurb](https://psycholonials.bandcamp.com/album/psycholonials))
+
+    This album is the full Psycholonials soundtrack with all music from [[album:psycholonials-ep-1|EP 1]] through [[album:psycholonials-ep-9|EP 9]], including a bonus track not featured on any other EP.
+
+    <i>Andrew Hussie:</i> (alternate artwork, rerelease)
+
+    <img src="media/misc/psycholonials-alt.jpg" width="300">
 ---
 Section: From EP 1
 ---
@@ -37,6 +49,7 @@ Originally Released As: Star I Never Caught
 Duration: '3:50'
 URLs:
 - https://psycholonials.bandcamp.com/track/summer-that-never-was-2
+- https://www.youtube.com/watch?v=ZfpzN5pxRC0
 - https://open.spotify.com/track/64mI4TSiB8uu3lJmThh2Pm
 ---
 Track: Morning Ritual
@@ -45,6 +58,7 @@ Originally Released As: Puzzle I Never Solved
 Duration: '2:47'
 URLs:
 - https://psycholonials.bandcamp.com/track/morning-ritual-2
+- https://www.youtube.com/watch?v=9SxGZAFQMug
 - https://open.spotify.com/track/3U73BkOHYfS4kWaePTQAxm
 ---
 Track: What's Wasting Me
@@ -53,6 +67,7 @@ Originally Released As: track:whats-wasting-me
 Duration: '2:35'
 URLs:
 - https://psycholonials.bandcamp.com/track/whats-wasting-me-2
+- https://www.youtube.com/watch?v=VQ4nWcC_BfA
 - https://open.spotify.com/track/6ER6SK5NgOBN1qmzYOcL13
 ---
 Section: From EP 2
@@ -63,6 +78,7 @@ Originally Released As: Sigh I Never Breathed
 Duration: '2:21'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-cold-hand-2
+- https://www.youtube.com/watch?v=eoFJUDK4hTU
 - https://open.spotify.com/track/0UhtxV3zRVSMNKGzrWFNuv
 ---
 Track: Together
@@ -71,6 +87,7 @@ Originally Released As: track:together-psycholonials-ep-2
 Duration: '2:04'
 URLs:
 - https://psycholonials.bandcamp.com/track/together-2
+- https://www.youtube.com/watch?v=-4ipCjnE5Ik
 - https://open.spotify.com/track/5fAqAdxpZcLjDnaRlD5f60
 ---
 Track: The Influencer
@@ -79,6 +96,7 @@ Originally Released As: Woman I Never Met
 Duration: '2:26'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-influencer-2
+- https://www.youtube.com/watch?v=JXxXzClDTG4
 - https://open.spotify.com/track/7rDTdq4EptIIaxfHczQQoj
 ---
 Track: Just Dreams
@@ -87,6 +105,7 @@ Originally Released As: People I Never Knew
 Duration: '3:10'
 URLs:
 - https://psycholonials.bandcamp.com/track/just-dreams-2
+- https://www.youtube.com/watch?v=-AolKyTr454
 - https://open.spotify.com/track/3KQG73E12y5Wl1Vo7WG7cb
 ---
 Track: I Have Some Ideas
@@ -95,6 +114,7 @@ Originally Released As: track:i-have-some-ideas
 Duration: '4:10'
 URLs:
 - https://psycholonials.bandcamp.com/track/i-have-some-ideas-2
+- https://www.youtube.com/watch?v=HO4qa2AkgkQ
 - https://open.spotify.com/track/4ITOGr1ByM1c35aKrvujYX
 ---
 Section: From EP 3
@@ -105,6 +125,7 @@ Originally Released As: track:requiem-labyrinths-heart
 Duration: '4:36'
 URLs:
 - https://psycholonials.bandcamp.com/track/time-is-helpless-2
+- https://www.youtube.com/watch?v=XJfeMmYLyWQ
 - https://open.spotify.com/track/4k75TPmKhhBHkrkrGgJdqb
 ---
 Track: Through The Play
@@ -113,6 +134,7 @@ Originally Released As: track:pleas-labyrinths-heart
 Duration: '3:13'
 URLs:
 - https://psycholonials.bandcamp.com/track/through-the-play-2
+- https://www.youtube.com/watch?v=8yKmwXr1HMA
 - https://open.spotify.com/track/3f4fancHgYFJGviyktVNLa
 ---
 Track: Just Almost
@@ -121,6 +143,7 @@ Originally Released As: Song I Never Played
 Duration: '1:37'
 URLs:
 - https://psycholonials.bandcamp.com/track/just-almost-2
+- https://www.youtube.com/watch?v=SupWvnw8y20
 - https://open.spotify.com/track/3gawxtrEZGg0nk9Xh31wNw
 ---
 Section: From EP 4
@@ -131,6 +154,7 @@ Originally Released As: track:outlaw-psycholonials-ep-4
 Duration: '3:57'
 URLs:
 - https://psycholonials.bandcamp.com/track/outlaw-2
+- https://www.youtube.com/watch?v=I2bHYiMU4G0
 - https://open.spotify.com/track/4S4Oyq95eiOypptWqDeEM7
 ---
 Track: A Screaming Inside
@@ -139,6 +163,7 @@ Originally Released As: Dante
 Duration: '2:14'
 URLs:
 - https://psycholonials.bandcamp.com/track/a-screaming-inside-2
+- https://www.youtube.com/watch?v=-hFL0mwgSFQ
 - https://open.spotify.com/track/0gnd9GNrY41ejYwqb5CNwq
 ---
 Track: Breakthroughs
@@ -147,6 +172,7 @@ Originally Released As: track:breakthroughs-psycholonials-ep-4
 Duration: '2:14'
 URLs:
 - https://psycholonials.bandcamp.com/track/breakthroughs-2
+- https://www.youtube.com/watch?v=BR4uk06kTxc
 - https://open.spotify.com/track/5cr7lxn0RXTj51HEJrsBbQ
 ---
 Track: Nervous Energy
@@ -155,6 +181,7 @@ Originally Released As: A Romance of Protons and Neutrons
 Duration: '4:28'
 URLs:
 - https://psycholonials.bandcamp.com/track/nervous-energy-2
+- https://www.youtube.com/watch?v=ICo1B-MvK9k
 - https://open.spotify.com/track/54G0LScgF65Ch7bHWXmsrk
 ---
 Track: Now And Forever
@@ -163,6 +190,7 @@ Originally Released As: track:now-and-forever
 Duration: '3:59'
 URLs:
 - https://psycholonials.bandcamp.com/track/now-and-forever-2
+- https://www.youtube.com/watch?v=qdL_FKg1bJA
 - https://open.spotify.com/track/6O9NbaWMGQU9zJyvvb7vBW
 ---
 Section: From EP 5
@@ -173,6 +201,7 @@ Originally Released As: track:in-the-works
 Duration: '4:22'
 URLs:
 - https://psycholonials.bandcamp.com/track/in-the-works-2
+- https://www.youtube.com/watch?v=Uhusl2R6kc0
 - https://open.spotify.com/track/1KTM56IDeOhMOBv8HmEOy8
 ---
 Track: Ephemeral Muse
@@ -181,6 +210,7 @@ Originally Released As: track:harrigan-we-are-all-satellites
 Duration: '4:46'
 URLs:
 - https://psycholonials.bandcamp.com/track/ephemeral-muse-2
+- https://www.youtube.com/watch?v=fcHxSRUjhE0
 - https://open.spotify.com/track/3wMjNIOUK2EAONoA3sX36D
 ---
 Track: Blood On Their Hands
@@ -189,6 +219,7 @@ Originally Released As: track:blood-on-their-hands
 Duration: '2:46'
 URLs:
 - https://psycholonials.bandcamp.com/track/blood-on-their-hands-2
+- https://www.youtube.com/watch?v=T_mm3VN6MaE
 - https://open.spotify.com/track/40wqV55Nz2PFOB5agcwnNR
 ---
 Section: From EP 6
@@ -199,6 +230,7 @@ Originally Released As: Cruel Ulysses
 Duration: '2:21'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-administrator-2
+- https://www.youtube.com/watch?v=Kbxeois4TMc
 - https://open.spotify.com/track/2kHU4sux0wCzD2c7NQeda2
 ---
 Track: Means Of Conquest
@@ -207,6 +239,7 @@ Originally Released As: Country I Never Saw
 Duration: '3:55'
 URLs:
 - https://psycholonials.bandcamp.com/track/means-of-conquest-2
+- https://www.youtube.com/watch?v=mA_GA8UcW6w
 - https://open.spotify.com/track/59ESzKgMAGKbwK69rwRyJi
 ---
 Track: Twelve Clown Salute
@@ -215,6 +248,7 @@ Originally Released As: track:twelve-clown-salute
 Duration: '2:19'
 URLs:
 - https://psycholonials.bandcamp.com/track/twelve-clown-salute-2
+- https://www.youtube.com/watch?v=Pnafd9DQt54
 - https://open.spotify.com/track/5QXXZqeSSE8Ue4KUzo3gMN
 ---
 Section: From EP 7
@@ -225,6 +259,7 @@ Originally Released As: track:the-march
 Duration: '2:46'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-march-2
+- https://www.youtube.com/watch?v=RSd3eMV7B58
 - https://open.spotify.com/track/1CuKshuD0soQDmBxRr3tTh
 ---
 Track: Such A Shame
@@ -233,6 +268,7 @@ Originally Released As: track:miranda-we-are-all-satellites
 Duration: '3:25'
 URLs:
 - https://psycholonials.bandcamp.com/track/such-a-shame-2
+- https://www.youtube.com/watch?v=IqTodCDs2P4
 - https://open.spotify.com/track/1XksnO0m84cUh7PFuhiSsT
 ---
 Track: Break This
@@ -241,6 +277,7 @@ Originally Released As: track:break-this
 Duration: '1:21'
 URLs:
 - https://psycholonials.bandcamp.com/track/break-this-2
+- https://www.youtube.com/watch?v=nfDlmMBkXDE
 - https://open.spotify.com/track/1ZaBg1nL9hJ8uVLfJEuFtk
 ---
 Section: From EP 8
@@ -251,6 +288,7 @@ Originally Released As: track:in-the-loop
 Duration: '2:38'
 URLs:
 - https://psycholonials.bandcamp.com/track/in-the-loop-2
+- https://www.youtube.com/watch?v=a783i3zuHZk
 - https://open.spotify.com/track/3ILu9zH2LuB9e3CP6SfxTZ
 ---
 Track: 'Flare: Insurrection Remix'
@@ -259,6 +297,7 @@ Originally Released As: Flare (Green Sun Remix)
 Duration: '4:08'
 URLs:
 - https://psycholonials.bandcamp.com/track/flare-insurrection-remix-2
+- https://www.youtube.com/watch?v=70Fn7AMT-WY
 - https://open.spotify.com/track/3fPWLONmFI8UBJgZUyqONb
 ---
 Track: 'Summer That Never Was: Firebrand Remix'
@@ -267,6 +306,7 @@ Originally Released As: track:summer-that-never-was-firebrand-remix
 Duration: '3:55'
 URLs:
 - https://psycholonials.bandcamp.com/track/summer-that-never-was-firebrand-remix-2
+- https://www.youtube.com/watch?v=9L73_6sSHB0
 - https://open.spotify.com/track/7iASFeTxfN8Hv7xH2lrf4t
 ---
 Section: From EP 9
@@ -277,6 +317,7 @@ Originally Released As: track:fix-this
 Duration: '1:54'
 URLs:
 - https://psycholonials.bandcamp.com/track/fix-this-2
+- https://www.youtube.com/watch?v=e-lT9rykPt4
 - https://open.spotify.com/track/0qy3cn12yEIMAP4Tev55Kw
 ---
 Track: Edge Of Dawn
@@ -285,6 +326,7 @@ Originally Released As: track:edge-of-dawn
 Duration: '4:33'
 URLs:
 - https://psycholonials.bandcamp.com/track/edge-of-dawn-2
+- https://www.youtube.com/watch?v=qKIcIc457pQ
 - https://open.spotify.com/track/3wgateK1DRUbM2pgLbWJbL
 ---
 Track: Threshold
@@ -293,6 +335,7 @@ Originally Released As: track:threshold-psycholonials-ep-9
 Duration: '1:47'
 URLs:
 - https://psycholonials.bandcamp.com/track/threshold-2
+- https://www.youtube.com/watch?v=EUy9aIOkT3Y
 - https://open.spotify.com/track/1HNcbJcICXmCNXFcFJNTKa
 ---
 Track: We Were Right About Everything
@@ -301,6 +344,7 @@ Originally Released As: track:lunatic-we-are-all-satellites
 Duration: '5:51'
 URLs:
 - https://psycholonials.bandcamp.com/track/we-were-right-about-everything-2
+- https://www.youtube.com/watch?v=K9X4zKUTwUY
 - https://open.spotify.com/track/2d8q0b4wRtdWpJl3Hm5VFD
 ---
 Track: Feeling I Can't Shake
@@ -309,6 +353,7 @@ Originally Released As: track:feeling-i-cant-shake
 Duration: '2:26'
 URLs:
 - https://psycholonials.bandcamp.com/track/feeling-i-cant-shake-2
+- https://www.youtube.com/watch?v=kZqwz7tzlv0
 - https://open.spotify.com/track/6Gi8uMvQnxKVR3Nc1Bw0o9
 ---
 Track: Zhen
@@ -317,6 +362,7 @@ Originally Released As: track:zhen
 Duration: '2:42'
 URLs:
 - https://psycholonials.bandcamp.com/track/zhen-2
+- https://www.youtube.com/watch?v=oZqFjUxIOWQ
 - https://open.spotify.com/track/69gFF5kuyCSJdBiRntGPFL
 ---
 Track: The Successor
@@ -325,6 +371,7 @@ Originally Released As: track:forgotten-labyrinths-heart
 Duration: '4:22'
 URLs:
 - https://psycholonials.bandcamp.com/track/the-successor-2
+- https://www.youtube.com/watch?v=SfbhgsTkeVw
 - https://open.spotify.com/track/2nGoAZvwC4m9juSN2rD2H9
 ---
 Track: Love Song
@@ -333,6 +380,7 @@ Originally Released As: track:love-song
 Duration: '3:54'
 URLs:
 - https://psycholonials.bandcamp.com/track/love-song-2
+- https://www.youtube.com/watch?v=VbEBQnWlC50
 - https://open.spotify.com/track/51KqiAops6wegL9HBWNZI3
 ---
 Track: 'Ephemeral Muse: Final Remix'
@@ -341,6 +389,7 @@ Originally Released As: track:ephemeral-muse-final-remix
 Duration: '4:08'
 URLs:
 - https://psycholonials.bandcamp.com/track/ephemeral-muse-final-remix-2
+- https://www.youtube.com/watch?v=icM0NtYYw5s
 - https://open.spotify.com/track/3oIQx0z9rNmEew41Ruxinb
 ---
 Section: Bonus tracks
@@ -352,6 +401,7 @@ Sampled Tracks:
 - track:someday-clark-powell
 URLs:
 - https://open.spotify.com/track/37viwKrZf0k5atmUR40D30
+- https://www.youtube.com/watch?v=xymjuAktP7o
 Review Points:
 - Date Recorded: March 24, 2024
   Field: Sampled Tracks

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -15342,8 +15342,8 @@ URLs:
 ---
 Track: Here Comes Santa Claus
 Artists:
-- Oakley Haldeman
-- Gene Autry
+- Gene Autry (lyrics, performance)
+- Oakley Haldeman (composition)
 Duration: '2:34'
 URLs:
 - https://www.youtube.com/watch?v=U6kRYKvWF1E
@@ -16159,59 +16159,6 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=quxTnEEETbo
 ---
-Track: Santa Claus Is Comin' to Town
-Artists:
-- John Frederick Coots
-- Haven Gillespie
-URLs:
-- https://www.youtube.com/watch?v=zFSVT8PFyI8
-Lyrics: |-
-    I've just come back from a lovely trip
-    Along the Milky Way
-    I stopped off at the North Pole
-    To spend the holiday
-
-    I called on dear old Santa Claus
-    To see what I could see
-    He took me to his workshop
-    And told his plan to me
-
-    So you better watch out
-    You better not cry
-    You better not pout
-    I'm telling you why
-    Santa Claus is comin' to town
-
-    He's making a list
-    Checking it twice
-    Gonna find out who's naughty or nice
-    Santa Claus is comin' to town
-
-    He sees you when you're sleeping
-    He knows when you're awake
-    He knows if you've been good or bad
-    So be good for goodness' sake
-
-    Oh you better watch out
-    You better not cry
-    You better not pout
-    I'm telling you why
-    Santa Claus is comin' to town
-
-    Oh you better watch out
-    You better not cry
-    You better not pout
-    I'm telling you why
-    Santa Claus is comin' to town
-Commentary: |-
-    <i>Niklink:</i> (wiki editor)
-
-    The lyrics may be a little different to what you're used to, but they correspond to the first recording of this carol by Harry Reser.
-
-    <i>Quasar Nebula:</i> (wiki editor)
-
-    [For a very long time,](https://web.archive.org/web/20130111060110/http://xzazupsilon.webs.com/nsnd.html) listed as referenced during the introduction of [[track:gog-rest-ye-merry-prospitians]]; this appears to be [[track:here-comes-santa-claus]] instead.
----
 Track: Shchedryk
 Artists:
 - Mykola Leontovych
@@ -16792,55 +16739,50 @@ URLs:
 Commentary: |-
     <i>Niklink:</i> (wiki editor)
     Also known as the "Westminster Chimes", "Cambridge Quarters", or "Cambridge Chimes". While the task of composing the chimes was given to Joseph Jowett in 1793, it's believed that he was probably assisted by either John Randall or William Crotch.
-# ---
-# Track: When Johnny Comes Marching Home
-#
-#   # Used to be referenced by Land of Sand and Rails,
-#   # presently orphaned. See #hsmusic-chat:
-#   # https://discord.com/channels/749042497610842152/779895315750715422/1199169695908118600
-#
-# Artists:
-# - Patrick Gilmore
-# URLs:
-# - https://www.youtube.com/watch?v=WtEqgG2EdTs
-# Referenced Tracks:
-# - Johnny Fill Up the Bowl
-# Lyrics: |-
-#     When Johnny comes marching home again
-#     Hurrah! Hurrah!
-#     We'll give him a hearty welcome then
-#     Hurrah! Hurrah!
-#     The men will cheer and the boys will shout
-#     The ladies they will all turn out
-#     And we'll all feel gay
-#     When Johnny comes marching home
-#
-#     The old church bell will peal with joy
-#     Hurrah! Hurrah!
-#     To welcome home our darling boy
-#     Hurrah! Hurrah!
-#     The village lads and lassies say
-#     With roses they will strew the way
-#     And we'll all feel gay
-#     When Johnny comes marching home
-#
-#     Get ready for the Jubilee
-#     Hurrah! Hurrah!
-#     We'll give the hero three times three
-#     Hurrah! Hurrah!
-#     The laurel wreath is ready now
-#     To place upon his loyal brow
-#     And we'll all feel gay
-#     When Johnny comes marching home
-#
-#     Let love and friendship on that day
-#     Hurrah, hurrah!
-#     Their choicest pleasures then display
-#     Hurrah, hurrah!
-#     And let each one perform some part
-#     To fill with joy the warrior's heart
-#     And we'll all feel gay
-#     When Johnny comes marching home
+---
+Track: When Johnny Comes Marching Home
+Artists:
+- Patrick Gilmore
+URLs:
+- https://www.youtube.com/watch?v=WtEqgG2EdTs
+Referenced Tracks:
+- Johnny Fill Up the Bowl
+Lyrics: |-
+    When Johnny comes marching home again
+    Hurrah! Hurrah!
+    We'll give him a hearty welcome then
+    Hurrah! Hurrah!
+    The men will cheer and the boys will shout
+    The ladies they will all turn out
+    And we'll all feel gay
+    When Johnny comes marching home
+
+    The old church bell will peal with joy
+    Hurrah! Hurrah!
+    To welcome home our darling boy
+    Hurrah! Hurrah!
+    The village lads and lassies say
+    With roses they will strew the way
+    And we'll all feel gay
+    When Johnny comes marching home
+
+    Get ready for the Jubilee
+    Hurrah! Hurrah!
+    We'll give the hero three times three
+    Hurrah! Hurrah!
+    The laurel wreath is ready now
+    To place upon his loyal brow
+    And we'll all feel gay
+    When Johnny comes marching home
+
+    Let love and friendship on that day
+    Hurrah, hurrah!
+    Their choicest pleasures then display
+    Hurrah, hurrah!
+    And let each one perform some part
+    To fill with joy the warrior's heart
+    And we'll all feel gay
+    When Johnny comes marching home
 ---
 Track: Yama No Ongakuka
 Artists:

--- a/album/reminders-of-you-beta.yaml
+++ b/album/reminders-of-you-beta.yaml
@@ -3,7 +3,7 @@ Date: March 22, 2021
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/reminders-of-you-beta
-- https://music.deconreconstruction.com/albums/reminders-of-you-beta
+# - https://music.deconreconstruction.com/albums/reminders-of-you-beta
 Artists:
 - Alex Votl
 Cover Artists:
@@ -19,19 +19,19 @@ Track: 'SIDE 1: Who You Were [Beta]'
 Duration: '02:15'
 URLs:
 - https://vasterror.bandcamp.com/track/side-1-who-you-were-beta
-- https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=side-1-who-you-were-beta
+# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=side-1-who-you-were-beta
 ---
 Track: 'Loss Of Innocence [Beta]'
 Duration: '04:09'
 URLs:
 - https://vasterror.bandcamp.com/track/loss-of-innocence-beta
-- https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=loss-of-innocence-beta
+# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=loss-of-innocence-beta
 ---
 Track: 'Still Here [Beta]'
 Duration: '03:21'
 URLs:
 - https://vasterror.bandcamp.com/track/still-here-beta
-- https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=still-here-beta
+# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=still-here-beta
 ---
 Track: 'Fixer-Upper [Beta]'
 Duration: '03:15'
@@ -39,7 +39,7 @@ Sampled Tracks:
 - SFX from Super Smash Bros
 URLs:
 - https://vasterror.bandcamp.com/track/fixer-upper-beta
-- https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=fixer-upper-beta
+# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=fixer-upper-beta
 ---
 Track: 'Face Yourself [Beta]'
 Duration: '03:44'
@@ -48,4 +48,4 @@ Referenced Tracks:
 - track:faint-linkin-park
 URLs:
 - https://vasterror.bandcamp.com/track/side-1-who-you-were-beta
-- https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=face-yourself-beta
+# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=face-yourself-beta

--- a/album/reminders-of-you-beta.yaml
+++ b/album/reminders-of-you-beta.yaml
@@ -1,5 +1,4 @@
 Album: 'Reminders Of You [Beta]'
-Directory: reminders-of-you-beta
 Date: March 22, 2021
 Date Added: October 25, 2023
 URLs:

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -5,7 +5,7 @@ Artists:
 - pragmaticNihilist
 URLs:
 - https://vasterror.bandcamp.com/album/repiton
-- https://music.deconreconstruction.com/albums/repiton
+# - https://music.deconreconstruction.com/albums/repiton
 Cover Artists:
 - Xamag
 Cover Art File Extension: png
@@ -23,7 +23,7 @@ Always Reference By Directory: true
 Duration: '3:56'
 URLs:
 - https://vasterror.bandcamp.com/track/methodology
-- https://music.deconreconstruction.com/albums/repiton?track=methodology
+# - https://music.deconreconstruction.com/albums/repiton?track=methodology
 ---
 Track: Day After Day
 Cover Artists:
@@ -33,7 +33,7 @@ Art Tags:
 Duration: '4:20'
 URLs:
 - https://vasterror.bandcamp.com/track/day-after-day
-- https://music.deconreconstruction.com/albums/repiton?track=day-after-day
+# - https://music.deconreconstruction.com/albums/repiton?track=day-after-day
 ---
 Track: Moment's Notice
 Cover Artists:
@@ -43,7 +43,7 @@ Art Tags:
 Duration: '3:37'
 URLs:
 - https://vasterror.bandcamp.com/track/moments-notice
-- https://music.deconreconstruction.com/albums/repiton?track=moments-notice
+# - https://music.deconreconstruction.com/albums/repiton?track=moments-notice
 ---
 Track: Suckerpunch
 Cover Artists:
@@ -53,7 +53,7 @@ Art Tags:
 Duration: '4:21'
 URLs:
 - https://vasterror.bandcamp.com/track/suckerpunch
-- https://music.deconreconstruction.com/albums/repiton?track=suckerpunch
+# - https://music.deconreconstruction.com/albums/repiton?track=suckerpunch
 ---
 Track: That's Right!
 Cover Artists:
@@ -63,7 +63,7 @@ Art Tags:
 Duration: '3:22'
 URLs:
 - https://vasterror.bandcamp.com/track/thats-right
-- https://music.deconreconstruction.com/albums/repiton?track=thats-right
+# - https://music.deconreconstruction.com/albums/repiton?track=thats-right
 Referenced Tracks:
 - track:september-earth-wind-fire
 Sampled Tracks:
@@ -81,7 +81,7 @@ Referenced Tracks:
 - Radioactive Ore
 URLs:
 - https://vasterror.bandcamp.com/track/survival
-- https://music.deconreconstruction.com/albums/repiton?track=survival
+# - https://music.deconreconstruction.com/albums/repiton?track=survival
 ---
 Track: Home
 Directory: home-repiton
@@ -90,14 +90,14 @@ Cover Artists:
 Duration: '2:08'
 URLs:
 - https://vasterror.bandcamp.com/track/home
-- https://music.deconreconstruction.com/albums/repiton?track=home
+# - https://music.deconreconstruction.com/albums/repiton?track=home
 ---
 Track: 'INTERMISSION: Risk'
 Directory: risk-vast-error
 Duration: '4:17'
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-risk
-- https://music.deconreconstruction.com/albums/repiton?track=intermission-risk
+# - https://music.deconreconstruction.com/albums/repiton?track=intermission-risk
 ---
 Track: Moonlight
 Directory: moonlight-repiton
@@ -107,7 +107,7 @@ Cover Artists:
 Duration: '3:01'
 URLs:
 - https://vasterror.bandcamp.com/track/moonlight
-- https://music.deconreconstruction.com/albums/repiton?track=moonlight
+# - https://music.deconreconstruction.com/albums/repiton?track=moonlight
 ---
 Track: Through It All
 Cover Artists:
@@ -115,7 +115,7 @@ Cover Artists:
 Duration: '4:37'
 URLs:
 - https://vasterror.bandcamp.com/track/through-it-all
-- https://music.deconreconstruction.com/albums/repiton?track=through-it-all
+# - https://music.deconreconstruction.com/albums/repiton?track=through-it-all
 ---
 Track: Tyrant
 Directory: tyrant-repiton
@@ -126,7 +126,7 @@ Referenced Tracks:
 - track:oversaturated-vast-error
 URLs:
 - https://vasterror.bandcamp.com/track/tyrant
-- https://music.deconreconstruction.com/albums/repiton?track=tyrant
+# - https://music.deconreconstruction.com/albums/repiton?track=tyrant
 ---
 Track: Take The Shot
 Cover Artists:
@@ -136,7 +136,7 @@ Art Tags:
 Duration: '3:38'
 URLs:
 - https://vasterror.bandcamp.com/track/take-the-shot
-- https://music.deconreconstruction.com/albums/repiton?track=take-the-shot
+# - https://music.deconreconstruction.com/albums/repiton?track=take-the-shot
 ---
 Track: Nailed It
 Cover Artists:
@@ -144,7 +144,7 @@ Cover Artists:
 Duration: '3:22'
 URLs:
 - https://vasterror.bandcamp.com/track/nailed-it
-- https://music.deconreconstruction.com/albums/repiton?track=nailed-it
+# - https://music.deconreconstruction.com/albums/repiton?track=nailed-it
 ---
 Track: Remember?
 Directory: remember-repiton
@@ -153,7 +153,7 @@ Cover Artists:
 Duration: '3:10'
 URLs:
 - https://vasterror.bandcamp.com/track/remember
-- https://music.deconreconstruction.com/albums/repiton?track=remember
+# - https://music.deconreconstruction.com/albums/repiton?track=remember
 ---
 Track: Promise
 Directory: promise-repiton
@@ -164,7 +164,7 @@ Cover Art File Extension: jpg
 Duration: '3:03'
 URLs:
 - https://vasterror.bandcamp.com/track/promise
-- https://music.deconreconstruction.com/albums/repiton?track=promise
+# - https://music.deconreconstruction.com/albums/repiton?track=promise
 ---
 Track: Only The Beginning
 Cover Artists:
@@ -174,7 +174,7 @@ Art Tags:
 Duration: '6:59'
 URLs:
 - https://vasterror.bandcamp.com/track/only-the-beginning
-- https://music.deconreconstruction.com/albums/repiton?track=only-the-beginning
+# - https://music.deconreconstruction.com/albums/repiton?track=only-the-beginning
 ---
 Section: Bonus track
 ---
@@ -191,4 +191,4 @@ Additional Names:
 Duration: '2:39'
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-where-to-now
-- https://music.deconreconstruction.com/albums/repiton?track=bonus-where-to-now
+# - https://music.deconreconstruction.com/albums/repiton?track=bonus-where-to-now

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -1,5 +1,4 @@
 Album: Repiton
-Directory: repiton
 Date: May 25, 2018
 Date Added: October 25, 2023
 Artists:

--- a/album/running-for-eons.yaml
+++ b/album/running-for-eons.yaml
@@ -3,7 +3,7 @@ Date: February 2, 2018
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/running-for-eons
-- https://music.deconreconstruction.com/albums/running-for-eons
+# - https://music.deconreconstruction.com/albums/running-for-eons
 Cover Artists:
 - tajazzled
 Cover Art File Extension: png
@@ -43,7 +43,7 @@ Sampled Tracks:
 - Dialogue Fear and Loathing in Las Vegas
 URLs:
 - https://vasterror.bandcamp.com/track/deep-sea-trouble
-- https://music.deconreconstruction.com/albums/running-for-eons?track=deep-sea-trouble
+# - https://music.deconreconstruction.com/albums/running-for-eons?track=deep-sea-trouble
 ---
 Track: Mind In The Shutter
 Artists:
@@ -63,7 +63,7 @@ Sampled Tracks:
 - Hanna-Barbera SFX
 URLs:
 - https://vasterror.bandcamp.com/track/mind-in-the-shutter
-- https://music.deconreconstruction.com/albums/running-for-eons?track=mind-in-the-shutter
+# - https://music.deconreconstruction.com/albums/running-for-eons?track=mind-in-the-shutter
 ---
 Track: Royale With Cheese
 Artists:
@@ -85,4 +85,4 @@ Sampled Tracks:
 - Shinji's Rant from Neon Genesis Evangelion
 URLs:
 - https://vasterror.bandcamp.com/track/royale-with-cheese
-- https://music.deconreconstruction.com/albums/running-for-eons?track=royale-with-cheese
+# - https://music.deconreconstruction.com/albums/running-for-eons?track=royale-with-cheese

--- a/album/running-for-eons.yaml
+++ b/album/running-for-eons.yaml
@@ -1,5 +1,4 @@
 Album: Running For Eons
-Directory: running-for-eons
 Date: February 2, 2018
 Date Added: October 25, 2023
 URLs:

--- a/album/s-forgive.yaml
+++ b/album/s-forgive.yaml
@@ -17,6 +17,10 @@ Art Tags:
 - Earth
 Cover Art File Extension: png
 Wallpaper File Extension: png
+Wallpaper Style: |-
+    opacity: 0.4;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Color: '#F4D23A'
 Groups:
 - Fandom

--- a/album/skaias-the-limit.yaml
+++ b/album/skaias-the-limit.yaml
@@ -183,6 +183,7 @@ Commentary: |-
 ---
 Track: I'm A Member of the Midnight Crew
 Directory: im-a-member-of-the-midnight-crew-sahcon
+Always Reference By Directory: true
 Duration: '2:18'
 Artists:
 - Sonnivate

--- a/album/soul-of-sovereignty-prelude-ost.yaml
+++ b/album/soul-of-sovereignty-prelude-ost.yaml
@@ -10,6 +10,7 @@ Cover Artists:
 - ggdg
 Cover Art File Extension: png
 Wallpaper File Extension: png
+Wallpaper Style: 'opacity: 0.65;'
 Wallpaper Artists:
 - ggdg
 Color: '#8FB5D9'

--- a/album/stable-time-loops-and-paradoxes.yaml
+++ b/album/stable-time-loops-and-paradoxes.yaml
@@ -6,6 +6,7 @@ URLs:
 - https://www.youtube.com/playlist?list=PLtcgklmZsk9C-zU_MOKHdizqkW8uhlATJ
 Cover Artists:
 - Culdhira
+Track Art File Extension: png
 # started by Celeste (until Delirious Biznasty, but Tranquil Downpour had just been started), continued & finished by Lilith
 # it's fair to say that it's from us both
 Art Tags:
@@ -97,6 +98,7 @@ Art Tags:
 Duration: '2:59'
 URLs:
 - https://www.youtube.com/watch?v=7FSsG2AF12M
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:under-the-hat
 MIDI Project Files:
@@ -121,6 +123,7 @@ Art Tags:
 Duration: '2:40'
 URLs:
 - https://www.youtube.com/watch?v=CyvbG6L0IDU
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:penumbra-phantasm
 Commentary: |-
@@ -129,8 +132,6 @@ Commentary: |-
     This song has been in the works for a very long time. The better part of a year, in fact. It went through a LOT of different iterations and versions (at one point even being part of an Undertale fan game that was unfortunately canceled) before landing where it is now. I finally decided to finish it and let the little bird fly for this album. Fun fact: It was originally titled "Penumbra Phantasm (Frosty Edition)," but then, thanks to a typo from [[artist:pascal-van-den-bos|PotatoBoss]], the "Edition" changed to "Style," and, honestly, I prefer it this way. Go figure, there would be one last change to the song before it was finally finished.
 ---
 Track: Solicide
-Directory: solicide-stlap
-Always Reference By Directory: true
 Artists:
 - Caelan Kier
 Cover Artists:
@@ -173,6 +174,7 @@ Art Tags:
 Duration: '4:13'
 URLs:
 - https://www.youtube.com/watch?v=1VhMGErwclI
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:sburban-jungle
 - track:showtime-original-mix
@@ -231,6 +233,7 @@ Art Tags:
 Duration: '2:03'
 URLs:
 - https://www.youtube.com/watch?v=JLLIa558rug
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:doctor
 MIDI Project Files:
@@ -315,14 +318,13 @@ Art Tags:
 Duration: '2:21'
 URLs:
 - https://www.youtube.com/watch?v=k_-P6O_n1co
+Cover Art File Extension: jpg
 Commentary: |-
     <i>Frost Carter:</i> (composer, booklet commentary)
 
     This song just kinda exists. I don't really remember initially making it. Maybe it magically appeared one day, ascended from Heaven to change the world and herald the 2nd coming of Christ himself. Or maybe I made it in the middle of the night on 0 sleep and forgot. Whichever you perfer. I won't make the choice for you. I'm not your mom.
 ---
 Track: Petrichor
-Directory: petrichor-stlap
-Always Reference By Directory: true
 Artists:
 - Caelan Kier
 Cover Artists:
@@ -350,6 +352,7 @@ Art Tags:
 Duration: '2:14'
 URLs:
 - https://www.youtube.com/watch?v=JuRLjkv6zUU
+Cover Art File Extension: jpg
 MIDI Project Files:
 - Title: MIDI by Pascal van den Bos (original composer)
   Files:
@@ -367,6 +370,7 @@ Cover Artists:
 Duration: '2:01'
 URLs:
 - https://www.youtube.com/watch?v=v2FaG_2hRjM
+Cover Art File Extension: jpg
 MIDI Project Files:
 - Title: MIDI by Pascal van den Bos (original composer)
   Files:
@@ -496,6 +500,7 @@ Art Tags:
 Duration: '1:27'
 URLs:
 - https://www.youtube.com/watch?v=P5htg-xI20M
+Cover Art File Extension: jpg
 MIDI Project Files:
 - Title: MIDI by Pascal van den Bos (original composer)
   Files:
@@ -569,6 +574,7 @@ Art Tags:
 Duration: '2:50'
 URLs:
 - https://www.youtube.com/watch?v=_ArcwQzg9lE
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:explore
 Commentary: |-
@@ -601,6 +607,7 @@ Art Tags:
 Duration: '6:58'
 URLs:
 - https://www.youtube.com/watch?v=bM-xp_8g62M
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:killed-by-br8k-spider
 Commentary: |-
@@ -609,7 +616,6 @@ Commentary: |-
     A pretty long one, and i guess it's kind of a non cannon afterwards to [[flash:8087|collide]] in my mind. I refrained from using leomotifs because I honestly don't think this song needs it. Now if you watched collide, it never actually showed them killing lord English right? Well this is in my mind the battle theme to what happened there. If you want you can watch the YouTube theories but simply put, after collide vriska summons more powerful beta (and possibly alpha) kids out of her sburb house thingy. So basically it beta kids, vriska and the ghost army vs lord English. And thats the song. I considered calling it "collide v3" but i felt it was too obvious.
 ---
 Track: LOWAS M.D.
-Directory: lowas-m-d
 Artists:
 - Frost Carter
 Cover Artists:
@@ -662,6 +668,7 @@ Art Tags:
 Duration: '3:00'
 URLs:
 - https://www.youtube.com/watch?v=9GIsMmaBTUg
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:mutiny
 - track:beatdown-strider-style
@@ -791,6 +798,7 @@ Art Tags:
 Duration: '4:13'
 URLs:
 - https://www.youtube.com/watch?v=mBcIMWZULF4
+Cover Art File Extension: jpg
 Referenced Tracks:
 - track:showtime-original-mix
 - track:three-in-the-morning

--- a/album/stable-time-loops-and-paradoxes.yaml
+++ b/album/stable-time-loops-and-paradoxes.yaml
@@ -7,8 +7,6 @@ URLs:
 Cover Artists:
 - Culdhira
 Track Art File Extension: png
-# started by Celeste (until Delirious Biznasty, but Tranquil Downpour had just been started), continued & finished by Lilith
-# it's fair to say that it's from us both
 Art Tags:
 - John
 - Rose
@@ -19,7 +17,7 @@ Art Tags:
 - Dirk
 - Jake
 - LoWaS
-Color: '#7cf2fc'
+Color: '#77d9f4'
 Groups:
 - The Paradox Music Team
 - Fandom
@@ -139,7 +137,6 @@ Cover Artists:
 Art Tags:
 - Rose
 - Green Sun
-# - Thorns of Oglogoth
 Duration: '2:59'
 URLs:
 - https://www.youtube.com/watch?v=MUUpyZPWbew
@@ -184,7 +181,7 @@ Referenced Tracks:
 - track:beatdown-strider-style
 - track:mutiny
 - track:lotus
-- track:black
+- track:liquid-negrocity
 - Courser
 - track:cascade-beta
 - track:spiders-claw
@@ -193,8 +190,6 @@ Referenced Tracks:
 - Crystalanthemums
 - track:upward-movement-dave-owns
 - Another Jungle
-- track:MeGaLoVania
-#unsure of where Megalovania (or MeGaLoVania is referenced, but everything else should be fine
 Commentary: |-
     <i>apatheticPianist:</i> (composer, booklet commentary)
 
@@ -228,8 +223,6 @@ Cover Artists:
 Art Tags:
 - John
 - Dave
-# - Warhammer of Zillyhoo
-# - Caledfwlch
 Duration: '2:03'
 URLs:
 - https://www.youtube.com/watch?v=JLLIa558rug
@@ -597,13 +590,6 @@ Art Tags:
 - Jade
 - Lord English
 - Victory Platform
-# - Light
-# - Breath
-# - Time
-# - Space
-# - Caledfwlch
-# - Pop-a-matic Vrillyhoo Hammer
-# - Quills of Echidna
 Duration: '6:58'
 URLs:
 - https://www.youtube.com/watch?v=bM-xp_8g62M
@@ -782,15 +768,6 @@ Art Tags:
 - The Condesce
 - Lord English
 - The Felt
-# - Unbreakable Katana
-# - Dragon Cane
-# - Caledfwlch
-# - Pop-a-matic Vrillyhoo Hammer
-# - Quills of Echidna
-# - Chainsaw
-# - Fork
-# - Homes Smell Ya Later
-# - Flintlocks of Zillyhau
 - LoTaK
 - Derse
 - LoFaF

--- a/album/stuck-funkin-demo-ost.yaml
+++ b/album/stuck-funkin-demo-ost.yaml
@@ -10,6 +10,7 @@ Art Tags:
 - AH
 - Boyfriend (Friday Night Funkin')
 - Lord English
+Wallpaper Style: 'opacity: 0.4;'
 Wallpaper File Extension: png
 Cover Art File Extension: jpg
 Track Art File Extension: jpg

--- a/album/super-smash-bros-ultimate.yaml
+++ b/album/super-smash-bros-ultimate.yaml
@@ -8,6 +8,7 @@ Cover Artists:
 - Yusuke Nakano ##https://www.ndw.jp/smashsp-illust_hiwa/
 Wallpaper Artists:
 - Yusuke Nakano ##https://www.ndw.jp/smashsp-illust_hiwa/
+Wallpaper Style: 'opacity: 0.45;'
 Color: '#f20d0d'
 Groups:
 - Beyond

--- a/album/team-paradox.yaml
+++ b/album/team-paradox.yaml
@@ -146,6 +146,17 @@ Cover Artists:
 - Team Paradox
 Art Tags:
 - Consorts
+Referenced Tracks:
+- When Johnny Comes Marching Home
+Review Points:
+- Date Recorded: April 10, 2024
+  Field: Referenced Tracks
+  Notes: |-
+    Possibly not referencing When Johnny Comes Marching Home
+  Reference Discussions:
+  - Date: January 22, 2024
+    Annotation: "#hsmusic-chat"
+    URL: https://discord.com/channels/749042497610842152/779895315750715422/1199169695908118600
 ---
 Track: Belt of Venus
 Artists:

--- a/album/the-gap.yaml
+++ b/album/the-gap.yaml
@@ -9,7 +9,10 @@ Artists:
 Cover Artists:
 - horizon
 Cover Art File Extension: png
-Wallpaper File Extension: png
+Wallpaper Style: |-
+    opacity: 0.6;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
 Wallpaper Artists:
 - horizon
 - Jebb (edits for wiki)

--- a/album/the-rebornening.yaml
+++ b/album/the-rebornening.yaml
@@ -1,5 +1,4 @@
 Album: THE REBORNENING
-Directory: the-rebornening
 Date: January 25, 2017
 Date Added: October 25, 2023
 URLs:

--- a/album/unbeatable-demo-tapes.yaml
+++ b/album/unbeatable-demo-tapes.yaml
@@ -21,6 +21,7 @@ Additional Files:
   - bg.gif
 Commentary: |-
     <i>peak divide:</i> ([Bandcamp about blurb](https://peakdivide.bandcamp.com/album/unbeatable-demo-tapes))
+
     Includes instrumentals for tracks 2-8 as bonus tracks.
 
     UNBEATABLE: DEMO TAPES is the official soundtrack for UNBEATABLE [white label] - a special episode set in the world of UNBEATABLE. We will be updating DEMO TAPES with new music each time [white label] is updated, so please check back regularly!
@@ -31,6 +32,18 @@ Commentary: |-
     DEMO TAPES is separate from the final UNBEATABLE soundtrack, which will be released when UNBEATABLE is complete. All mixes presented in DEMO TAPES are not final and are subject to change in the full game.
 
     [unbeatablegame.com](https://www.unbeatablegame.com)
+
+    <i>peak divide:</i> ([Bandcamp credits blurb](https://peakdivide.bandcamp.com/album/unbeatable-demo-tapes))
+
+    [[artist:peak-divide|peak divide:]]<br>
+    [[artist:clara-maddux|Clara Maddux]] - composition, arrangement, guitars, bass, drums, lyrics<br>
+    [[artist:vasily-nikolaev|Vasily Nikolaev]] - composition, arrangement, synths, mixing, mastering
+
+    [[artist:rachel-lake|Rachel Lake]] - vocals, composition<br>
+    [[artist:robert-j-lake|RJ Lake]] - music supervision, lyrics, arrangement & composition on track 1 & 8<br>
+    [[artist:andrew-cleveland|Andrew Cleveland]] - guitar solo on track 2<br>
+    [[artist:derrick-lightning|Derrick Lightning]] - saxophone on track 9<br>
+    [[artist:andrew-tsai|Andrew Tsai]] - cover art design
 ---
 Section: Main Album
 ---

--- a/album/vast-error-vol-1-3.yaml
+++ b/album/vast-error-vol-1-3.yaml
@@ -1,5 +1,4 @@
 Album: Vast Error Vol. 1-3
-Directory: vast-error-vol-1-3
 Date: June 1, 2021
 Date Added: August 18, 2023
 Wallpaper Style: 'opacity: 0.85;'

--- a/album/vast-error-vol-1-3.yaml
+++ b/album/vast-error-vol-1-3.yaml
@@ -8,7 +8,7 @@ Wallpaper Artists:
 - artist:kobacat
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-1-3
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3
 Cover Artists:
 - Sparaze
 - Joyfulldreams
@@ -29,7 +29,7 @@ Cover Artists:
 Duration: '01:12'
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=the-static
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=the-static
 ---
 Track: Curtain Call
 Directory: curtain-call-vol-1-3
@@ -39,7 +39,7 @@ Cover Artists:
 Duration: '01:37'
 URLs:
 - https://vasterror.bandcamp.com/track/curtain-call-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=curtain-call
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=curtain-call
 ---
 Track: Blood Right
 Directory: blood-right-vol-1-3
@@ -49,7 +49,7 @@ Cover Artists:
 Duration: '03:35'
 URLs:
 - https://vasterror.bandcamp.com/track/blood-right-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=blood-right
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=blood-right
 ---
 Track: Cosmic Significance
 Directory: cosmic-significance-vol-1-3
@@ -59,7 +59,7 @@ Cover Artists:
 Duration: '03:53'
 URLs:
 - https://vasterror.bandcamp.com/track/cosmic-significance-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=cosmic-significance
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=cosmic-significance
 ---
 Track: Star Children
 Directory: star-children-vol-1-3
@@ -69,7 +69,7 @@ Cover Artists:
 Duration: '03:37'
 URLs:
 - https://vasterror.bandcamp.com/track/star-children-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=star-children
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=star-children
 ---
 Track: A New World
 Directory: a-new-world-vol-1-3
@@ -79,7 +79,7 @@ Cover Artists:
 Duration: '01:42'
 URLs:
 - https://vasterror.bandcamp.com/track/a-new-world-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=a-new-world
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=a-new-world
 ---
 Track: Razzmatazz
 Directory: razzmatazz-vol-1-3
@@ -89,7 +89,7 @@ Cover Artists:
 Duration: '02:16'
 URLs:
 - https://vasterror.bandcamp.com/track/razzmatazz-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=razzmatazz
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=razzmatazz
 ---
 Track: Mammory Master
 Directory: mammory-master-vol-1-3
@@ -99,7 +99,7 @@ Cover Artists:
 Duration: '01:45'
 URLs:
 - https://vasterror.bandcamp.com/track/mammory-master-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mammory-master
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mammory-master
 ---
 Track: Striving For A Future
 Directory: striving-for-a-future-vol-1-3
@@ -111,7 +111,7 @@ Art Tags:
 Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/striving-for-a-future-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=striving-for-a-future
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=striving-for-a-future
 ---
 Track: A Very Active Imagination
 Directory: a-very-active-imagination-vol-1-3
@@ -121,7 +121,7 @@ Cover Artists:
 Duration: '03:38'
 URLs:
 - https://vasterror.bandcamp.com/track/a-very-active-imagination-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=a-very-active-imagination
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=a-very-active-imagination
 ---
 Track: Bias
 Directory: bias-vol-1-3
@@ -131,7 +131,7 @@ Cover Artists:
 Duration: '03:00'
 URLs:
 - https://vasterror.bandcamp.com/track/bias-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=bias
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=bias
 ---
 Track: Six By Six
 Directory: six-by-six-vol-1-3
@@ -141,7 +141,7 @@ Cover Artists:
 Duration: '02:48'
 URLs:
 - https://vasterror.bandcamp.com/track/six-by-six-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=six-by-six
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=six-by-six
 ---
 Track: Ferocity Weaving
 Directory: ferocity-weaving-vol-1-3
@@ -151,7 +151,7 @@ Cover Artists:
 Duration: '05:02'
 URLs:
 - https://vasterror.bandcamp.com/track/ferocity-weaving-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=ferocity-weaving
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=ferocity-weaving
 ---
 Track: Radioactive Ore
 Directory: radioactive-ore-vol-1-3
@@ -163,7 +163,7 @@ Art Tags:
 Duration: '02:36'
 URLs:
 - https://vasterror.bandcamp.com/track/radioactive-ore-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=radioactive-ore
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=radioactive-ore
 ---
 Track: Starry Night
 Directory: starry-night-vol-1-3
@@ -173,7 +173,7 @@ Cover Artists:
 Duration: '01:37'
 URLs:
 - https://vasterror.bandcamp.com/track/starry-night-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=starry-night
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=starry-night
 ---
 Track: Clamor
 Directory: clamor-vast-error
@@ -184,7 +184,7 @@ Cover Artists:
 Duration: '01:53'
 URLs:
 - https://vasterror.bandcamp.com/track/clamor-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=clamor
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=clamor
 Referenced Tracks:
 - Sortir
 ---
@@ -196,7 +196,7 @@ Cover Artists:
 Duration: '01:40'
 URLs:
 - https://vasterror.bandcamp.com/track/song-for-the-lost-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=song-for-the-lost
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=song-for-the-lost
 ---
 Track: Woof-
 Directory: woof-vol-1-3
@@ -206,7 +206,7 @@ Cover Artists:
 Duration: '03:17'
 URLs:
 - https://vasterror.bandcamp.com/track/woof-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=woof-
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=woof-
 ---
 Track: Sunrise
 Directory: sunrise-vol-1-3
@@ -216,7 +216,7 @@ Cover Artists:
 Duration: '03:18'
 URLs:
 - https://vasterror.bandcamp.com/track/sunrise-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sunrise
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sunrise
 ---
 Track: J-Jitterbug
 Directory: j-jitterbug-vol-1-3
@@ -226,7 +226,7 @@ Cover Artists:
 Duration: '02:00'
 URLs:
 - https://vasterror.bandcamp.com/track/j-jitterbug-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=j-jitterbug
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=j-jitterbug
 ---
 Track: Extra Worse
 Directory: extra-worse-vol-1-3
@@ -236,7 +236,7 @@ Cover Artists:
 Duration: '01:44'
 URLs:
 - https://vasterror.bandcamp.com/track/extra-worse-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=extra-worse
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=extra-worse
 ---
 Track: On Repeat
 Directory: on-repeat-vol-1-3
@@ -246,7 +246,7 @@ Cover Artists:
 Duration: '02:14'
 URLs:
 - https://vasterror.bandcamp.com/track/on-repeat
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=on-repeat
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=on-repeat
 ---
 Track: Commercial Break
 Directory: commercial-break-vol-1-3
@@ -256,7 +256,7 @@ Cover Artists:
 Duration: '03:20'
 URLs:
 - https://vasterror.bandcamp.com/track/commercial-break-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=commercial-break
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=commercial-break
 ---
 Track: 'INTERMISSION: Beyond The Wall'
 Directory: beyond-the-wall-vol-1-3
@@ -264,7 +264,7 @@ Originally Released As: Beyond the Wall (Intermission)
 Duration: '03:13'
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-beyond-the-wall-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=intermission-beyond-the-wall
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=intermission-beyond-the-wall
 ---
 Track: Third Eye
 Directory: third-eye-vol-1-3
@@ -276,7 +276,7 @@ Art Tags:
 Duration: '02:25'
 URLs:
 - https://vasterror.bandcamp.com/track/third-eye-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=third-eye
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=third-eye
 ---
 Track: Oversaturated
 Directory: oversaturated-vol-1-3
@@ -286,7 +286,7 @@ Cover Artists:
 Duration: '04:27'
 URLs:
 - https://vasterror.bandcamp.com/track/oversaturated-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=oversaturated
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=oversaturated
 ---
 Track: Paint The Town Black
 Directory: paint-the-town-black-vol-1-3
@@ -296,7 +296,7 @@ Cover Artists:
 Duration: '02:59'
 URLs:
 - https://vasterror.bandcamp.com/track/paint-the-town-black-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=paint-the-town-black
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=paint-the-town-black
 ---
 Track: Final Bow
 Directory: final-bow-vol-1-3
@@ -306,7 +306,7 @@ Cover Artists:
 Duration: '02:10'
 URLs:
 - https://vasterror.bandcamp.com/track/final-bow-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=final-bow
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=final-bow
 ---
 Track: You'd Do It For Randolph Scott
 Directory: youd-do-it-for-randolph-scott-vol-1-3
@@ -316,7 +316,7 @@ Cover Artists:
 Duration: '01:36'
 URLs:
 - https://vasterror.bandcamp.com/track/youd-do-it-for-randolph-scott-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=youd-do-it-for-randolph-scott
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=youd-do-it-for-randolph-scott
 ---
 Track: Alone In The Rain
 Directory: alone-in-the-rain-vol-1-3
@@ -326,7 +326,7 @@ Cover Artists:
 Duration: '03:53'
 URLs:
 - https://vasterror.bandcamp.com/track/alone-in-the-rain-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=alone-in-the-rain
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=alone-in-the-rain
 ---
 Track: Poetic
 Directory: poetic-vol-1-3
@@ -336,7 +336,7 @@ Cover Artists:
 Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/poetic-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=poetic
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=poetic
 ---
 Track: Zehanpuryu
 Directory: zehanpuryu-vol-1-3
@@ -346,7 +346,7 @@ Cover Artists:
 Duration: '02:25'
 URLs:
 - https://vasterror.bandcamp.com/track/zehanpuryu-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=zehanpuryu
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=zehanpuryu
 ---
 Track: Revelations
 Directory: revelations-vol-1-3
@@ -356,7 +356,7 @@ Cover Artists:
 Duration: '02:21'
 URLs:
 - https://vasterror.bandcamp.com/track/revelations
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=revelations
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=revelations
 ---
 Track: The Day After Spring Began
 Directory: the-day-after-spring-began-vol-1-3
@@ -366,7 +366,7 @@ Cover Artists:
 Duration: '03:00'
 URLs:
 - https://vasterror.bandcamp.com/track/the-day-after-spring-began-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=the-day-after-spring-began
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=the-day-after-spring-began
 ---
 Track: Terran Wanderer
 Directory: terran-wanderer-vol-1-3
@@ -376,7 +376,7 @@ Cover Artists:
 Duration: '02:13'
 URLs:
 - https://vasterror.bandcamp.com/track/terran-wanderer-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=terran-wanderer
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=terran-wanderer
 ---
 Track: Invigorated Wasteland
 Directory: invigorated-wasteland-vol-1-3
@@ -386,7 +386,7 @@ Cover Artists:
 Duration: '02:24'
 URLs:
 - https://vasterror.bandcamp.com/track/invigorated-wasteland-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=invigorated-wasteland
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=invigorated-wasteland
 ---
 Track: Scarred For Life
 Directory: scarred-for-life-vol-1-3
@@ -396,7 +396,7 @@ Cover Artists:
 Duration: '02:30'
 URLs:
 - https://vasterror.bandcamp.com/track/scarred-for-life-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=scarred-for-life
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=scarred-for-life
 ---
 Track: Curtain Call (psithurist's "the game isn't sgrub" remix)
 Directory: curtain-call-remix-vol-1-3
@@ -406,7 +406,7 @@ Cover Artists:
 Duration: '02:26'
 URLs:
 - https://vasterror.bandcamp.com/track/curtain-call-psithurists-the-game-isnt-sgrub-remix-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=curtain-call-psithurists-the-game-isnt-sgrub-remix
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=curtain-call-psithurists-the-game-isnt-sgrub-remix
 ---
 Track: Polkafighter!
 Directory: polkafighter-vol-1-3
@@ -416,7 +416,7 @@ Cover Artists:
 Duration: '01:22'
 URLs:
 - https://vasterror.bandcamp.com/track/polkafighter-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=polkafighter
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=polkafighter
 ---
 Track: Mantle Piece
 Directory: mantle-piece-vol-1-3
@@ -426,7 +426,7 @@ Cover Artists:
 Duration: '04:28'
 URLs:
 - https://vasterror.bandcamp.com/track/mantle-piece-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mantle-piece
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mantle-piece
 ---
 Track: Mother Of The Stars
 Directory: mother-of-the-stars-vol-1-3
@@ -436,7 +436,7 @@ Cover Artists:
 Duration: '02:26'
 URLs:
 - https://vasterror.bandcamp.com/track/mother-of-the-stars-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mother-of-the-stars
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mother-of-the-stars
 ---
 Track: Sickly Green Glow
 Directory: sickly-green-glow-vol-1-3
@@ -446,7 +446,7 @@ Cover Artists:
 Duration: '02:42'
 URLs:
 - https://vasterror.bandcamp.com/track/sickly-green-glow-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sickly-green-glow
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sickly-green-glow
 ---
 Track: Waltz In The Static Void
 Directory: waltz-in-the-static-void-vol-1-3
@@ -456,7 +456,7 @@ Cover Artists:
 Duration: '01:54'
 URLs:
 - https://vasterror.bandcamp.com/track/waltz-in-the-static-void-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=waltz-in-the-static-void
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=waltz-in-the-static-void
 ---
 Track: Code Red And Existential Dread
 Directory: code-red-and-existential-dread-vol-1-3
@@ -466,7 +466,7 @@ Cover Artists:
 Duration: '04:06'
 URLs:
 - https://vasterror.bandcamp.com/track/code-red-and-existential-dread-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=code-red-and-existential-dread
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=code-red-and-existential-dread
 ---
 Track: Sortir
 Directory: sortir-vol-1-3
@@ -476,7 +476,7 @@ Cover Artists:
 Duration: '03:46'
 URLs:
 - https://vasterror.bandcamp.com/track/sortir-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sortir
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sortir
 ---
 Track: Vast Error
 Directory: vast-error-vol-1-3
@@ -486,7 +486,7 @@ Cover Artists:
 Duration: '04:08'
 URLs:
 - https://vasterror.bandcamp.com/track/vast-error-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=vast-error
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=vast-error
 ---
 Track: Ultima Hoc Fatum
 Directory: ultima-hoc-fatum-vol-1-3
@@ -496,7 +496,7 @@ Cover Artists:
 Duration: '06:09'
 URLs:
 - https://vasterror.bandcamp.com/track/ultima-hoc-fatum-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=ultima-hoc-fatum
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=ultima-hoc-fatum
 ---
 Track: Gone
 Directory: gone-vol-1-3
@@ -506,7 +506,7 @@ Cover Artists:
 Duration: '02:34'
 URLs:
 - https://vasterror.bandcamp.com/track/gone
-- https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=gone
+# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=gone
 ---
 Section: Download-only tracks
 ---

--- a/album/vast-error-vol-1.yaml
+++ b/album/vast-error-vol-1.yaml
@@ -1,5 +1,4 @@
 Album: Vast Error Vol. 1
-Directory: vast-error-vol-1
 Date: March 22, 2017
 Date Added: October 25, 2023
 URLs:

--- a/album/vast-error-vol-2.yaml
+++ b/album/vast-error-vol-2.yaml
@@ -1,5 +1,4 @@
 Album: Vast Error Vol. 2
-Directory: vast-error-vol-2
 Date: July 15, 2017
 Date Added: October 25, 2023
 URLs:

--- a/album/vast-error-vol-3.yaml
+++ b/album/vast-error-vol-3.yaml
@@ -1,5 +1,4 @@
 Album: Vast Error Vol. 3
-Directory: vast-error-vol-3
 Date: December 18, 2017
 Date Added: October 25, 2023
 URLs:

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -10,7 +10,7 @@ Banner Dimensions: 1100x216
 Banner File Extension: jpg
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-4
-- https://music.deconreconstruction.com/albums/vast-error-vol-4
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4
 Cover Artists:
 - TetraTheRipper
 Cover Art File Extension: png
@@ -32,7 +32,7 @@ Cover Artists:
 - big chalupa
 URLs:
 - https://vasterror.bandcamp.com/track/nostalgia
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nostalgia
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nostalgia
 ---
 Track: Road To Recovery
 Duration: '3:27'
@@ -42,7 +42,7 @@ Cover Artists:
 - Xamag
 URLs:
 - https://vasterror.bandcamp.com/track/road-to-recovery
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=road-to-recovery
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=road-to-recovery
 Commentary: |-
     <i>Xamag:</i> (track artist, alternate artwork)
 
@@ -58,7 +58,7 @@ Cover Artists:
 - SilentNeptune
 URLs:
 - https://vasterror.bandcamp.com/track/immortal
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=immortal
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=immortal
 ---
 Track: Air Exchange
 Duration: '3:34'
@@ -71,7 +71,7 @@ Referenced Tracks:
 - Zehanpuryu
 URLs:
 - https://vasterror.bandcamp.com/track/air-exchange
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=air-exchange
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=air-exchange
 ---
 Track: Radical Statical
 Duration: '2:37'
@@ -83,7 +83,7 @@ Referenced Tracks:
 - Mammory Master
 URLs:
 - https://vasterror.bandcamp.com/track/radical-statical
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=radical-statical
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=radical-statical
 ---
 Track: Predestination
 Directory: predestination-vast-error
@@ -98,7 +98,7 @@ Referenced Tracks:
 - A New Day
 URLs:
 - https://vasterror.bandcamp.com/track/predestination
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=predestination
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=predestination
 ---
 Track: Corporate
 Directory: corporate-vast-error
@@ -110,7 +110,7 @@ Cover Artists:
 - Spruik
 URLs:
 - https://vasterror.bandcamp.com/track/corporate
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=corporate
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=corporate
 ---
 Track: The Crucible
 Duration: '2:19'
@@ -120,7 +120,7 @@ Cover Artists:
 - groeuf
 URLs:
 - https://vasterror.bandcamp.com/track/the-crucible
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=the-crucible
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=the-crucible
 ---
 Track: LC Rains
 Duration: '2:13'
@@ -130,7 +130,7 @@ Cover Artists:
 - Xamag
 URLs:
 - https://vasterror.bandcamp.com/track/lc-rains
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=lc-rains
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=lc-rains
 ---
 Track: Secure
 Directory: secure-vast-error
@@ -141,7 +141,7 @@ Cover Artists:
 - groeuf
 URLs:
 - https://vasterror.bandcamp.com/track/secure
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=secure
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=secure
 ---
 Track: Gravitational Pull
 Duration: '2:36'
@@ -151,7 +151,7 @@ Cover Artists:
 - falthiere
 URLs:
 - https://vasterror.bandcamp.com/track/gravitational-pull
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=gravitational-pull
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=gravitational-pull
 ---
 Track: Solana
 Duration: '2:30'
@@ -161,7 +161,7 @@ Cover Artists:
 - Circlejourney
 URLs:
 - https://vasterror.bandcamp.com/track/solana
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solana
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solana
 ---
 Track: 'INTERMISSION: Ever Closer'
 Directory: ever-closer
@@ -172,7 +172,7 @@ Cover Artists:
 - Vast Error
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-ever-closer
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=intermission-ever-closer
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=intermission-ever-closer
 ---
 Track: Trial By Fire
 Duration: '4:20'
@@ -182,7 +182,7 @@ Cover Artists:
 - banavalope
 URLs:
 - https://vasterror.bandcamp.com/track/trial-by-fire
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=trial-by-fire
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=trial-by-fire
 ---
 Track: My Protective Light
 Duration: '2:51'
@@ -192,7 +192,7 @@ Cover Artists:
 - Captainquestion
 URLs:
 - https://vasterror.bandcamp.com/track/my-protective-light
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=my-protective-light
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=my-protective-light
 ---
 Track: It's Alive
 Duration: '2:05'
@@ -204,7 +204,7 @@ Art Tags:
 - 'cw: blood (abstract)'
 URLs:
 - https://vasterror.bandcamp.com/track/its-alive
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=its-alive
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=its-alive
 ---
 Track: Disenchanted
 Duration: '3:26'
@@ -221,7 +221,7 @@ Referenced Tracks:
 - Seal It Over
 URLs:
 - https://vasterror.bandcamp.com/track/disenchanted
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=disenchanted
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=disenchanted
 ---
 Track: Nebula
 Directory: nebula-vast-error
@@ -232,7 +232,7 @@ Cover Artists:
 - Chumi
 URLs:
 - https://vasterror.bandcamp.com/track/nebula
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nebula
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nebula
 ---
 Track: Cheap (Boxed Wine)
 Duration: '3:17'
@@ -246,7 +246,7 @@ Referenced Tracks:
 - track:oversaturated-vast-error
 URLs:
 - https://vasterror.bandcamp.com/track/cheap-boxed-wine
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=cheap-boxed-wine
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=cheap-boxed-wine
 ---
 Track: Expanse Of All
 Duration: '3:00'
@@ -256,7 +256,7 @@ Cover Artists:
 - Cristata
 URLs:
 - https://vasterror.bandcamp.com/track/expanse-of-all
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=expanse-of-all
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=expanse-of-all
 ---
 Track: Indefinite Progress
 Duration: '2:38'
@@ -266,7 +266,7 @@ Cover Artists:
 - Aeritus
 URLs:
 - https://vasterror.bandcamp.com/track/indefinite-progress
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=indefinite-progress
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=indefinite-progress
 ---
 Track: Refutation
 Directory: refutation-vast-error
@@ -279,7 +279,7 @@ Referenced Tracks:
 - Scarred For Life
 URLs:
 - https://vasterror.bandcamp.com/track/refutation
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=refutation
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=refutation
 ---
 Track: Furbish
 Duration: '2:43'
@@ -289,7 +289,7 @@ Cover Artists:
 - anemonta
 URLs:
 - https://vasterror.bandcamp.com/track/furbish
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=furbish
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=furbish
 ---
 Track: Be All End All
 Duration: '2:06'
@@ -299,7 +299,7 @@ Cover Artists:
 - Deer
 URLs:
 - https://vasterror.bandcamp.com/track/be-all-end-all
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=be-all-end-all
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=be-all-end-all
 Commentary: |-
     <i>Deer:</i> (track artist, alternate artwork)
 
@@ -314,7 +314,7 @@ Cover Artists:
 - yorozuya
 URLs:
 - https://vasterror.bandcamp.com/track/solidarity
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solidarity
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solidarity
 ---
 Track: Aortian Embrace
 Duration: '3:56'
@@ -324,7 +324,7 @@ Cover Artists:
 - Cristata
 URLs:
 - https://vasterror.bandcamp.com/track/aortian-embrace
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=aortian-embrace
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=aortian-embrace
 ---
 Track: Fine With You
 Duration: '3:10'
@@ -334,7 +334,7 @@ Cover Artists:
 - falthiere
 URLs:
 - https://vasterror.bandcamp.com/track/fine-with-you
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=fine-with-you
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=fine-with-you
 ---
 Track: One Step Forward
 Duration: '4:17'
@@ -344,7 +344,7 @@ Cover Artists:
 - Greaserparty
 URLs:
 - https://vasterror.bandcamp.com/track/one-step-forward
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=one-step-forward
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=one-step-forward
 ---
 Track: Soul Shaded
 Duration: '2:18'
@@ -354,7 +354,7 @@ Cover Artists:
 - Deer
 URLs:
 - https://vasterror.bandcamp.com/track/soul-shaded
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=soul-shaded
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=soul-shaded
 ---
 Track: A Flesh Cage Of Emotion
 Duration: '3:00'
@@ -366,7 +366,7 @@ Referenced Tracks:
 - Solana
 URLs:
 - https://vasterror.bandcamp.com/track/a-flesh-cage-of-emotion
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=a-flesh-cage-of-emotion
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=a-flesh-cage-of-emotion
 ---
 Track: Oversaturated (Elevator Mix)
 Duration: '0:49'
@@ -378,7 +378,7 @@ Referenced Tracks:
 - track:oversaturated-vast-error
 URLs:
 - https://vasterror.bandcamp.com/track/oversaturated-elevator-mix
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=oversaturated-elevator-mix
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=oversaturated-elevator-mix
 ---
 Track: Good Old Hornless Jerryatric
 Duration: '2:29'
@@ -388,7 +388,7 @@ Cover Artists:
 - Cereovo
 URLs:
 - https://vasterror.bandcamp.com/track/good-old-hornless-jerryatric
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=good-old-hornless-jerryatric
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=good-old-hornless-jerryatric
 ---
 Track: Chamber Cultist
 Duration: '2:32'
@@ -400,7 +400,7 @@ Art Tags:
 - 'cw: blood'
 URLs:
 - https://vasterror.bandcamp.com/track/chamber-cultist
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=chamber-cultist
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=chamber-cultist
 ---
 Track: Transmuted
 Directory: transmuted-vast-error
@@ -416,7 +416,7 @@ Referenced Tracks:
 - Risingson
 URLs:
 - https://vasterror.bandcamp.com/track/transmuted
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=transmuted
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=transmuted
 ---
 Track: Farewell But Not Goodbye
 Duration: '4:24'
@@ -426,7 +426,7 @@ Cover Artists:
 - SilentNeptune
 URLs:
 - https://vasterror.bandcamp.com/track/farewell-but-not-goodbye
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=farewell-but-not-goodbye
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=farewell-but-not-goodbye
 ---
 Track: Pandora
 Directory: pandora-vast-error
@@ -447,7 +447,7 @@ Referenced Tracks:
 - Solana
 URLs:
 - https://vasterror.bandcamp.com/track/pandora
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=pandora
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=pandora
 ---
 Track: Bittersweet
 Directory: bittersweet-vast-error
@@ -458,7 +458,7 @@ Cover Artists:
 - big chalupa
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bittersweet
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bittersweet
 ---
 Section: Bonus tracks
 ---
@@ -480,7 +480,7 @@ Cover Artists:
 - Vast Error
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-nothing-special
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-nothing-special
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-nothing-special
 ---
 Track: Twelve By Twelve
 Additional Names:
@@ -501,7 +501,7 @@ Referenced Tracks:
 - Six By Six
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-twelve-by-twelve
-- https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-twelve-by-twelve
+# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-twelve-by-twelve
 ---
 Section: Download-only tracks
 ---

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -1,5 +1,4 @@
 Album: Vast Error Vol. 4
-Directory: vast-error-vol-4
 Date: October 21, 2018
 Date Added: October 25, 2023
 Wallpaper File Extension: jpg

--- a/album/vast-error-vol-5-side-1.yaml
+++ b/album/vast-error-vol-5-side-1.yaml
@@ -1,5 +1,4 @@
 Album: 'Vast Error Vol. 5: Side 1'
-Directory: vast-error-vol-5-side-1
 Date: September 05, 2022
 Date Added: April 13, 2024
 URLs:

--- a/album/vast-error-vol-5-side-1.yaml
+++ b/album/vast-error-vol-5-side-1.yaml
@@ -3,7 +3,7 @@ Date: September 05, 2022
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-5-side-1
-- https://music.deconreconstruction.com/albums/vast-error-vol-5-side-1
+# - https://music.deconreconstruction.com/albums/vast-error-vol-5-side-1
 Cover Artists:
 - Tyson Northcutt
 Cover Art File Extension: png

--- a/album/vast-error-vol-5-side-2.yaml
+++ b/album/vast-error-vol-5-side-2.yaml
@@ -1,5 +1,4 @@
 Album: 'Vast Error Vol. 5: Side 2'
-Directory: vast-error-vol-5-side-2
 Date: September 12, 2022
 Date Added: April 13, 2024
 URLs:

--- a/album/vast-error-vol-5-side-2.yaml
+++ b/album/vast-error-vol-5-side-2.yaml
@@ -3,7 +3,7 @@ Date: September 12, 2022
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-5-side-2
-- https://music.deconreconstruction.com/albums/vast-error-vol-5-side-2
+# - https://music.deconreconstruction.com/albums/vast-error-vol-5-side-2
 Cover Artists:
 - Tyson Northcutt
 Cover Art File Extension: png

--- a/album/vertigo.yaml
+++ b/album/vertigo.yaml
@@ -9,7 +9,7 @@ Cover Artists:
 - Dawn Davis
 Wallpaper Artists:
 - Dawn Davis
-- Jebb (edits for wiki)
+- Niklink (edits for wiki)
 Cover Art File Extension: png
 Wallpaper File Extension: png
 Wallpaper Style: |-

--- a/album/we-can-always-go-home.yaml
+++ b/album/we-can-always-go-home.yaml
@@ -7,12 +7,12 @@ Artists:
 - Beatrice
 Cover Artists:
 - Beatrice
-Wallpaper Style: 'opacity: 0.7;'
+Cover Art File Extension: png
 Wallpaper File Extension: png
+Wallpaper Style: 'opacity: 0.6;'
 Wallpaper Artists:
 - Beatrice
-- Jebb (edits for wiki)
-Cover Art File Extension: jpg
+- Niklink (edits for wiki)
 Color: '#6DC6F2'
 Groups:
 - Fandom

--- a/artists.yaml
+++ b/artists.yaml
@@ -6967,10 +6967,20 @@ Artist: N.W.A.
 Artist: n3rdysk3tch3s
 Aliases:
 - Lulu
+- LuDraws YT
+- LuDraws
+- xLuDrawsx
+- LuGames
+- xLuGamesx
+- LuluTheWarrior
 URLs:
 - https://doodles-of-a-nerd-kid.tumblr.com/
+- https://twitter.com/n3rdysk3tch3s
 - https://www.instagram.com/n3rdysk3tch3s/
-- https://02x.lu/
+- https://soundcloud.com/ludraws-yt
+- https://www.deviantart.com/n3rdysk3tch3s
+- https://www.youtube.com/channel/UCEbHhUzoZ0Baj88WJhT-8bw
+- https://www.reddit.com/user/xLuDrawsx
 Dead URLs:
 - https://twitter.com/xLuDrawsx
 ---

--- a/groups.yaml
+++ b/groups.yaml
@@ -19,13 +19,11 @@ Featured Albums:
 - Genesis Frog
 - One Year Older
 Description: |-
-    Albums released on Homestuck's official Bandcamp: the canon foundational to and long inspiring its massive fan community.
+    Homestuck's official music releases, comprising the canon foundational to and long inspiring its vibrant fan community.
     <hr class="split">
-    Coinciding (probably coincidentally) with the launch of [Homestuck^2](https://homestuck2.com/), on 25 October 2019 (10/25, a.k.a. [[flash:4109]] Day), the majority of then-released Homestuck albums were combined and re-released as compilation albums. ([Source!](https://www.reddit.com/r/homestuck/comments/dn0jo6/bandcamp_just_rereleased_a_bunch_of_albums_with/))
-    Undeniably, this was a practical move for those new to the discography, or looking to complete a collection, since the compiled albums were also considerably reduced in price. However, much was lost in terms of presentation: besides the cover arts of merged album releases being dropped due to the nature of the format, much more mysteriously vanished were <i>all</i> track art!
-    No official word was given regarding purposes for this distancing, but the consequences were clear: these compilations were the future; fan-contributed track art would be left in the past.
-    With no ill intent towards those in charge of managing the Bandcamp, we (alongside many fans) found this disheartening, and more than a little disrespectful towards the effort and creativity of the fans responsible for the wonderful gallery of art created for Homestuck's expansive discography. So, when official decisions baffled, fans took action and tried something different; [we released the Homestuck Music Wiki for the first time](https://www.reddit.com/r/homestuck/comments/dwtc4w/i_made_a_wiki_for_homestuck_albums_including/) on 15 November 2019, just three weeks after the Bandcamp restructure.
-    Since then, we've been working with a variety of community members (listeners and musicians alike!) to improve and expand the wiki ever further; today, we hope it stands both a practical resource and a celebratory testament to the history - and future - of Homestuck music!
+    Music was introduced into Homestuck soon after its 2009 launch, in contrast with previous MS Paint Adventures, and it rapidly became an iconic aspect of the story. Homestuck's music contributors flourished into a loose and diverse collective of artists, the Homestuck Music Team; official music albums were released via Bandcamp at a dizzying pace, whether in [[album:homestuck-vol-1|numbered volumes]], [[album:strife|solo efforts]], or [[album:alterniabound|themed compilations]]. Despite their cult success, the team fizzled out after the release of [[album:cherubim|Cherubim]] in 2013, with subsequent official releases mainly being concrete, contracted work for various spin-off efforts.
+
+    On October 25th 2019, the official Bandcamp page was thoroughly restructured without warning, with albums being haphazardly combined into compilations. Unique track artwork was discarded and many albums were left completely unavailable. Currently, HSMusic presents these albums as they were originally released.
 ---
 Group: Fandom
 Featured Albums:

--- a/groups.yaml
+++ b/groups.yaml
@@ -268,7 +268,7 @@ URLs:
 - https://vasterror.bandcamp.com/
 - https://twitter.com/Deconrecon_
 - https://www.deconreconstruction.com/
-- https://music.deconreconstruction.com/
+# - https://music.deconreconstruction.com/
 Description: |-
     Studio consisting of many creators from the Homestuck fan community and beyond, responsible for [Vast Error](https://www.deconreconstruction.com/vasterror/1), [its spinoffs](https://deconreconstruction.itch.io/snowbound-blood), and other projects.
     <hr class="split">

--- a/groups.yaml
+++ b/groups.yaml
@@ -340,9 +340,10 @@ URLs:
 - https://psycholonials.bandcamp.com/
 - https://www.psycholonials.com/
 Description: |-
-    <i>Psycholonials.</i>
+    "While in communication with supernatural forces, two influencers launch a daring new social media brand." A visual novel by [[artist:andrew-hussie|Andrew Hussie]].
     <hr class="split">
-    "All chapters of Psycholonials will be released along with an EP album. If a song from the current chapter doesn't appear in the latest EP, it will appear in a future EP."
+    Heavily influenced by COVID-19 lockdowns, the George Floyd protests, and other controversies of mid-2020, Psycholonials is Andrew Hussie's first post-Homestuck original work, releasing from February 3rd to April 20th, 2021. It features music by [[artist:clark-powell|Clark Powell]], often repurposed from her [[group:clark-powell|previous independent efforts]].
+    Each of Psycholonials' 9 chapters was released alongside an EP album containing music featured in that chapter. On the game's third anniversary, coinciding with the game becoming free, the EPs were removed from Bandcamp, with the now heavily-discounted full soundtrack remaining available.
 ---
 Group: UNDERTALE & DELTARUNE
 URLs:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -363,8 +363,7 @@ Content: |-
         - tweaked most durations above to closer match official sources
         - fixed name of [[track:xmas-i-dont-know-such-a-thing]] (was "Xmas? I Don't Know Such A Thing!")
         - moved [[track:summer-vanilla]] from "Other works originating outside of Homestuck" to "Other music originating outside of Homestuck"
-    - added official YouTube and Spotify listening links to [[album:requiem-for-a-homestuck]] (thanks, Niklink!)
-    - added official YouTube listening links to [[group:psycholonials]] (thanks, Niklink!)
+    - added official YouTube and Spotify listening links to [[album:requiem-for-a-homestuck]], [[group:psycholonials]], and [[album:friendsymphony]] (thanks, Niklink!)
     - added YouTube listening links to [[track:sad-jhon-full]], [[track:moonreposter-full-version]], [[track:fighter-kanaya-full-version]], [[track:eturnedtothree-served-cold-full]], [[track:train-requiem]], [[track:cool-mp3]], [[track:my-magnum-opus]], and [[track:entangled-vinculum-vitae]] (thanks, Niklink!)
     - added YouTube listening link to [[album:oceanfalls-vol-1]] (thanks, Niklink!)
     - added Bandcamp listening links to bonus tracks in [[album:pantheon]]
@@ -385,6 +384,7 @@ Content: |-
     - fixed [[track:squiddles-in-paradise]] not referencing [[track:squiddles]] (thanks, ceruleanModulator!)
     - fixed [[track:squiddles-in-paradise]] not sampling [[track:plumbthroat-gives-chase]] (plus a lyric adjustment) (thanks, Niklink!)
     - fixed [[track:frost-vol6]] not referencing [[track:vertigo]] (thanks, Jebb!)
+    - fixed [[track:umbral-ultimatum]] not referencing [[track:sburban-jungle]] (thanks, Mauskustus!)
     - fixed [[track:MeGaLoVania]] not sampling [[track:megalovania-halloween]] (thanks, Morris!)
     - fixed [[track:trollcops-radio-play]] referencing [[track:trollcops]], now the other way around
     - fixed [[track:havoc]] not referencing [[track:my-hibernation]] (thanks, Lilith!)
@@ -401,13 +401,12 @@ Content: |-
     - fixed [[track:worst-end]] not referencing [[track:pascal-kepler-thief-of-mind]] (thanks, Rosetta Leijonde!)
     - fixed [[track:yeah-it-is]] not referencing [[track:nuclear-james-roach]] (thanks, JG!)
     - fixed [[track:this-time-its-eridan]] not referencing [[track:buskers-theme]]
-    - fixed [[track:gog-rest-ye-merry-prospitians]] referencing [[track:santa-claus-is-comin-to-town]] instead of [[track:here-comes-santa-claus]] (thanks, Pyryte!)
+    - fixed [[track:gog-rest-ye-merry-prospitians]] referencing 'Santa Claus Is Comin' to Town' instead of [[track:here-comes-santa-claus]] (thanks, Pyryte!)
     - fixed [[track:candles-and-merry-gentlemen]] referencing [[track:candlelight]], instead of the other way around (thanks, Grace, Niklink!)
     - fixed [[track:wily-espionage]] not referencing [[track:wily-espionage-original]] (original) (thanks, Niklink!)
     - fixed [[track:the-land-of-wind-and-shade]] not referencing [[track:the-land-of-wind-and-shade-original]] (original) (thanks, Niklink!)
     - fixed [[track:a-war-of-one-bullet]] not referencing [[track:inevitable-end]]
     - fixed [[track:eternal-suffering]] not sampling [[track:through-fire-justice-is-served]] (thanks, Rosetta Leijonde, FF!)
-    - fixed [[track:land-of-sand-and-rails]] referencing "When Johnny Comes Marching Home" (thanks, Celeste!)
     - fixed [[track:he-is-already-here]] not referencing [[track:clubbed-to-death-kurayamino-variation]]
     - fixed [[track:the-note-desolation-plays]] not referencing [[track:presentiment]]
     - fixed [[track:showtime-svix-mix-lofam2]] ([[album:lofam2]]) referencing [[track:showtime-original-mix]] instead of [[track:showtime-svix-mix]] ([[album:showtime-svix-mix|single]])

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -366,8 +366,7 @@ Content: |-
     - added official YouTube and Spotify listening links to [[album:requiem-for-a-homestuck]], [[group:psycholonials]], and [[album:friendsymphony]] (thanks, Niklink!)
     - added YouTube listening links to [[track:sad-jhon-full]], [[track:moonreposter-full-version]], [[track:fighter-kanaya-full-version]], [[track:eturnedtothree-served-cold-full]], [[track:train-requiem]], [[track:cool-mp3]], [[track:my-magnum-opus]], and [[track:entangled-vinculum-vitae]] (thanks, Niklink!)
     - added YouTube listening link to [[album:oceanfalls-vol-1]] (thanks, Niklink!)
-    - added Bandcamp listening links to bonus tracks in [[album:pantheon]]
-    - added MUSIC@DCRC links to [[album:running-for-eons]], [[album:repiton]], [[album:vast-error-vol-4]], [[album:catch-322]], [[album:dead-shufflers-anything-goes]], [[album:corporate-holiday-hits]], [[album:reminders-of-you-beta]], [[album:vast-error-vol-1-3]], [[album:empyreal-rhapsody]], and [[album:faux-dramatica]]
+    - added Bandcamp listening links to bonus tracks in [[album:pantheon]]  <!-- - added MUSIC@DCRC links to [[album:running-for-eons]], [[album:repiton]], [[album:vast-error-vol-4]], [[album:catch-322]], [[album:dead-shufflers-anything-goes]], [[album:corporate-holiday-hits]], [[album:reminders-of-you-beta]], [[album:vast-error-vol-1-3]], [[album:empyreal-rhapsody]], and [[album:faux-dramatica]] -->
     - added YouTube listening links to [[track:battle-with-a-legendary-fiduspawn]], [[track:in-the-depths]], [[track:barn-buddies]]
     - added SoundCloud listening links to most tracks by [[artist:rainy]], across albums [[album:desynced-vol-1]], [[album:desynced-vol-2]], [[album:election-season]], [[album:pantheon]], and [[album:sburban-neighborhood]]
     - added description and [Category:Homestuck wiki link](https://siivagunner.fandom.com/wiki/Category:Homestuck) to [[artist:siivagunner]] (thanks, Rosetta Leijonde!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -403,7 +403,8 @@ Content: |-
     - fixed [[track:this-time-its-eridan]] not referencing [[track:buskers-theme]]
     - fixed [[track:gog-rest-ye-merry-prospitians]] referencing [[track:santa-claus-is-comin-to-town]] instead of [[track:here-comes-santa-claus]] (thanks, Pyryte!)
     - fixed [[track:candles-and-merry-gentlemen]] referencing [[track:candlelight]], instead of the other way around (thanks, Grace, Niklink!)
-    - fixed [[track:the-land-of-wind-and-shade]] not referencing [[track:the-land-of-wind-and-shade-original]] (yes, those are different) (thanks, Niklink!)
+    - fixed [[track:wily-espionage]] not referencing [[track:wily-espionage-original]] (original) (thanks, Niklink!)
+    - fixed [[track:the-land-of-wind-and-shade]] not referencing [[track:the-land-of-wind-and-shade-original]] (original) (thanks, Niklink!)
     - fixed [[track:a-war-of-one-bullet]] not referencing [[track:inevitable-end]]
     - fixed [[track:eternal-suffering]] not sampling [[track:through-fire-justice-is-served]] (thanks, Rosetta Leijonde, FF!)
     - fixed [[track:land-of-sand-and-rails]] referencing "When Johnny Comes Marching Home" (thanks, Celeste!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -209,13 +209,13 @@ Content: |-
     - added alternate art by [[artist:clorinspats]] to [[track:lancer]] (thanks, clorinspats!!)
     - added wallpapers to [[album:lofam]], [[album:lofam2]], [[album:bittersweet]], [[album:sburb-funkin-edition-ost]], and [[album:rappets-davekat-collection]] (thanks, Niklink!)
     - added art and commentary by [[artist:lunise]] to [[track:stalemate-play-the-rain]] (later repurposed for [[track:dogfight-dirtiests-dubstep-remix]])
-    - added wallpapers to [[album:desynced-vol-1]], [[album:pantheon]], and [[album:homestuck-swagazaki]] (thanks, Jebb!)
+    - added wallpapers to [[album:desynced-vol-1]], [[album:desynced-vol-2]], [[album:pantheon]], and [[album:homestuck-swagazaki]] (thanks, Jebb!)
     - added higher quality wallpaper to [[album:sunday-night-strifin-act-1-plus-2-ost]] (thanks, Niklink!)
     - added stretch-free banners to [[album:sburb-funkin-edition-ost]] and [[album:svert-ost-volume-one]] (thanks, Niklink!)
     - added full-size art to some [[group:deconrecon]] album covers: [[album:vast-error-vol-4]], [[album:catch-322]], [[album:empyreal-rhapsody]] (thanks, Niklink!)
     - added wallpaper, banner, and additional files to [[album:autumn-every-day]] (thanks, Niklink!)
     - added full-size art across [[group:jamie-paige]] albums, and to the covers of [[album:skies-forever-blue]], [[album:sburb-funkin-edition-ost]], [[album:rappets-davekat-collection]], and [[album:the-rebornening]] (thanks, Niklink!)
-    - added full-size art to older [[group:desynced]] albums: [[album:desynced-vol-1]], [[album:desynced-vol-2]], and [[album:election-season]] (thanks, Niklink!)
+    - added full-size art to [[group:psycholonials]] and older [[group:desynced]] albums: [[album:desynced-vol-1]], [[album:desynced-vol-2]], and [[album:election-season]] (thanks, Niklink!)
     - added a bunch of fan animations (thanks, Jebb!)
         - added animations by [[artist:shadok]]: [[flash:homestuck-the-baby-is-you-animated]] through [[flash:noelle-is-spamtons-mom]]
         - added animations by [[artist:bugflower413]]: [[flash:damara-ascend]] through [[flash:dethrone-bugflower413]]
@@ -364,6 +364,7 @@ Content: |-
         - fixed name of [[track:xmas-i-dont-know-such-a-thing]] (was "Xmas? I Don't Know Such A Thing!")
         - moved [[track:summer-vanilla]] from "Other works originating outside of Homestuck" to "Other music originating outside of Homestuck"
     - added official YouTube and Spotify listening links to [[album:requiem-for-a-homestuck]] (thanks, Niklink!)
+    - added official YouTube listening links to [[group:psycholonials]] (thanks, Niklink!)
     - added YouTube listening links to [[track:sad-jhon-full]], [[track:moonreposter-full-version]], [[track:fighter-kanaya-full-version]], [[track:eturnedtothree-served-cold-full]], [[track:train-requiem]], [[track:cool-mp3]], [[track:my-magnum-opus]], and [[track:entangled-vinculum-vitae]] (thanks, Niklink!)
     - added YouTube listening link to [[album:oceanfalls-vol-1]] (thanks, Niklink!)
     - added Bandcamp listening links to bonus tracks in [[album:pantheon]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -215,8 +215,8 @@ Content: |-
     - added full-size art to some [[group:deconrecon]] album covers: [[album:vast-error-vol-4]], [[album:catch-322]], [[album:empyreal-rhapsody]] (thanks, Niklink!)
     - added wallpaper, banner, and additional files to [[album:autumn-every-day]] (thanks, Niklink!)
     - added full-size art across [[group:jamie-paige]] albums, and to the covers of [[album:skies-forever-blue]], [[album:sburb-funkin-edition-ost]], [[album:rappets-davekat-collection]], and [[album:the-rebornening]] (thanks, Niklink!)
-    - added a bunch of flashes and fan animations (thanks, Jebb!)
-        - added flashes from [[flash-act:desynced]] featuring tracks currently on wiki
+    - added full-size art to older [[group:desynced]] albums: [[album:desynced-vol-1]], [[album:desynced-vol-2]], and [[album:election-season]] (thanks, Niklink!)
+    - added a bunch of fan animations (thanks, Jebb!)
         - added animations by [[artist:shadok]]: [[flash:homestuck-the-baby-is-you-animated]] through [[flash:noelle-is-spamtons-mom]]
         - added animations by [[artist:bugflower413]]: [[flash:damara-ascend]] through [[flash:dethrone-bugflower413]]
         - added animations by [[artist:ichellor]] & co: [[flash:wake-3d-reanimated-old]] through [[flash:echidna-of-fates-and-choices]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -399,7 +399,7 @@ Content: |-
     - fixed [[track:breeze]] not referencing [[track:evanescence-maria-schneider]]
     - fixed [[track:fortnite-funny-moments-epic-fails-episode-413]] not referencing [[track:lexxer-ascend]] and [[track:nuclear-james-roach]] (thanks, Rosetta Leijonde!)
     - fixed [[track:worst-end]] not referencing [[track:pascal-kepler-thief-of-mind]] (thanks, Rosetta Leijonde!)
-    - fixed [[track:yeah-it-is]] not referencing [[track:nuclear-james-roach]] (thanks, JG!)
+    - fixed [[track:yeah-it-is]] not referencing [[track:nuclear-james-roach]] (thanks, JG!) and referencing [[track:MeGaLoVania]] instead of [[track:megalovania-undertale]] (thanks, Jebb!)
     - fixed [[track:this-time-its-eridan]] not referencing [[track:buskers-theme]]
     - fixed [[track:gog-rest-ye-merry-prospitians]] referencing 'Santa Claus Is Comin' to Town' instead of [[track:here-comes-santa-claus]] (thanks, Pyryte!)
     - fixed [[track:candles-and-merry-gentlemen]] referencing [[track:candlelight]], instead of the other way around (thanks, Grace, Niklink!)


### PR DESCRIPTION
- Fixes #367
- Fixes #382
- Fixes #383
- Fixes #448
- Fixes #455
- Fixes #456
- Fixes #457
- Opacity adjustment pass on new album backgrounds
- Removed extraneous directory fields for some Vast Error albums
- Improved wallpapers: We can always go home, Vertigo, [S] Forgive, the gap, Vertigo, Desynced Vol. 1, Desynced Vol. 2
- Added wallpapers: Pesterquest Soundtrack, Assorted Mythological Textbooks and Strange Beasts
- Improved banners: Brostuck, Dweller's Empty Path
- Fixed Funkstuck//24 missing James Roach group
- Fixed Umbral Ultimatum not referencing Sburban Jungle
- Fixed Go Beyond and Fighting Further crediting wrong cover artist
- Official and Psycholonials group blurbs
- Removed some unnecessary comments and unreferenced songs
- Comment out DCRC website listening links (all broken for the time being)
- Some other stuff I'm surely forgetting

Requires hsmusic/hsmusic-media#44

