### PR TITLE
Minor STLaP 3 (and 2, and Desynced Vol. 1) fixes

### DIFF
--- a/album/desynced-vol-1.yaml
+++ b/album/desynced-vol-1.yaml
@@ -523,6 +523,7 @@ Art Tags:
 - Masky (Desynced)
 Referenced Tracks:
 - Liquid Negrocity
+- I'm a Member of the Midnight Crew
 ---
 Track: Desynced Anthem
 Artists:

--- a/album/stlap2.yaml
+++ b/album/stlap2.yaml
@@ -974,7 +974,7 @@ Art Tags:
 - AH
 Referenced Tracks:
 - Spider's Claw
-- track:escapade-stlap3 # "Losas" in booklet
+- track:escapade-desynced # "Losas" in booklet
 - Crystalanthemums
 - Courser
 - Versus

--- a/album/stlap3.yaml
+++ b/album/stlap3.yaml
@@ -53,7 +53,7 @@ Commentary: |-
     [[artist:siedlag]]<br>
     [[artist:wumby]]<br>
     [[artist:doctorcorby]]<br>
-    emusic<br>
+    [[artist:e-music]]<br>
     [[artist:bisectro]]<br>
     [[artist:artatruc]]<br>
     [[artist:t4ngl3p4l]]<br>
@@ -108,11 +108,10 @@ Commentary: |-
 ---
 Track: Escapade
 Directory: escapade-stlap3
+Originally Released As: track:escapade-desynced
 Always Reference By Directory: true
 Additional Names:
 - LoSaS (original name)
-Artists:
-- Pascal van den Bos
 Duration: 3:22
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/escapade
@@ -123,9 +122,6 @@ Cover Artists:
 Art Tags:
 - Jack Noir
 # - Ninja Sword # (?) as prototyped
-Referenced Tracks:
-- Liquid Negrocity
-- I'm a Member of the Midnight Crew
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commmentary)
 
@@ -1165,7 +1161,7 @@ Referenced Tracks:
 - The Nobles
 - Windswept Shale
 - Radiant Dunes
-- track:escapade-stlap3
+- track:escapade-desynced
 - On Apocalyptic Shores
 - Chaos Flames
 - Fight for the Future


### PR DESCRIPTION
These mostly concern the track, Escapade by Pascal van den Bos, which was released on Desynced Vol. 1 (2/7/2020), and later on Stable Time Loops and Paradoxes 3 (4/13/2020).

- removed Artists field and Referenced Tracks field from the STLaP 3 release of Escapade - [hsmusic-data/stlap3.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/stlap3.yaml)
- added Originally Released As field to STLaP 3 release of Escapade - [hsmusic-data/stlap3.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/stlap3.yaml)
- added I'm a Member of the Midnight Crew (referenced track) to the Desynced Vol. 1 release of Escapade (cause otherwise, the STLaP 3 rerelease would only reference Liquid Negrocity) in [hsmusic-data/desynced-vol-1.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/desynced-vol-1.yaml) 
- changed `track:escapade-stlap3` references into `track:escapade-desynced` references in [hsmusic-data/stlap2.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/stlap2.yaml), and [hsmusic-data/stlap3.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/stlap3.yaml),  so now all the tracks referencing Escapade should be together
- fixed e_music artist link on STLaP 3 album credits (from Bandcamp); it was `emusic`, when it should've been `[[artist:e-music]]` in [hsmusic-data/stlap3.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/stlap3.yaml)