### PR TITLE
Add descriptions for additional files and track sections

### DIFF
--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -608,6 +608,8 @@ Commentary: |-
     <img src="media/misc/skaian-summoning.png" width="300">
 ---
 Section: Bonus tracks
+Description: >-
+    [[track:the-thirteenth-hour]], [[track:theme]], and [[track:walls-covered-in-blood-dx]] were "super-secret hidden bonus tracks" on Bandcamp. The remaining bonus tracks were listenable online.
 ---
 Track: The Thirteenth Hour
 Duration: '2:10'

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -21,9 +21,18 @@ Art Tags:
 Additional Files:
 - Title: Album booklet
   Description: >-
-    Credit and commentary booklet, included with the album download. Also includes wide bonus artworks by [[artist:cindy-dominguez]] and [[artist:andrew-hussie]].
+    Credit and commentary booklet, included with the album download. Also contains wide background artworks by [[artist:cindy-dominguez]] and [[artist:andrew-hussie]].
   Files:
   - Alternia_Commentary.pdf
+- Title: Booklet background artworks
+  Description: >-
+    Extracted from album booklet PDF; these artworks are a tag-team effort by by [[artist:cindy-dominguez]] and [[artist:andrew-hussie]].
+  Files:
+  - Booklet Background 1.png
+  - Booklet Background 2.png
+  - Booklet Background 3.jpg
+  - Booklet Background 4.jpg
+  - Booklet Background 5.jpg
 Commentary: |-
     <i>Toby Fox:</i> (booklet commentary - front)
 

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -19,7 +19,9 @@ Art Tags:
 - Terezi
 - Alternia
 Additional Files:
-- Title: Album Booklet
+- Title: Album booklet
+  Description: >-
+    Credit and commentary booklet, included with the album download. Also includes wide bonus artworks by [[artist:cindy-dominguez]] and [[artist:andrew-hussie]].
   Files:
   - Alternia_Commentary.pdf
 Commentary: |-

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -89,10 +89,12 @@ Wallpaper Artists:
 - Niklink (edits for wiki)
 Default Track Cover Art Date: October 25, 2017
 Additional Files:
-- Title: Album Booklet
+- Title: Album booklet
+  Description: >-
+    Credit and commentary booklet, included with the album download.
   Files:
   - AlterniaBound_Commentary.pdf
-- Title: Bandcamp Banner
+- Title: Bandcamp banner
   Files:
   - banner.jpg
 ---

--- a/album/beyond-canon.yaml
+++ b/album/beyond-canon.yaml
@@ -129,9 +129,11 @@ Commentary: |-
     [[artist:emelia-k]]
 Default Track Cover Art Date: June 1, 2020
 Additional Files:
