### PR TITLE
Small update of Synthetica artist info (Smurfbeatz --> O'Neil Gerald)

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -27497,6 +27497,19 @@ Lyrics: |-
     Here, there, and everywhere
     Hip, hip
 ---
+Track: Home (Keys of a PIano)
+Artists:
+- O'Neil Gerald
+Duration: 5:14
+URLs:
+- https://www.newgrounds.com/audio/listen/151603
+Commentary: |-
+    <i>O'Neil Gerald:</i> ([Newgrounds description](https://www.newgrounds.com/audio/listen/151603))
+
+    Okay...I think I've established a new genre. I call it...Drum & Keys! Why, you might ask. This song here is a slight example of how instead of creating rock with a guitar, I use a piano to create a lyrical but substantial melody that drives my songs. Tell me what you think of the song and my genre name!
+
+    BTW, this version of the song is eqed to sound less clustered in the chorus. It's all I could do with an mp3 file.
+---
 Track: Hotel California
 Artists:
 - The Eagles

--- a/album/synthetica.yaml
+++ b/album/synthetica.yaml
@@ -24,7 +24,7 @@ Commentary: |-
     [[artist:nal1200]] ft. [[artist:lira-yin|LiraLei (Lira Yin)]]<br>
     [[artist:quarl|Quarl (Ruqal)]]<br>
     [[artist:env|Envy (~EnV~)]]<br>
-    [[artist:smurfbeatz]]<br>
+    [[artist:oneil-gerald|Smurfbeatz]]<br>
     [[artist:beatsource|Ethalyn (BeatSource)]]<br>
     [[artist:renoakrhythm]]<br>
     [[artist:synthetic-music-apparatus|SMA (Synthetic Music Apparatus)]]<br>
@@ -53,7 +53,7 @@ Commentary: |-
     [[artist:nal1200]] ft. [[artist:lira-yin|Lira Yin (Liralei)]]<br>
     [[artist:quarl|Ruqal (Quarl)]]<br>
     [[artist:env|Envy]]<br>
-    [[artist:smurfbeatz]]<br>
+    [[artist:oneil-gerald|Smurfbeatz]]<br>
     [[artist:beatsource|Beatsource]]<br>
     [[artist:renoakrhythm]]<br>
     [[artist:synthetic-music-apparatus|Synthetic Music Apparatus (SMA)]]<br>
@@ -142,7 +142,9 @@ Duration: '3:48'
 ---
 Track: Keys of A Piano
 Artists:
-- Smurfbeatz
+- O'Neil Gerald
+Referenced Tracks:
+- track:home-keys-of-a-piano
 Duration: '4:46'
 ---
 Track: Happiness (BeatSource Remix)

--- a/artists.yaml
+++ b/artists.yaml
@@ -9863,7 +9863,19 @@ Dead URLs:
 - https://deferretted.tumblr.com/
 - https://nocchiosvices.tumblr.com/
 ---
-Artist: Smurfbeatz
+Artist: O'Neil Gerald
+Aliases:
+- Smurfbeatz
+- TheMerelyHuman
+- O'Neil Donald
+- O'Neil Gerald Donald
+URLs:
+- https://themerelyhuman.newgrounds.com
+- https://twitter.com/oneilgerald_
+- https://www.youtube.com/channel/UC82DrgZUjVnOpkNsDRYMKRg
+- https://linktr.ee/oneildonaldmusic
+- https://open.spotify.com/artist/5clOVqkLG4LsJCOk8LUMOF
+- https://music.apple.com/us/artist/oneil-donald/1646996437
 Dead URLs:
 - https://smurfbeatz.newgrounds.com
 ---


### PR DESCRIPTION
Affects the following YAMLs with the following additions/changes for each:
[hsmusic-data/album/synthetica.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/synthetica.yaml)
- added referenced track `Home (Keys of a Piano)` to `Keys of A Piano` track
- changed `[[artist:smurfbeatz]]` to `[[artist:oneil-gerald|Smurfbeatz]]` in both album commentary fields
- changed Smurfbeatz credit in `Keys of A Piano` to be O'Neil Gerald
[hsmusic-data/artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml)
- Smurfbeatz is now O'Neil Gerald, moved Smurfbeatz alias to newly created Aliases field underneath, as well as adding a plathora of aliases (O'Neil Donald, O'Neil Gerald Donald, and TheMerelyHuman) and (live!) URLs (Apple Music, YouTube, linktree, twitter, and TheMerelyHuman newgrounds page)
[hsmusic-data/album/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml)
- added track `Home (Keys of a Piano)`