### PR TITLE
cam:UA original version additional files & related commentary

### DIFF
--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -35,15 +35,17 @@ Wallpaper Artists:
 - Shelby Cragg
 - Niklink (edits for wiki)
 Additional Files:
-- Title: Album Credits
+- Title: Credits, lyrics, and trivia
   Files:
   - CREDITS_A.txt
-- Title: Lyrics & Trivia
-  Files:
   - LYRICS_ETC_A.txt
-- Title: Outdated Credits and Lyrics
+- Title: Credits, lyrics, and trivia prior to plagiarized tracks' removal
+  Description: >-
+    See [[Purple Tyrant]] for details. When the album was updated with replacement tracks, there was no recreated PDF with updated credits.
   Files:
-  - CREDITS_A.pdf
+  - CREDITS_A (pre-removal).pdf
+  - CREDITS_A (pre-removal).txt
+  - LYRICS_ETC_A (pre-removal).txt
 Commentary: |-
     <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20120405160556/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-a))
 
@@ -460,6 +462,8 @@ Commentary: |-
     This track and [[track:indigo-archer]] weren't initially included on coloUrs and mayhem - different tracks were in their place. They were both found to be to be plagiarized from Frozen Synapse's soundtrack, and were removed from the album [the day after it released](https://web.archive.org/web/20150114103237/http://fwugradiation.tumblr.com/post/20394523143/frozen-synapse-and-indigo-archer). ([See also this Penny Arcade thread.](https://forums.penny-arcade.com/discussion/157658/mspa-horse-proposal-week-everyone-post-your-fanyetis/p66))
 
     Although the tracks were removed promptly, replacements (by unrelated artists) didn't show on the album til over a month later, on May 14. (The release was certainly between [May 11](https://web.archive.org/web/20120511201244/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-a) and [May 16](https://web.archive.org/web/20120516233943/http://homestuck.bandcamp.com/track/indigo-archer); May 14 was initially ascertained from the HTTP metadata for [this capture of Indigo Archer's artwork](https://web.archive.org/web/20160412163142im_/http://f4.bcbits.com/img/a1546705741_16.jpg), and ratified by [this Penny Arcade post](https://forums.penny-arcade.com/discussion/159306/mspa-toda-reads-scott-pilgrim/p77#Comment_23094351).)
+
+    As included in <code>LYRICS_ETC_A.txt</code> before the plagiarized tracks were removed and replaced, for Indigo Archer and Purple Tyrant respectively, the contest-submitted names were "Mechani% of the Void" and "An Invincible Demon". Indigo Archer was "written" for Equius, and Purple Tyrant was "written" for Lord English.
 
     <i>Toby Fox:</i> (contest management, [Tumblr](https://web.archive.org/web/20150114103237/http://fwugradiation.tumblr.com/post/20394523143/frozen-synapse-and-indigo-archer))
 

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -57,6 +57,7 @@ Content: |-
     - added MIDI recreations from [[album:sburbmon-ost]] across the original tracks' official releases (thanks, Makin!)
     - added YouTube listening links, commentary, and additional names to [[album:le-canrivalry-album-is-mandatory]] (thanks, vriska/leo!)
     - added YouTube listening links, commentary, and additional names to [[track:the-fall]], [[track:soliloquy]], [[track:sand-molding]], [[track:unrequited]], and [[track:new-irish-stew]]
+    - added additional files to [[album:coloUrs-and-mayhem-universe-a]], and commentary paragraph to [[track:purple-tyrant]], to do with album bonus files before plagiarized tracks were removed and replaced
     - added current details about "Music in Circles" album to [[track:new-irish-stew]]
     - added citations for commentary across [[album:junior-recital]] and [[album:senior-recital]]
     - moved [[track:dance-of-thorns-richaadeb]] from [[album:more-homestuck-fandom]] into single release (thanks, Jebb!)


### PR DESCRIPTION
Notes:

- Resolves #493 
- Resolves #494 
- Merge alongside hsmusic/hsmusic-media#62

This was originally a post-release fix (part of #522), but it kind of breaks the appearance of the album page with the staging/release codebase! So this depends on hsmusic/hsmusic-wiki#490, part of the next main update.