-- Title: Fan Anthology Art Booklet
+- Title: Anthology art booklet
+  Description: >-
+    Booklet featuring all the fan-anthology track artworks, plus making-of commentary and WIPs. From [UMSPAF's Tumblr](https://hsfanmusic.skaia.net/post/619761136023257089/unofficialmspafans-we-are-proud-to-announce-the).
   Files:
-  - 'Beyond Canon Anthology Art Book.pdf'
+  - Beyond Canon Anthology Art Book.pdf
 ---
 Track: exclusion zone
 Artists:

--- a/album/cherubim.yaml
+++ b/album/cherubim.yaml
@@ -20,10 +20,12 @@ Banner Artists:
 Banner Dimensions: 1100x203
 Banner File Extension: png
 Additional Files:
-- Title: Album Credits
+- Title: Album credits
+  Description: >-
+    Included with the album download.
   Files:
   - TrackCredits.txt
-- Title: Bandcamp Banner
+- Title: Bandcamp banner
   Files:
   - banner.jpg
 Commentary: |-

--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -37,6 +37,8 @@ Wallpaper Artists:
 - Niklink (edits for wiki)
 Additional Files:
 - Title: Credits, lyrics, and trivia
+  Description: >-
+    Included with the album download.
   Files:
   - CREDITS_A.txt
   - LYRICS_ETC_A.txt

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -31,11 +31,11 @@ Wallpaper Artists:
 - Shelby Cragg
 - Niklink (edits for wiki)
 Additional Files:
-- Title: Album Credits
+- Title: Credits, lyrics, and trivia
+  Description: >-
+    Included with the album download.
   Files:
   - CREDITS_B.txt
-- Title: Lyrics & Trivia
-  Files:
   - LYRICS_ETC_B.txt
 Commentary: |-
     <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20120414114842/https://homestuck.bandcamp.com/album/colours-and-mayhem-universe-b))

--- a/album/genesis-frog.yaml
+++ b/album/genesis-frog.yaml
@@ -83,7 +83,9 @@ Wallpaper Style: |-
     background-size: auto;
 Wallpaper File Extension: png
 Additional Files:
-- Title: Solo Album Month Bandcamp Banner and Background
+- Title: Solo Album Month Bandcamp banner & background
+  Description: >-
+    Greyscale theme used on Bandcamp throughout late 2012, with the releases of [[album:symphony-impossible-to-play]], [[album:one-year-older]], and this album.
   Files:
   - banner.jpg
   - bg.jpg

--- a/album/homestuck-vol-1-4.yaml
+++ b/album/homestuck-vol-1-4.yaml
@@ -64,8 +64,10 @@ Commentary: |-
     [[artist:michael-vallejo]]<br>
     [[artist:toby-fox|Toby "Radiation" Fox]]
 ---
-Color: '#38f43d'
 Section: From Homestuck Vol. 1
+Color: '#38f43d'
+Description: >-
+    Doesn't include [[track:sburban-jungle-brief-mix]] or [[track:aggrieve-violin-redux]].
 ---
 Track: Showtime (Piano Refrain)
 Originally Released As: Showtime (Piano Refrain)
@@ -151,8 +153,10 @@ URLs:
 - https://homestuck.bandcamp.com/track/skies-of-skaia-3
 - https://youtu.be/tjq32cJRqpc
 ---
-Color: '#cb87f6'
 Section: From Homestuck Vol. 2
+Color: '#cb87f6'
+Description: >-
+    Tracks [[track:john-sleeps-skaian-magicant|11]], [[track:gardener|15]], and [[track:potential-verdancy|19]] are new to this release, replacing [[track:skaian-dreams-remix]], [[track:guardian]], and [[track:kinetic-verdancy]] respectively; [[track:nightlife-extended]] is excluded without a replacement.
 ---
 Track: Harlequin (Rock Version)
 Originally Released As: Harlequin (Rock Version)
@@ -271,8 +275,10 @@ Referenced Tracks:
 Sampled Tracks:
 - Verdancy (Bassline)
 ---
-Color: '#ef001d'
 Section: From Homestuck Vol. 3
+Color: '#ef001d'
+Description: >-
+    Doesn't include [[track:rediscover-fusion-remix]] (which had been previously removed from the original Vol. 3).
 ---
 Track: Beatdown (Strider Style)
 Originally Released As: Beatdown (Strider Style)
@@ -382,8 +388,10 @@ URLs:
 - https://homestuck.bandcamp.com/track/pony-chorale-3
 - https://youtu.be/B88bE5niVFQ
 ---
-Color: '#51a2fd'
 Section: From Homestuck Vol. 4
+Color: '#51a2fd'
+Description: >-
+    Doesn't include [[track:mutiny]], [[track:guardian-v2]], or [[track:contention-vol4]] (all of which had been previously removed from the original Vol. 4).
 ---
 Track: Revelawesome
 Originally Released As: Revelawesome
@@ -497,7 +505,9 @@ URLs:
 - https://homestuck.bandcamp.com/track/black-3
 - https://youtu.be/dJ7H7MkL1Yk
 ---
-Section: Bonus tracks
+Section: Bonus track
+Description: >-
+    New to this release.
 ---
 Track: Doctor (Original Loop)
 Suffix Directory: false

--- a/album/homestuck-vol-1-4.yaml
+++ b/album/homestuck-vol-1-4.yaml
@@ -156,7 +156,7 @@ URLs:
 Section: From Homestuck Vol. 2
 Color: '#cb87f6'
 Description: >-
-    Tracks [[track:john-sleeps-skaian-magicant|11]], [[track:gardener|15]], and [[track:potential-verdancy|19]] are new to this release, replacing [[track:skaian-dreams-remix]], [[track:guardian]], and [[track:kinetic-verdancy]] respectively; [[track:nightlife-extended]] is excluded without a replacement.
+    [[track:john-sleeps-skaian-magicant]], [[track:gardener]], and [[track:potential-verdancy]] are new to this release, replacing [[track:skaian-dreams-remix]], [[track:guardian]], and [[track:kinetic-verdancy]] respectively; [[track:nightlife-extended]] is excluded without a replacement.
 ---
 Track: Harlequin (Rock Version)
 Originally Released As: Harlequin (Rock Version)

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -217,7 +217,8 @@ Commentary: |-
     ([Release listening / Q&A stream](https://www.youtube.com/watch?v=HJWqqikd6S0))
 Additional Files:
 - Title: Album Booklet
-  Description: Original divided into two parts, or choose the compressed file for all the pages in one.
+  Description: >-
+    Stylized credit and commentary booklet, included with the album download. Due to file size limitations, the original PDF is divided into two parts; choose the compressed file for all the pages in one.
   Files:
   - Booklet (Part 1 of 2).pdf
   - Booklet (Part 2 of 2).pdf

--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -18,12 +18,16 @@ Wallpaper Artists:
 - Homestuck
 - Niklink (edits for wiki)
 Additional Files:
-- Title: SBURB Wallpaper
+- Title: SBURB wallpaper
+  Description: >-
+    Included in the album download, as well as the download for [[album:homestuck-vol-1-4]].
   Files:
   - sburbwp_1280x1024.jpg
   - sburbwp_1440x900.jpg
   - sburbwp_1920x1080.jpg
-- Title: Alternate Covers
+- Title: Alternate cover artworks
+  Description: >-
+    Included in the album download. One for each option on the [wardrobifier](https://mspaintadventures.fandom.com/wiki/Wardrobifier).
   Files:
   - Homestuck_Vol4_alt1.jpg
   - Homestuck_Vol4_alt2.jpg

--- a/album/homestuck-vol-5.yaml
+++ b/album/homestuck-vol-5.yaml
@@ -27,6 +27,8 @@ Additional Files:
   Files:
   - Homestuck_Vol5.pdf
 - Title: What Pumpkin site banner
+  Description: >-
+    Banner on ["about the albums"](https://web.archive.org/web/20100616162425/http://www.whatpumpkin.com/albums.html) page.
   Files:
   - vol5.jpg
 Commentary: |-

--- a/album/homestuck-vol-5.yaml
+++ b/album/homestuck-vol-5.yaml
@@ -21,10 +21,12 @@ Art Tags:
 - Squiddles
 - Skaia
 Additional Files:
-- Title: Album Booklet
+- Title: Album booklet
+  Description: >-
+    Credit booklet with some extended album cover artworks, also. Includes credits for tracks by [[artist:soluslunes]] which were later removed; the album download stopped including this booklet.
   Files:
   - Homestuck_Vol5.pdf
-- Title: What Pumpkin Site Banner
+- Title: What Pumpkin site banner
   Files:
   - vol5.jpg
 Commentary: |-

--- a/album/homestuck-vol-6.yaml
+++ b/album/homestuck-vol-6.yaml
@@ -32,6 +32,8 @@ Additional Files:
   Files:
   - bg.jpg
 - Title: What Pumpkin site banner
+  Description: >-
+    Banner on ["about the albums"](https://web.archive.org/web/20110718035128/http://www.whatpumpkin.com/albums.html) page.
   Files:
   - vol6_wp_banner.jpg
 Commentary: |-

--- a/album/homestuck-vol-6.yaml
+++ b/album/homestuck-vol-6.yaml
@@ -28,10 +28,10 @@ Wallpaper Artists:
 - Andrew Hussie
 Wallpaper Style: 'opacity: 0.55;'
 Additional Files:
-- Title: Bandcamp Background
+- Title: Bandcamp background
   Files:
   - bg.jpg
-- Title: What Pumpkin Site Banner
+- Title: What Pumpkin site banner
   Files:
   - vol6_wp_banner.jpg
 Commentary: |-

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -25,10 +25,14 @@ Wallpaper Artists:
 - Homestuck
 Wallpaper Style: 'opacity: 1;'
 Additional Files:
-- Title: Album Credits
+- Title: Album credits
+  Description: >-
+    Included with the album download.
   Files:
   - Vol 7.txt
-- Title: Bandcamp Banner and Background
+- Title: Bandcamp banner & background
+  Description: >-
+    This album and [[album:mobius-trip-and-hadron-kaleido]] were released on the same day; the banner artwork highlights both of them.
   Files:
   - banner.jpg
   - bg.jpg

--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -29,10 +29,12 @@ Wallpaper Style: |-
     background-repeat: repeat;
     background-size: auto;
 Additional Files:
-- Title: Album Credits
+- Title: Album credits
+  Description: >-
+    Music and artwork credits, included with the album download.
   Files:
   - Credits.txt
-- Title: Bandcamp Banner and Background
+- Title: Bandcamp banner & background
   Files:
   - banner.jpg
   - bg.gif

--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -1205,6 +1205,8 @@ MIDI Project Files:
   - "I'm a Member of the Midnight Crew (Acapella) - cookiefonster.mid"
 ---
 Section: Bonus tracks
+Description: >-
+    The track [[track:null-vol8]] was only included for a brief period after this album's release.
 ---
 Track: How Do I Live (D8 Night Version)
 Additional Names:

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -33,7 +33,9 @@ Wallpaper Style: |-
     background-repeat: repeat;
     background-size: auto;
 Additional Files:
-- Title: Album Credits
+- Title: Album credits
+  Description: >-
+    Music and artwork credits, included with the album download.
   Files:
   - VOL_9_CREDITS.txt
 - Title: Bandcamp Banner and Background

--- a/album/lofam.yaml
+++ b/album/lofam.yaml
@@ -225,17 +225,18 @@ Banner Style: |-
     image-rendering: crisp-edges;
 Additional Files:
 - Title: Album Booklet
+  Description: >-
+    Credit and commentary booklet, included with the album download.
   Files:
   - Commentary Booklet.pdf
 - Title: Bandcamp Banner
   Files:
   - banner.png
 - Title: Site Banner
+  Description: >-
+    Banner on [hsfanmusic.skaia.net](https://hsfanmusic.skaia.net/lofam.html).
   Files:
   - banner_alt.png
-- Title: The Straggler (Sburban Rush animation) 
-  Files:
-  - the_straggler___sburban_rush_by_ralengainsborough.swf
 ---
 Track: Beginnings (Press Start to Play)
 Additional Names:
@@ -737,6 +738,12 @@ Art Tags:
 - John
 Referenced Tracks:
 - Sburban Jungle
+Additional Files:
+- Title: The Straggler
+  Description: >-
+    Fan-animation referenced in commentary, by [[artist:ralen-gainsborough]] (this track's composer). [Shared on DeviantArt.](https://www.deviantart.com/ralengainsborough/art/The-Straggler-Sburban-Rush-172750637)
+  Files:
+  - the_straggler___sburban_rush_by_ralengainsborough.swf
 Commentary: |-
     <i>Ralen Gainsborough:</i> (booklet commentary)
 

--- a/album/medium.yaml
+++ b/album/medium.yaml
@@ -27,7 +27,7 @@ Wallpaper Style: |-
     background-repeat: no-repeat;
     opacity: 0.9;
 Additional Files:
-- Title: Bandcamp Background
+- Title: Bandcamp background
   Files:
   - bg.jpg
 Commentary: |-

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -24,7 +24,9 @@ Color: '#dd0000'
 Groups:
 - group:official
 Additional Files:
-- Title: Album Cover Wallpaper (shared separately)
+- Title: Cover artwork wallpaper
+  Description: >-
+    Officially shared through [MSPA's desktop wallpaper page](http://www.mspaintadventures.com/desktops.html), in three sizes.
   Files:
   - mcwpp_1280x1024.jpg
   - mcwpp_1440x900.jpg

--- a/album/mobius-trip-and-hadron-kaleido.yaml
+++ b/album/mobius-trip-and-hadron-kaleido.yaml
@@ -24,10 +24,14 @@ Groups:
 Art Tags:
 - Mobius Trip
 Additional Files:
-- Title: Album Booklet
+- Title: Album booklet
+  Description: >-
+    Highly stylized lyric booklet, included with the album download. Features four exclusive artworks.
   Files:
   - Mobius_Trip_And_Hadron_Kaleido_Booklet.pdf
-- Title: Bandcamp Banner (w/ Vol. 7)
+- Title: Bandcamp banner
+  Description: >-
+    This album and [[album:homestuck-vol-7]] were released on the same day; the banner artwork highlights both of them.
   Files:
   - banner.jpg
 Commentary: |-

--- a/album/one-year-older.yaml
+++ b/album/one-year-older.yaml
@@ -591,6 +591,8 @@ Commentary: |-
     And of course, thanks for listening to this album, and supporting both me and the comic in whatever way you have.
 ---
 Section: 2019 release
+Description: >-
+    Hidden track, exclusive to the album download, included on the artist's personal-Bandcamp 2019 rerelease.
 ---
 Track: it's good to see you again
 Date First Released: October 29, 2019

--- a/album/one-year-older.yaml
+++ b/album/one-year-older.yaml
@@ -90,10 +90,14 @@ Wallpaper Style: |-
     background-size: auto;
 Wallpaper File Extension: png
 Additional Files:
-- Title: Album Booklet
+- Title: Album booklet
+  Description: >-
+    Commentary booklet, included with the album download.
   Files:
   - Commentary Book.pdf
-- Title: Solo Album Month Bandcamp Banner and Background
+- Title: Solo Album Month Bandcamp banner & background
+  Description: >-
+    Greyscale theme used on Bandcamp throughout late 2012, with the releases of [[album:symphony-impossible-to-play]], this album, and [[album:genesis-frog]].
   Files:
   - banner.jpg
   - bg.jpg

--- a/album/sburb.yaml
+++ b/album/sburb.yaml
@@ -88,13 +88,19 @@ Commentary: |-
 
     I was really glad when [James] had that Sburb album come out, you know, he referenced [[Sburban Jungle]] on that, which was, you know, an honor of course, and hearing it [[track:exodus|performed]] by [[artist:erik-scheele|Erik Scheele]] on the piano... And I think that's my favorite piece of Homestuck music, that album, just because regardless of where the themes came from, it was just good listening. You know. Could put that on during breakfast. (laughs)
 Additional Files:
-- Title: Commentary PDF
+- Title: Composer's notes
+  Description: >-
+    Liner notes for each piece, included with the album download. Not part of the composer's 2019 rerelease, which has updated commentary on the track pages instead.
   Files:
   - Composers Notes.pdf
 - Title: Composer's sheet music, all-in-one
+  Description: >-
+    Individual files, as they were [[media:misc/sburb-download.png|included]] in the album download, are available on the track pages; this zip file bundles them in one. Sheet music was not part of the composer's 2019 rerelease, though the Bandcamp blurb indicated it was available at email inquiry.
   Files:
   - 'Sburb - James Dever.zip'
-- Title: Bandcamp Banner (w/ The Wanderers)
+- Title: Bandcamp banner
+  Description: >-
+    This album and [[album:the-wanderers]] were released at about the same time; the banner artwork highlights both of them.
   Files:
   - banner.jpg
 ---

--- a/album/squiddles.yaml
+++ b/album/squiddles.yaml
@@ -19,13 +19,17 @@ Wallpaper Artists:
 Wallpaper Style: 'opacity: 0.85;'
 Wallpaper File Extension: png
 Additional Files:
-- Title: Album Booklet
+- Title: Album booklet
+  Description: >-
+    Credit and lyric booklet, included with the album download. Includes background artworks by [[artist:cindy-dominguez]].
   Files:
   - Squiddles_booklet.pdf
-- Title: Squiddles! Full Opening
+- Title: Squiddles! full opening
+  Description: >-
+    The iconic serial opening, included with the album download.
   Files:
   - squiddlevid.swf
-- Title: What Pumpkin Site Banner
+- Title: What Pumpkin site banner
   Files:
   - squiddles_banner.jpg
 Commentary: |-

--- a/album/squiddles.yaml
+++ b/album/squiddles.yaml
@@ -21,7 +21,7 @@ Wallpaper File Extension: png
 Additional Files:
 - Title: Album booklet
   Description: >-
-    Credit and lyric booklet, included with the album download. Includes background artworks by [[artist:cindy-dominguez]].
+    Credit and lyric booklet, included with the album download. Contains background artworks by [[artist:cindy-dominguez]].
   Files:
   - Squiddles_booklet.pdf
 - Title: Squiddles! full opening
@@ -30,6 +30,8 @@ Additional Files:
   Files:
   - squiddlevid.swf
 - Title: What Pumpkin site banner
+  Description: >-
+    Banner on ["Squiddles!"](https://web.archive.org/web/20100829123650/http://www.whatpumpkin.com:80/squiddles.html) page.
   Files:
   - squiddles_banner.jpg
 Commentary: |-

--- a/album/symphony-impossible-to-play.yaml
+++ b/album/symphony-impossible-to-play.yaml
@@ -29,11 +29,15 @@ Wallpaper Style: |-
     background-size: auto;
 Wallpaper File Extension: png
 Additional Files:
-- Title: Solo Album Month Bandcamp Banner and Background
+- Title: Solo Album Month Bandcamp banner & background
+  Description: >-
+    Greyscale theme used on Bandcamp throughout late 2012, with the releases of this album, [[album:one-year-older]], and [[album:genesis-frog]].
   Files:
   - banner.jpg
   - bg.jpg
-- Title: Album Cover Wallpaper (shared separately)
+- Title: Album cover wallpapers
+  Description: >-
+    Wallpapers shared by [[artist:tavia-morra]], the album cover artist, [on Tumblr](https://www.tumblr.com/seeyoutmorra/105491297899/symphony-impossible-to-play-by-clark-powell-cover).
   Files:
   - symphonyimpossibletoplaywallpaper1280x768.jpg
   - symphonyimpossibletoplaywallpaper1280x960.jpg

--- a/album/the-baby-is-you.yaml
+++ b/album/the-baby-is-you.yaml
@@ -19,7 +19,9 @@ Art Tags:
 - Karkat
 - Dave
 Additional Files:
-- Title: Official Lyrics
+- Title: Official lyrics
+  Description: >-
+    Included with the album download, probably.
   Files:
   - lyrics for queer dicks.txt
 Commentary: |-

--- a/album/the-felt.yaml
+++ b/album/the-felt.yaml
@@ -18,7 +18,7 @@ Art Tags:
 Wallpaper Artists:
 - Molly Gur
 Additional Files:
-- Title: Bandcamp Background
+- Title: Bandcamp background
   Files:
   - bg.jpg
 Wallpaper Style: 'opacity: 0.5;'

--- a/album/the-wanderers.yaml
+++ b/album/the-wanderers.yaml
@@ -74,10 +74,14 @@ Wallpaper Style: |-
     background-color: #83bace;
     opacity: 0.85;
 Additional Files:
-- Title: Album Credits
+- Title: Album credits
+  Description: >-
+    Included with the album download.
   Files:
   - Tracks and Art.txt
-- Title: Bandcamp Banner and Background
+- Title: Bandcamp banner & background
+  Description: >-
+    This album and [[album:sburb]] were released at about the same time; the banner artwork highlights both of them.
   Files:
   - banner.jpg
   - bg.jpg

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -192,6 +192,8 @@ Content: |-
     - moved [[track:gasters-theme-pga]] ([[album:perfectly-generic-album]]) from main track list to new "Removed in 2022 release" section (thanks, Tangle!)
     - moved [[track:thunderhead-loftlocked]] from [[album:more-homestuck-fandom]] to [[album:loftlocked-vol-1]] (thanks, Lilith!)
     - moved [[track:an-apple-disaster]] from [[album:references-beyond-homestuck]] to [[album:improvised-touhou-music-with-annoying-commentary]] (thanks, Lilith!)
+    <!-- other moved misc -->
+    - moved "The Straggler" additional file from [[album:lofam]] additional files to [[track:sburban-rush]]
     <!-- general removals -->
     - removed "Infection 2" and made this into an additional name on [[track:chronic-infection]] (and added commentary here; thanks, Lilith!)
     - removed "Flare (Green Sun Remix)" and made this into an additional name on [[track:flare-insurrection-remix]] (which was previously listed as a rerelease)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -121,6 +121,7 @@ Content: |-
     <!-- artworks -->
     - added better-quality alternate artwork to [[track:elephant-gun]] (thanks, Lilith!)
     <!-- additional files -->
+    - added booklet backgrounds as additional files to [[album:alternia]]
     - added composers' NSF project files to [[track:logorg]], [[track:bars-jailbreak]], [[track:drillgorg]], and [[track:retrobution]] (duplicated from album's additional files; thanks, Lan!)
     - added album release photoset to [[album:ulterior-motives]]
     <!-- additional names -->


### PR DESCRIPTION
This is a very WIP pull request, just filing so it's open and tracked.

Based on hsmusic/hsmusic-wiki#541 of course!
Merge alongside hsmusic/hsmusic-media#82.

official discography only in this PR

- additional file descriptions
  - [x] mc;dd -> sburb (general)
  - [x] vol 8, vol 9, vol 10
  - [x] prospit & derse -> genesis frog (solo albums)
  - [x] coloUrs and mayhem
  - [x] cherubim, collide
  - [x] pesterquest soundtrack, beyond canon
- track section descriptions
  - [x] vol 1-4
  - [x] vol 8
  - [x] alternia
  - [x] one year older
