### PR TITLE
Land Lilith's additions: Stacatto Force artist fixes

### DIFF
--- a/album/alternate-hues-and-melodies.yaml
+++ b/album/alternate-hues-and-melodies.yaml
@@ -46,7 +46,7 @@ Commentary: |-
     [[artist:liquidvoid]]<br>
     [[artist:calikid]]<br>
     [[artist:dcmd]]<br>
-    [[artist:the-utsf2]]
+    [[artist:stacatto-force]]
 
     Artists:<br>
     [[artist:doctorcorby]]<br>
@@ -167,7 +167,7 @@ Referenced Tracks:
 Track: :33 < Arsenic Cat
 Directory: arsenic-cat
 Artists:
-- The UTSF2
+- Stacatto Force
 Cover Artists:
 - Hilaletto
 Cover Art File Extension: png

--- a/artists.yaml
+++ b/artists.yaml
@@ -9753,6 +9753,12 @@ Dead URLs:
 ---
 Artist: Mystery Skulls
 ---
+Artist: Stacatto Force
+Aliases:
+- The UTSF2
+Dead URLs:
+- https://www.youtube.com/channel/UCjGbTxr9QVHKIqi-m8IirEg
+---
 Artist: Stan LePard
 ---
 Artist: Star Wars
@@ -10325,8 +10331,6 @@ Artist: The Smashing Pumpkins
 Artist: The Stanley Brothers
 ---
 Artist: The Super Mario Players
----
-Artist: The UTSF2
 ---
 Artist: The Voice Inside Your Head
 ---


### PR DESCRIPTION
Lands a couple commits pushed to #503 by @Lilithtreasure.

This artist only has one credit on the wiki so far, so this doesn't actually combine two artist entries. But Stacatto Force has more credits in Beforusbound, so there'll be additional credits not otherwise brought together in #280!
