### PR TITLE
Little Town Hero

### DIFF
--- a/album/little-town-hero-original-soundtrack.yaml
+++ b/album/little-town-hero-original-soundtrack.yaml
@@ -5,23 +5,42 @@ Artists:
 - Hitomi Sato
 - GAME FREAK
 Date: April 23, 2020
-#https://vgmdb.net/album/100935
-#URLs:
-#- 
+# Reference: https://vgmdb.net/album/100935
+URLs:
+- https://www.youtube.com/playlist?list=PLnVpmehyaOFZKdsXGSh0NXbRtAjuek78S
 Cover Artists:
 - GAME FREAK
 Cover Art File Extension: png
 Wallpaper Artists:
 - GAME FREAK
 Wallpaper Style: |-
-    background-position: top center;
-Color: '#68d0d1'
+    opacity: 0.6;
+Color: '#e26843'
 Groups:
 - Toby Fox
 - Beyond
 Commentary: |-
     <i>Morris:</i> (wiki editor)
-    Fun Fact: Among some early versions of songs in the game, [[group:undertale-and-deltarune|UNDERTALE]]'s [[track:last-episode]] goes unused in the game's files.
+
+    Fun Fact: Among some early versions of songs in the game, UNDERTALE's [[track:last-episode]] goes unused in the game's files.
+
+    <i>Morris:</i> ([album addition pull request](https://github.com/hsmusic/hsmusic-data/pull/473))
+
+    references may seem a bit odd, but I tried to make the order of them as accurate as possible. Nintendo Switch DOWNLOAD SOFT COMPILATION ALBUM ([VGMdb](https://vgmdb.net/album/98119)) includes a "Concept Medley" containing [[The Fields Before Us]], [[Win by a Hair]], [[Pasmina]], [[Blood-red Carpet]], [[Neverending Roar]], and [[End the Story!]] Some of these are the same as in the final game, some are early versions (The Fields Before Us is an early version that can still be found unused in the game's files, Win by a Hair is Toby's original version while the final game has a Sato arrangement). I used this medley as the foundation of the references. In a developer interview, devs mentioned that once they got Toby for the music, he immediately layed out some main motif concepts, I presume these are what appear in the medley. Hence, for songs appearing in the medley, I point to them as the origins.
+
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    This track listing is based on the digital-download release included with the Japanese physical release of Little Town Hero ([see VGMdb](https://vgmdb.net/album/100935)). [Little Town Hero - Big Idea Edition!](https://www.nisamerica.com/little-town-hero/) included a CD soundtrack titled "Town Tunes" ([VGMdb](https://vgmdb.net/album/95456)), and this came with 28 tracks (in a slightly different order), excluding these:
+
+    - [[track:welcome-to-my-town]]
+    - [[track:pasmina]]
+    - [[track:this-is-my-town-shop-area]]
+    - [[track:this-is-my-town-farm-area]]
+    - [[track:lost-reminiscence]]
+    - [[track:clanking-caverns]]
+    - [[track:evolution-dance]]
+    - [[track:tale-of-the-dark]]
+    - [[track:blood-red-carpet]]
 ---
 Track: Welcome to My Town
 Duration: '1:51'
@@ -83,6 +102,8 @@ Referenced Tracks:
 - Three Bad Boys
 ---
 Track: Roar
+Directory: roar-little-town-hero
+Always Reference By Directory: true
 Duration: '1:23'
 Artists:
 - Toby Fox
@@ -101,6 +122,7 @@ URLs:
 - https://www.youtube.com/watch?v=OCwxYGEJGgk
 ---
 Track: You Won!
+Directory: you-won-little-town-hero
 Duration: '0:12'
 Artists:
 - Hitomi Sato
@@ -352,4 +374,4 @@ Referenced Tracks:
 - The Fields Before Us
 Commentary: |-
     <i>Morris:</i> (wiki editor)
-    The title of this song feels like it's a reference to the [[group:undertale-and-deltarune|DELTARUNE]] songs [[track:a-town-called-hometown]] and [[track:you-can-always-come-home]].
+    The title of this song feels like it's a reference to the DELTARUNE songs [[track:a-town-called-hometown]] and [[track:you-can-always-come-home]].

--- a/album/little-town-hero-original-soundtrack.yaml
+++ b/album/little-town-hero-original-soundtrack.yaml
@@ -19,13 +19,16 @@ Color: '#68d0d1'
 Groups:
 - Toby Fox
 - Beyond
+Commentary: |-
+    <i>Morris:</i> (wiki editor)
+    Fun Fact: Among some early versions of songs in the game, [[group:undertale-and-deltarune|UNDERTALE]]'s [[track:last-episode]] goes unused in the game's files.
 ---
 Track: Welcome to My Town
 Duration: '1:51'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=lG9hW03Ws9I
 Referenced Tracks:
 - The Fields Before Us
 ---
@@ -34,7 +37,7 @@ Duration: '7:21'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=aTx2DSQLcBA
 Referenced Tracks:
 - The Fields Before Us
 ---
@@ -43,9 +46,7 @@ Duration: '0:08'
 Artists:
 - Hitomi Sato
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=UZDVppxz5Ag
 ---
 Track: Three Bad Boys
 Duration: '1:29'
@@ -53,9 +54,7 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=x0CtqfSWVrY
 ---
 Track: Idea Rush
 Duration: '3:06'
@@ -64,18 +63,14 @@ Artists:
 Contributors:
 - Toby Fox (composer)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=Qznqi6wH81o
 ---
 Track: Pasmina
 Duration: '1:24'
 Artists:
 - Toby Fox
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=l-rrCHEoR1U
 ---
 Track: Bad Boys Battle
 Duration: '3:34'
@@ -83,7 +78,7 @@ Artists:
 - Toby Fox
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=DtukEni9q28
 Referenced Tracks:
 - Three Bad Boys
 ---
@@ -93,7 +88,7 @@ Artists:
 - Toby Fox
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=Nokv3RHRP_w
 Referenced Tracks:
 - Neverending Roar
 ---
@@ -103,35 +98,32 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=OCwxYGEJGgk
 ---
 Track: You Won!
 Duration: '0:12'
 Artists:
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=7sil14Rd8VQ
 Referenced Tracks:
-- 
+- The Fields Before Us
 ---
 Track: Royal Orders
 Duration: '1:44'
 Artists:
-- Hitomi Sato
-## Toby & Sato composition
+- Hitomi Sato (composer & arranger)
+Contributors:
+- Toby Fox (composer)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=IHwUAitPi7Q
 ---
 Track: This is My Town (Shop Area)
 Duration: '7:21'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=ggM0j-xS1Do
 Referenced Tracks:
 - This is My Town
 ---
@@ -141,11 +133,9 @@ Artists:
 - Hitomi Sato (arranger)
 Contributors:
 - Toby Fox (composer)
-# arrangement by Sato, original Toby version from Concept Medley
+# arrangement by Sato, original Toby version appears on Concept Medley
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=nOC55n-rDl4
 ---
 Track: Battering Ram
 Duration: '4:13'
@@ -153,7 +143,7 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
+- https://www.youtube.com/watch?v=uAW0mt3iqG8
 Referenced Tracks:
 - Neverending Roar
 ---
@@ -162,7 +152,7 @@ Duration: '0:58'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=FKzn5jOmNn8
 Referenced Tracks:
 - The Fields Before Us
 ---
@@ -171,7 +161,7 @@ Duration: '1:42'
 Artists:
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=heP_BY5ZJq8
 Referenced Tracks:
 - Pasmina
 ---
@@ -181,16 +171,14 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=s7sMOHoc-Es
 ---
 Track: Metamorphic Dance
 Duration: '4:01'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=rWr1tOAQqsY
 Referenced Tracks:
 - Neverending Roar
 ---
@@ -199,7 +187,7 @@ Duration: '7:21'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=SlgZUNd95Ek
 Referenced Tracks:
 - This is My Town
 ---
@@ -210,9 +198,7 @@ Artists:
 Contributors:
 - Toby Fox (composer)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=Cg-w8YUV4gI
 ---
 Track: Lost Reminiscence
 Duration: '2:10'
@@ -220,7 +206,7 @@ Artists:
 - Toby Fox
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=Q6CcpqkWuWY
 Referenced Tracks:
 - Mystic Aura
 ---
@@ -230,25 +216,21 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=hYfVuyZafUU
 ---
 Track: Clanking Caverns
 Duration: '1:11'
 Artists:
 - Hitomi Sato
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=B4nJvl7RP2c
 ---
 Track: Evolution Dance
 Duration: '10:20'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=IOEjerAzmK8
 Referenced Tracks:
 - Neverending Roar
 ---
@@ -258,19 +240,15 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=YUsIzA9BPt8
 ---
 Track: The Fields Before Us
 Duration: '3:09'
 Artists:
 - Toby Fox
 URLs:
-- 
-Referenced Tracks:
-- 
-#based on concept demo from medley and unused in-game leftovers
+- https://www.youtube.com/watch?v=t0AZ-4U7Vdc
+#early version appears in concept medley and goes unused in the game's files
 ---
 Track: Mystic Aura
 Duration: '1:59'
@@ -278,7 +256,7 @@ Artists:
 - Toby Fox
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=Gl5x88wygvA
 Referenced Tracks:
 - No Time To Lose
 ---
@@ -287,28 +265,24 @@ Duration: '1:37'
 Artists:
 - Hitomi Sato
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=9lCyKJtVidY
 ---
 Track: No Time To Lose
 Duration: '1:03'
 Artists:
 - Toby Fox
 URLs:
-- 
-Referenced Tracks: #because this version is Toby-only, I'm inclined to believe this is the origin of the melody. because Mystic Aura is in the same key, I believe it is based on this song, and then Lost Reminiscence is a re-arrange of that in a different key.
-- 
+- https://www.youtube.com/watch?v=g4IoqZDliVg
+#because this version is Toby-only, I'm inclined to believe this is the origin of the melody. because Mystic Aura is in the same key, I believe it is based on this song, and then Lost Reminiscence is a re-arrange of that in a different key.
 ---
 Track: Scythe That Cuts Fate
 Duration: '3:38'
 Artists:
-- Hitomi Sato
-# Toby comp
+- Hitomi Sato (arranger)
+Contributors:
+- Toby Fox (composer)
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=uCocKi9JK6Q
 ---
 Track: Game Over
 Directory: game-over-little-town-hero
@@ -316,7 +290,7 @@ Duration: '0:10'
 Artists:
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=xViVpiLHnYw
 Referenced Tracks:
 - The Fields Before Us
 ---
@@ -325,9 +299,7 @@ Duration: '2:47'
 Artists:
 - Toby Fox
 URLs:
-- 
-Referenced Tracks:
-- 
+- https://www.youtube.com/watch?v=UgiCbngFvB8
 ---
 Track: Neverending Roar
 Duration: '3:18'
@@ -335,7 +307,7 @@ Artists:
 - Toby Fox (composer & arranger)
 - Hitomi Sato (arranger)
 URLs:
-- 
+- https://www.youtube.com/watch?v=6Jo88Qq-8I4
 Referenced Tracks:
 - Blood-red Carpet #both songs appear in concept medley. since the part of Neverending Roar with the "Blood-red Carpet melody" doesn't appear, but the melody does appear in the Blood-red Carpet part of the medley, I'm listing Blood-red Carpet as the origin of the melody.
 ---
@@ -345,7 +317,7 @@ Artists:
 - Toby Fox
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=9e3y6sLTbxI
 Referenced Tracks:
 - This is My Town
 - The Fields Before Us
@@ -356,7 +328,7 @@ Duration: '3:44'
 Artists:
 - Toby Fox
 URLs:
-- 
+- https://www.youtube.com/watch?v=NImwFskVK1k
 Referenced Tracks:
 - The Fields Before Us
 ---
@@ -365,7 +337,7 @@ Duration: '4:32'
 Artists:
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=gJk30gUc2lg
 Referenced Tracks:
 - Pasmina
 - The Fields Before Us
@@ -375,6 +347,9 @@ Duration: '3:26'
 Artists:
 - Hitomi Sato
 URLs:
-- 
+- https://www.youtube.com/watch?v=KUnq5nfpOK8
 Referenced Tracks:
 - The Fields Before Us
+Commentary: |-
+    <i>Morris:</i> (wiki editor)
+    The title of this song feels like it's a reference to the [[group:undertale-and-deltarune|DELTARUNE]] songs [[track:a-town-called-hometown]] and [[track:you-can-always-come-home]].

--- a/album/little-town-hero-original-soundtrack.yaml
+++ b/album/little-town-hero-original-soundtrack.yaml
@@ -1,0 +1,378 @@
+Album: Little Town Hero Original Soundtrack
+Directory: little-town-hero-original-soundtrack
+Artists:
+- Toby Fox
+- Hitomi Sato
+- GAME FREAK
+Date: April 23, 2020
+#https://vgmdb.net/album/100935
+#URLs:
+#- 
+Cover Artists:
+- GAME FREAK
+Cover Art File Extension: png
+Wallpaper Artists:
+- GAME FREAK
+Color: '#68d0d1'
+Groups:
+- Toby Fox
+- Beyond
+---
+Track: Welcome to My Town
+Duration: '1:51'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- The Fields Before Us
+---
+Track: This is My Town
+Duration: '7:21'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- The Fields Before Us
+---
+Track: A New Chapter
+Duration: '0:08'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Three Bad Boys
+Duration: '1:29'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Idea Rush
+Duration: '3:06'
+Artists:
+- Hitomi Sato (arranger)
+Contributors:
+- Toby Fox (composer)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Pasmina
+Duration: '1:24'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Bad Boys Battle
+Duration: '3:34'
+Artists:
+- Toby Fox
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- Three Bad Boys
+---
+Track: Roar
+Duration: '1:23'
+Artists:
+- Toby Fox
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- Neverending Roar
+---
+Track: Village Clash
+Duration: '5:14'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: You Won!
+Duration: '0:12'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Royal Orders
+Duration: '1:44'
+Artists:
+- Hitomi Sato
+## Toby & Sato composition
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: This is My Town (Shop Area)
+Duration: '7:21'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- This is My Town
+---
+Track: Win by a Hair
+Duration: '3:01'
+Artists:
+- Hitomi Sato (arranger)
+Contributors:
+- Toby Fox (composer)
+# arrangement by Sato, original Toby version from Concept Medley
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Battering Ram
+Duration: '4:13'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- Neverending Roar
+---
+Track: Teardrop-shaped Stones
+Duration: '0:58'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- The Fields Before Us
+---
+Track: Want to Talk About Sheep?
+Duration: '1:42'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- Pasmina
+---
+Track: Gravemaker
+Duration: '3:12'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Metamorphic Dance
+Duration: '4:01'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- Neverending Roar
+---
+Track: This is My Town (Farm Area)
+Duration: '7:21'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- This is My Town
+---
+Track: Sky Attack
+Duration: '4:23'
+Artists:
+- Hitomi Sato (arranger)
+Contributors:
+- Toby Fox (composer)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Lost Reminiscence
+Duration: '2:10'
+Artists:
+- Toby Fox
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- Mystic Aura
+---
+Track: Rising Waves
+Duration: '3:44'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Clanking Caverns
+Duration: '1:11'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Evolution Dance
+Duration: '10:20'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- Neverending Roar
+---
+Track: Laughing Doll
+Duration: '4:18'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: The Fields Before Us
+Duration: '3:09'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- 
+#based on concept demo from medley and unused in-game leftovers
+---
+Track: Mystic Aura
+Duration: '1:59'
+Artists:
+- Toby Fox
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- No Time To Lose
+---
+Track: Tale of the Dark
+Duration: '1:37'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: No Time To Lose
+Duration: '1:03'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks: #because this version is Toby-only, I'm inclined to believe this is the origin of the melody. because Mystic Aura is in the same key, I believe it is based on this song, and then Lost Reminiscence is a re-arrange of that in a different key.
+- 
+---
+Track: Scythe That Cuts Fate
+Duration: '3:38'
+Artists:
+- Hitomi Sato
+# Toby comp
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Game Over
+Directory: game-over-little-town-hero
+Duration: '0:10'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- The Fields Before Us
+---
+Track: Blood-red Carpet
+Duration: '2:47'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- 
+---
+Track: Neverending Roar
+Duration: '3:18'
+Artists:
+- Toby Fox (composer & arranger)
+- Hitomi Sato (arranger)
+URLs:
+- 
+Referenced Tracks:
+- Blood-red Carpet #both songs appear in concept medley. since the part of Neverending Roar with the "Blood-red Carpet melody" doesn't appear, but the melody does appear in the Blood-red Carpet part of the medley, I'm listing Blood-red Carpet as the origin of the melody.
+---
+Track: Little Town Hero
+Duration: '5:53'
+Artists:
+- Toby Fox
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- This is My Town
+- The Fields Before Us
+- End the Story!
+---
+Track: End the Story!
+Duration: '3:44'
+Artists:
+- Toby Fox
+URLs:
+- 
+Referenced Tracks:
+- The Fields Before Us
+---
+Track: Our Special Rites
+Duration: '4:32'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- Pasmina
+- The Fields Before Us
+---
+Track: A Place You Can Call Home
+Duration: '3:26'
+Artists:
+- Hitomi Sato
+URLs:
+- 
+Referenced Tracks:
+- The Fields Before Us

--- a/album/little-town-hero-original-soundtrack.yaml
+++ b/album/little-town-hero-original-soundtrack.yaml
@@ -13,6 +13,8 @@ Cover Artists:
 Cover Art File Extension: png
 Wallpaper Artists:
 - GAME FREAK
+Wallpaper Style: |-
+    background-position: top center;
 Color: '#68d0d1'
 Groups:
 - Toby Fox

--- a/album/one-year-older.yaml
+++ b/album/one-year-older.yaml
@@ -253,7 +253,6 @@ Commentary: |-
     So, to try and accompany the general air of mystery and exploration that would have gone with a long journey into the center of Skaia, I took an old idea in Locrian mode. If you're a music person, Locrian is when you take a major scale, but start it on the last note. It's a rather off-kilter scale, and it can't ever really resolve to the tonic chord like most other scales can, which made it rather suited to a piece about the sort of strange secrets and landscapes that could be hidden in the center of Skaia.
 ---
 Track: Game Over
-Always Reference By Directory: true
 Duration: '3:42'
 URLs:
 - https://erikscheele.bandcamp.com/track/game-over

--- a/album/one-year-older.yaml
+++ b/album/one-year-older.yaml
@@ -253,6 +253,7 @@ Commentary: |-
     So, to try and accompany the general air of mystery and exploration that would have gone with a long journey into the center of Skaia, I took an old idea in Locrian mode. If you're a music person, Locrian is when you take a major scale, but start it on the last note. It's a rather off-kilter scale, and it can't ever really resolve to the tonic chord like most other scales can, which made it rather suited to a piece about the sort of strange secrets and landscapes that could be hidden in the center of Skaia.
 ---
 Track: Game Over
+Always Reference By Directory: true
 Duration: '3:42'
 URLs:
 - https://erikscheele.bandcamp.com/track/game-over

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -100,6 +100,7 @@ Content: |-
         - added [[album:midworld-merriment]]!
     - added various video game soundtracks featuring [[group:toby-fox]]
         - added [[album:super-smash-bros-ultimate]]!
+        - added [[album:little-town-hero-original-soundtrack]]!
         - added [[album:pokemon-sword-shield-super-music-collection]]!
         - added [[album:pokemon-scarlet-violet-super-music-collection]]!
         - added [[album:celestial]] by [[artist:ed-sheeran]], and [[track:celestial-toby-fox]] by [[group:toby-fox]]!


### PR DESCRIPTION
return of Bonetrousle commits

references may seem a bit odd, but I tried to make the order of them as accurate as possible. [Nintendo Switch DOWNLOAD SOFT COMPILATION ALBUM](https://vgmdb.net/album/98119) includes a "Concept Medley" containing The Fields Before Us, Win by a Hair, Pasmina, Blood-red Carpet, Neverending Roar, and End the Story! Some of these are the same as in the final game, some are early versions (The Fields Before Us is an early version that can still be found unused in the game's files, Win by a Hair is Toby's original version while the final game has a Sato arrangement). I used this medley as the foundation of the references. In a developer interview, devs mentioned that once they got Toby for the music, he immediately layed out some main motif concepts, I presume these are what appear in the medley. Hence, for songs appearing in the medley, I point to them as the origins.

sadly, there are no good uploads of this album specifically on YouTube, so I had to get urls from a different playlist (some tracks have different, seemingly unnofficial, names on there) and I don't have a playlist for the full album on hand.