### PR TITLE
Album addition: Shenanigans: MSPA by Thomas Ibarra!

### DIFF
--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -730,6 +730,8 @@ MIDI Project Files:
   - 'Do The Windy Thing - Unknown (marching band).mid'
 ---
 Track: Pilot Light
+Artists:
+- Thomas Ibarra
 Duration: 2:51
 URLs:
 - https://homestuck.bandcamp.com/track/pilot-light-2

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -730,6 +730,11 @@ MIDI Project Files:
   - 'Do The Windy Thing - Unknown (marching band).mid'
 ---
 Track: Pilot Light
+Additional Names:
+- Name: >-
+    Pilot Light: The Witch's Cauldron
+  Annotation: >-
+    [Soundcloud release](https://soundcloud.com/sparksd2145/pilot-light-the-witchs)
 Artists:
 - Thomas Ibarra
 Duration: 2:51
@@ -748,6 +753,12 @@ Art Tags:
 - LoFaF
 Referenced Tracks:
 - Flare
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
+
+   Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
+
+   This is my first attempt at an entry for the 2012 Homestuck Music Contest.
 ---
 Track: Ohgodcat
 Artists:

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -754,11 +754,11 @@ Art Tags:
 Referenced Tracks:
 - Flare
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
 
-   Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
+    Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
 
-   This is my first attempt at an entry for the 2012 Homestuck Music Contest.
+    This is my first attempt at an entry for the 2012 Homestuck Music Contest.
 ---
 Track: Ohgodcat
 Artists:

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -730,13 +730,7 @@ MIDI Project Files:
   - 'Do The Windy Thing - Unknown (marching band).mid'
 ---
 Track: Pilot Light
-Additional Names:
-- Name: >-
-    Pilot Light: The Witch's Cauldron
-  Annotation: >-
-    [Soundcloud release](https://soundcloud.com/sparksd2145/pilot-light-the-witchs)
-Artists:
-- Thomas Ibarra
+Main Release: 'Shenanigans: MSPA'
 Duration: 2:51
 URLs:
 - https://homestuck.bandcamp.com/track/pilot-light-2
@@ -751,14 +745,6 @@ Art Tags:
 - LoLaR
 - LoHaC
 - LoFaF
-Referenced Tracks:
-- Flare
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
-
-    Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
-
-    This is my first attempt at an entry for the 2012 Homestuck Music Contest.
 ---
 Track: Ohgodcat
 Artists:

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -730,7 +730,6 @@ MIDI Project Files:
   - 'Do The Windy Thing - Unknown (marching band).mid'
 ---
 Track: Pilot Light
-Main Release: 'Shenanigans: MSPA'
 Duration: 2:51
 URLs:
 - https://homestuck.bandcamp.com/track/pilot-light-2
@@ -745,6 +744,8 @@ Art Tags:
 - LoLaR
 - LoHaC
 - LoFaF
+Referenced Tracks:
+- Flare
 ---
 Track: Ohgodcat
 Artists:

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -1091,6 +1091,8 @@ Commentary: |-
 Track: Irradiated
 Suffix Directory: true
 Always Reference By Directory: true
+Artists:
+- Thomas Ibarra
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/irradiated
@@ -1103,8 +1105,13 @@ Art Tags:
 - 'cw: blood'
 - Warhammer of Zillyhoo
 - Breath
-Referenced Tracks:
+Previous Productions:
 - track:irradiated-thomas-ibarra
+Referenced Tracks:
+- Harlequin
+- Liquid Negrocity
+- Sburban Jungle
+- track:carefree-action
 Commentary: |-
     <i>Thomas Ibarra:</i> (composer, booklet commentary)
 

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -277,8 +277,7 @@ Commentary: |-
 Track: Rectify
 Suffix Directory: true
 Always Reference By Directory: true
-Artists:
-- Thomas Ibarra
+Main Release: 'Shenanigans: MSPA'
 Duration: 2:52
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/rectify
@@ -288,14 +287,10 @@ Cover Artists:
 Art Tags:
 - Jack Noir
 - Green Sun
-Referenced Tracks:
-- Liquid Negrocity
-- Atomyk Ebonpyre
-- Showtime (Piano Refrain)
 Commentary: |-
     <i>Thomas Ibarra:</i> (composer, booklet commentary)
 
-    My second entry to [[album:coloUrs-and-mayhem-universe-a|the music contest]], Rectify, was a follow-up to [[track:irradiated-lofam2]] in that it presented the same goal of making something different with the [[Black]]/[[Liquid Negrocity]] leitmotif. In this composition, based on Cascade, the menacing tone of Black would be turned into a battle theme for the good, as if Jack had performed a heelturn in light of impressive character development. It was a fun, fulfilling project that taught me many new things.
+    My second entry to [[album:coloUrs-and-mayhem-universe-a|the music contest]], Rectify, was a follow-up to [[track:irradated|Irradiated]] in that it presented the same goal of making something different with the [[Black]]/[[Liquid Negrocity]] leitmotif. In this composition, based on Cascade, the menacing tone of Black would be turned into a battle theme for the good, as if Jack had performed a heelturn in light of impressive character development. It was a fun, fulfilling project that taught me many new things.
 ---
 Track: Rabbunctious!
 Additional Names:
@@ -418,7 +413,7 @@ Art Tags:
 - Jack Noir
 - Frog Temple
 - Pumpkin
-- 
+-
 Referenced Tracks:
 - Endless Expanse
 - Carapacian Dominion
@@ -1096,8 +1091,7 @@ Commentary: |-
 Track: Irradiated
 Suffix Directory: true
 Always Reference By Directory: true
-Artists:
-- Thomas Ibarra
+Main Release: Irradated
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/irradiated
@@ -1110,11 +1104,6 @@ Art Tags:
 - 'cw: blood'
 - Warhammer of Zillyhoo
 - Breath
-Referenced Tracks:
-- Harlequin
-- Liquid Negrocity
-- Sburban Jungle
-- track:carefree-action
 Commentary: |-
     <i>Thomas Ibarra:</i> (composer, booklet commentary)
 

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -1090,7 +1090,7 @@ Commentary: |-
 ---
 Track: Irradiated
 Suffix Directory: true
-Main Release: 'Shenanigans: MSPA'
+Always Reference By Directory: true
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/irradiated
@@ -1103,6 +1103,8 @@ Art Tags:
 - 'cw: blood'
 - Warhammer of Zillyhoo
 - Breath
+Referenced Tracks:
+- track:irradiated-thomas-ibarra
 Commentary: |-
     <i>Thomas Ibarra:</i> (composer, booklet commentary)
 

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -290,7 +290,7 @@ Art Tags:
 Commentary: |-
     <i>Thomas Ibarra:</i> (composer, booklet commentary)
 
-    My second entry to [[album:coloUrs-and-mayhem-universe-a|the music contest]], Rectify, was a follow-up to [[track:irradated|Irradiated]] in that it presented the same goal of making something different with the [[Black]]/[[Liquid Negrocity]] leitmotif. In this composition, based on Cascade, the menacing tone of Black would be turned into a battle theme for the good, as if Jack had performed a heelturn in light of impressive character development. It was a fun, fulfilling project that taught me many new things.
+    My second entry to [[album:coloUrs-and-mayhem-universe-a|the music contest]], Rectify, was a follow-up to [[track:irradiated-shenanigans-mspa|Irradiated]] in that it presented the same goal of making something different with the [[Black]]/[[Liquid Negrocity]] leitmotif. In this composition, based on Cascade, the menacing tone of Black would be turned into a battle theme for the good, as if Jack had performed a heelturn in light of impressive character development. It was a fun, fulfilling project that taught me many new things.
 ---
 Track: Rabbunctious!
 Additional Names:
@@ -1090,8 +1090,7 @@ Commentary: |-
 ---
 Track: Irradiated
 Suffix Directory: true
-Always Reference By Directory: true
-Main Release: Irradated
+Main Release: 'Shenanigans: MSPA'
 Duration: 2:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/irradiated

--- a/album/lofam3.yaml
+++ b/album/lofam3.yaml
@@ -1309,8 +1309,8 @@ Commentary: |-
     [[Mother]] - [[artist:erik-scheele|Erik "Jit" Scheele]]
 ---
 Track: Electric Fireflies
-Artists:
-- Thomas Ibarra
+Suffix Directory: true
+Main Release: 'Shenanigans: MSPA'
 Duration: 3:39
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/electric-fireflies
@@ -1329,10 +1329,6 @@ Art Tags:
 - Dirk
 - Jake
 - Serenity
-Referenced Tracks:
-- Firefly Cloud
-- Doctor
-- Showtime (Original Mix)
 Commentary: |-
     <i>Thomas Ibarra:</i> (composer, booklet commentary)
 
@@ -2197,7 +2193,7 @@ Commentary: |-
     <i>Lunise:</i> (track artist, booklet commentary)
 
     I HOPE YOU LIKE GAMEGRL
-    
+
     <i>Lunise:</i> ([Tumblr](https://www.tumblr.com/lunedraws-archive/46861279192/does-this-look-familiar-it-should-because-this-is), excerpt, 04/01/2013)
 
     Does this look familiar? It should because this is the new and improved, revamped version of some art for a track that didn't quite make it onto [[album:lofam2|LOFAM2]]! What was once the art for [[track:stalemate-play-the-rain]] is now the art for Dogfight (Dirtiest's Dubstep Remix), which will soon be on LOFAM3, and I'm glad to announce that it didn't cause me <i>nearly</i> as much pain and suffering as it originally did. Upscaling to 300dpi was a bit of an issue but in the grand scheme of things this version was a lot less painful to do than its low-res counterpart.

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -2265,6 +2265,33 @@ Duration: 1:58
 URLs:
 - https://media.hsmusic.wiki/misc/archive/Inevitable%20End.mp3
 ---
+Track: Irradiated
+Directory: irradiated-thomas-ibarra
+Always Reference By Directory: true
+Additional Names:
+- Name: >-
+    Irradiated (obsolete)
+  Annotation: >-
+    [SoundCloud](https://soundcloud.com/sparksd2145/irradiated)
+Artists:
+- Thomas Ibarra
+Duration: 2:16
+URLs:
+- https://soundcloud.com/sparksd2145/irradiated
+Referenced Tracks:
+- Harlequin
+- Liquid Negrocity
+- Sburban Jungle
+- track:carefree-action
+Commentary: |-
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    The SoundCloud description for this track reads "Homestuck remixes, lots of them." just like the other tracks also uploaded on [[date:8/12/2011]], so it was presumably included with the original [[album:shenanigans-mspa]] set. It's not included there today though, and was probably replaced by [[track:irradiated-shenanigans-mspa|the updated version]] ([[track:irradiated-lofam2|made for LOFAM2]]).
+
+    Despite its SoundCloud upload in August, this original version of the track dates earlier than [[track:irradiated-animation-version|the animation version]] from February 2011.
+
+    This track has the same duration as the later version. By that alone, it's ostensibly possible that this track was included on Shenanigans: MSPA's [Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/). But it doesn't seem likely, since the updated version is from [[date:6/20/2012]], predating the Bandcamp release by three months. [The download from skaia.net](http://dl.skaia.net/albums), aligning with Bandcamp's track list, affirms the updated version is what got included there.
+---
 Track: Karkalicious
 Artists:
 - Superspecks!

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -2284,7 +2284,7 @@ Referenced Tracks:
 - Sburban Jungle
 - track:carefree-action
 Commentary: |-
-    <i>Quasar Nebula:</i> (wiki editor)
+    <i>Quasar Nebula:</i> (wiki editor, 10/3/2024)
 
     The SoundCloud description for this track reads "Homestuck remixes, lots of them." just like the other tracks also uploaded on [[date:8/12/2011]], so it was presumably included with the original [[album:shenanigans-mspa]] set. It's not included there today though, and was probably replaced by [[track:irradiated-shenanigans-mspa|the updated version]] ([[track:irradiated-lofam2|made for LOFAM2]]).
 

--- a/album/shenanigans-mspa-chiptuned.yaml
+++ b/album/shenanigans-mspa-chiptuned.yaml
@@ -30,6 +30,7 @@ Additional Names:
 Duration: 3:14
 URLs:
 - https://soundcloud.com/sparksd2145/strife-chiptuned
+- https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Strife_8bit.wav
 Referenced Tracks:
 - track:strife-shenanigans-mspa
 Commentary: |-
@@ -41,6 +42,8 @@ Track: Rectify - Chiptuned
 Additional Names:
 - Rectify_8bit.wav (filename)
 Duration: 3:12
+URLs:
+- https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Rectify_8bit.wav
 Referenced Tracks:
 - track:rectify-shenanigans-mspa
 ---
@@ -48,6 +51,8 @@ Track: Pilot Light - Chiptuned
 Additional Names:
 - Pilot Light_8bit.wav (filename)
 Duration: 2:51
+URLs:
+- https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Pilot+Light_8bit.wav
 Referenced Tracks:
 - Pilot Light
 ---
@@ -55,6 +60,8 @@ Track: Curtain Roll - Chiptuned
 Additional Names:
 - Curtain Roll_8bit.wav (filename)
 Duration: 1:30
+URLs:
+- https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Curtain+Roll_8bit.wav
 Referenced Tracks:
 - Curtain Roll
 ---
@@ -62,5 +69,7 @@ Track: Downtime - Chiptuned
 Additional Names:
 - Downtime_8bit.wav (filename)
 Duration: 1:30
+URLs:
+- https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Downtime_8bit.wav
 Referenced Tracks:
 - track:downtime-lofam

--- a/album/shenanigans-mspa-chiptuned.yaml
+++ b/album/shenanigans-mspa-chiptuned.yaml
@@ -1,0 +1,66 @@
+Album: 'Shenanigans: MSPA - Chiptuned'
+Date: December 31, 2014
+Artists:
+- Thomas Ibarra
+Has Track Numbers: false
+Cover Artists:
+- Thomas Ibarra
+Referenced Artworks:
+- 'Shenanigans: MSPA'
+- "Pilot Light: The Witch's Cauldron"
+Color: '#f8ebc9'
+Groups:
+- Fandom
+Commentary: |-
+    <i>Quasar Nebula:</i> (wiki editor, 11/6/2025)
+
+    Companion tracks for [[album:shenanigans-mspa]]. Only the first of these tracks has previously been released, so the date for this album is from there. The rest of the tracks were shared with us (with permission to preserve and share) while gathering files and doing research for the main album.
+
+    <i>Thomas Ibarra, Quasar Nebula|[[artist:thomas-ibarra]]:</i> (wiki communications over Discord DMs, excerpt, 11/6/2025)
+
+    > <i>[[artist:quasar-nebula|Lan]]:</i> I'm working on a page for the Chiptuned tracks, now... to me, even though I think maybe only a single one of these tracks was ever released before... I think the cover art really gives the impression that this was its own set of tracks, a companion to Shenanigans: MSPA proper
+
+    It's true, they are companion tracks. In all actuality they're the same tracks, with instruments swapped and some minor modifications.
+
+    I did not fully grasp what made a chiptune song, a chiptune song at the time
+---
+Track: Strife - Chiptuned
+Additional Names:
+- Strife_8bit.wav (filename)
+Duration: 3:14
+URLs:
+- https://soundcloud.com/sparksd2145/strife-chiptuned
+Referenced Tracks:
+- track:strife-shenanigans-mspa
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/strife-chiptuned), excerpt)
+
+    I took a look at my favorite works, and decided they'd sound neat with tb_peach. I believe I was right.
+---
+Track: Rectify - Chiptuned
+Additional Names:
+- Rectify_8bit.wav (filename)
+Duration: 3:12
+Referenced Tracks:
+- track:rectify-shenanigans-mspa
+---
+Track: Pilot Light - Chiptuned
+Additional Names:
+- Pilot Light_8bit.wav (filename)
+Duration: 2:51
+Referenced Tracks:
+- Pilot Light
+---
+Track: Curtain Roll - Chiptuned
+Additional Names:
+- Curtain Roll_8bit.wav (filename)
+Duration: 1:30
+Referenced Tracks:
+- Curtain Roll
+---
+Track: Downtime - Chiptuned
+Additional Names:
+- Downtime_8bit.wav
+Duration: 1:30
+Referenced Tracks:
+- track:downtime-lofam

--- a/album/shenanigans-mspa-chiptuned.yaml
+++ b/album/shenanigans-mspa-chiptuned.yaml
@@ -60,7 +60,7 @@ Referenced Tracks:
 ---
 Track: Downtime - Chiptuned
 Additional Names:
-- Downtime_8bit.wav
+- Downtime_8bit.wav (filename)
 Duration: 1:30
 Referenced Tracks:
 - track:downtime-lofam

--- a/album/shenanigans-mspa-chiptuned.yaml
+++ b/album/shenanigans-mspa-chiptuned.yaml
@@ -41,6 +41,7 @@ Commentary: |-
 Track: Rectify - Chiptuned
 Additional Names:
 - Rectify_8bit.wav (filename)
+Has Date: false
 Duration: 3:12
 URLs:
 - https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Rectify_8bit.wav
@@ -50,6 +51,7 @@ Referenced Tracks:
 Track: Pilot Light - Chiptuned
 Additional Names:
 - Pilot Light_8bit.wav (filename)
+Has Date: false
 Duration: 2:51
 URLs:
 - https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Pilot+Light_8bit.wav
@@ -59,6 +61,7 @@ Referenced Tracks:
 Track: Curtain Roll - Chiptuned
 Additional Names:
 - Curtain Roll_8bit.wav (filename)
+Has Date: false
 Duration: 1:30
 URLs:
 - https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Curtain+Roll_8bit.wav
@@ -68,6 +71,7 @@ Referenced Tracks:
 Track: Downtime - Chiptuned
 Additional Names:
 - Downtime_8bit.wav (filename)
+Has Date: false
 Duration: 1:30
 URLs:
 - https://archive.org/details/shenanigans-mspa/'Chiptuned'+Versions/Downtime_8bit.wav

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -2,7 +2,7 @@ Album: 'Shenanigans: MSPA'
 Directory: shenanigans-mspa
 Artists:
 - Thomas Ibarra
-Date: September 22, 2012
+Date: January 1, 2013
 URLs:
 - https://soundcloud.com/sparksd2145/sets/homestuck-mixes
 Cover Artists:
@@ -12,6 +12,10 @@ Color: '#bca5bc'
 Groups:
 - Fandom
 Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud album description](https://soundcloud.com/sparksd2145/sets/homestuck-mixes))
+
+    Homestuck remixes, lots of them.
+
     <i>Thomas Ibarra:</i> ([Bandcamp download blurb](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/))
 
     Comes complete with a near-perfect rendering of the [[flash:fan-animation-homestuck|"Irradiated"]] animation (in celebration of nearly 100,000 hits as of this writing), and a printable booklet of all original track art!
@@ -20,41 +24,24 @@ Commentary: |-
 
     Gracious thanks to the talented individuals running MS Paint Adventures, their hard work inspired me to write these recomposed works.
 
-    <i>Thomas Ibarra:</i> ([SoundCloud album description](https://soundcloud.com/sparksd2145/sets/homestuck-mixes))
-
-    Homestuck remixes, lots of them.
-
     <i>Quasar Nebula:</i> (wiki editor)
 
-    This album is a rather early fandom release. Its entry on the wiki is mostly modeled around [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/); this release is no longer directly available, but is rehosted [on skaia.net](http://dl.skaia.net/albums). Shenanigans: MSPA is also an [album/set on SoundCloud](https://soundcloud.com/sparksd2145/sets/homestuck-mixes) (by the composer), and this is still online.
+    This album is a rather early fandom release. Its entry on the wiki is mostly modeled around [the SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes), which appears to be where these tracks were originally released. Shenanigans: MSPA was also released [on Bandcamp](tps://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/); this release is no longer directly available, but is rehosted [on skaia.net](http://dl.skaia.net/albums). (Albeit, missing the track art booklet and Irradiated animation rendering, which are currently lost media.)
 
-    The track list on Bandcamp is the one reflected on the wiki, where tracks are alphabetical. On SoundCloud the tracks are ordered differently, and a handful of tracks there were not on Bandcamp:
+    The track list on SoundCloud is the one reflected on the wiki; tracks are generally ordered (presumably by the composer) in a custom way, rather than chronologically. On Bandcamp tracks are alphabetical. The wiki also uses the "album release date" and per-track dates from SoundCloud. On Bandcamp the release date is [[date:September 22, 2012]]. (The SoundCloud set appears to have been created on [[date:August 12, 2011]], matching the upload date of the earliest few tracks.)
 
-    1. [[track:rectify-shenanigans-mspa]]
-    2. [[track:pilot-light-shenanigans-mspa|Pilot Light: The Witch's Cauldron]]
-    3. [[track:curtain-roll]]
-    4. [[track:irradiated-shenanigans-mspa|Irradiated - Updated]]
-    5. [[track:downtime-shenanigans-mspa]]
-    6. [[track:the-felt-rise-of-lord-english|The Felt - Rise of Lord English (updated)]]
-    7. [[track:requiem-of-space]]
-    8. [[track:sburb-shenanigans-mspa]]
-    9. [[track:schrodingers-session]]
-    10. [[track:strife-shenanigans-mspa]]
-    11. [[track:curtain-roll-extended-mix]]
-    12. [[track:overture-of-paradox-space]]
-    13. [[track:irradiated-animation-version]] (SoundCloud-only)
-    14. [[track:revelations-shenanigans-mspa]]
-    15. [[track:advance-shenanigans-mspa]]
-    16. [[track:sweet-tart-theme]]
-    17. [[track:lotus-shenanigans-mspa]]
-    18. [[track:flowers-and-fireflies]]
-    19. [[track:feathered-shenanigans-mspa]]
-    20. [[track:john-walk-along-the-ruins|John: Walk along the Ruins]]
-    21. [[track:sweet-tart-theme-extended]] (SoundCloud-only)
-    22. [[track:electric-fireflies]]
-    23. [[track:adieu-shenanigans-mspa]] (SoundCloud-only)
+    The SoundCloud set has three tracks which weren't present on Bandcamp:
 
-    Bandcamp-exclusive tracks include [[track:ace-of-spades]], [[track:interlude-shenanigans-mspa]], [[track:mjollnir-shenanigans-mspa]], and [[track:shatter-shenanigans-mspa]].
+    - [[track:irradiated-animation-version]]
+    - [[track:sweet-tart-theme-extended]]
+    - [[track:adieu-shenanigans-mspa]]
+
+    Bandcamp, likewise, had four exclusive tracks:
+
+    - [[track:ace-of-spades]]
+    - [[track:interlude-shenanigans-mspa]]
+    - [[track:mjollnir-shenanigans-mspa]]
+    - [[track:shatter-shenanigans-mspa]]
 Additional Files:
 - Title: Track Art Booklet
   Description: >-

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -27,7 +27,7 @@ Commentary: |-
 
     This album is a rather early fandom release. Its entry on the wiki is mostly modeled around [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/); this release is no longer directly available, but is rehosted [on skaia.net](http://dl.skaia.net/albums). Shenanigans: MSPA is also an [album/set on SoundCloud](https://soundcloud.com/sparksd2145/sets/homestuck-mixes) (by the composer), and this is still online.
 
-    The track list on Bandcamp is the one reflected on the wiki, where tracks are alphabetical. On SoundCloud the tracks are ordered by chronological release, and a handful of tracks there were not on Bandcamp:
+    The track list on Bandcamp is the one reflected on the wiki, where tracks are alphabetical. On SoundCloud the tracks are ordered differently, and a handful of tracks there were not on Bandcamp:
 
     1. [[track:rectify-shenanigans-mspa]]
     2. [[track:pilot-light-shenanigans-mspa|Pilot Light: The Witch's Cauldron]]
@@ -75,6 +75,7 @@ Referenced Tracks:
 Track: Advance
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 10/20/2011
 Duration: 3:18
 URLs:
 - https://soundcloud.com/sparksd2145/advance
@@ -85,6 +86,7 @@ Referenced Tracks:
 - Showtime (Original Mix)
 ---
 Track: Curtain Roll
+Date First Released: 8/12/2011
 Duration: 1:31
 URLs:
 - https://soundcloud.com/sparksd2145/curtainroll
@@ -93,6 +95,7 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 ---
 Track: Curtain Roll - Extended Mix
+Date First Released: 11/25/2011
 Duration: 2:54
 URLs:
 - https://soundcloud.com/sparksd2145/curtain-roll-extended-mix
@@ -107,11 +110,13 @@ Commentary: |-
 Track: Downtime
 Suffix Directory: true
 Main Release: Land of Fans and Music
+Date First Released: 8/12/2011
 Duration: 2:15
 URLs:
 - https://soundcloud.com/sparksd2145/downtime
 ---
 Track: Electric Fireflies
+Date First Released: 1/28/2013
 Duration: 3:39
 URLs:
 - https://soundcloud.com/sparksd2145/electric-fireflies
@@ -123,6 +128,7 @@ Referenced Tracks:
 Track: Feathered
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 1/1/2012
 Duration: 1:47
 URLs:
 - https://soundcloud.com/sparksd2145/feathered
@@ -135,6 +141,7 @@ Commentary: |-
     An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
 ---
 Track: Flowers and Fireflies
+Date First Released: 10/2/2011
 Duration: 4:14
 URLs:
 - https://soundcloud.com/sparksd2145/flowers-and-fireflies
@@ -156,6 +163,7 @@ Referenced Tracks:
 Track: Irradiated
 Directory: irradiated-shenanigans-mspa
 Always Reference By Directory: true
+Date First Released: 6/20/2012
 Additional Names:
 - Name: >-
     Irradated
@@ -183,6 +191,7 @@ Commentary: |-
     As the SoundCloud description and comment there indicate, this isn't the original version of Irradiated. It does appear to be the same version as included in [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/) of Shenanigans: MSPA, with matching 2:16 duration and included in [the SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
 ---
 Track: John - Walk along the Ruins
+Date First Released: 7/31/2012
 Additional Names:
 - Name: >-
     John: Walk along the Ruins
@@ -201,6 +210,7 @@ Commentary: |-
 Track: Lotus
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 12/2/2011
 Duration: 2:56
 URLs:
 - https://soundcloud.com/sparksd2145/lotus
@@ -220,6 +230,7 @@ Referenced Tracks:
 - Skaian Skuffle
 ---
 Track: Overture of Paradox Space
+Date First Released: 10/11/2011
 Duration: 1:27
 URLs:
 - https://soundcloud.com/sparksd2145/overture-of-paradox-space
@@ -232,12 +243,28 @@ Commentary: |-
 ---
 Track: Pilot Light
 Suffix Directory: true
-Main Release: 'coloUrs and mayhem: Universe B'
+Date First Released: 1/10/2012
+Additional Names:
+- Name: >-
+    Pilot Light: The Witch's Cauldron
+  Annotation: >-
+    [SoundCloud](https://soundcloud.com/sparksd2145/pilot-light-the-witchs)
 Duration: 2:51
+URLs:
+- https://soundcloud.com/sparksd2145/pilot-light-the-witchs
+Referenced Tracks:
+- Flare
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
+
+    Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
+
+    This is my first attempt at an entry for [[album:coloUrs-and-mayhem-universe-a|the 2012 Homestuck Music Contest]].
 ---
 Track: Rectify
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 1/23/2012
 Duration: 2:52
 URLs:
 - https://soundcloud.com/sparksd2145/rectify
@@ -246,15 +273,16 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 - Showtime (Piano Refrain)
 Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify), 1/23/2012)
 
     Rectify, by AutoDevote. (now completed!)
 
-    - I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
+    \- I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
 
-    I present my track for Jack Noir, Rectify. This is my second entry for the Homestuck Music Contest, and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
+    I present my track for Jack Noir, Rectify. This is my second entry for [[album:coloUrs-and-mayhem-universe-a|the Homestuck Music Contest]], and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
 ---
 Track: Requiem of Space
+Date First Released: 8/12/2011
 Duration: 1:40
 URLs:
 - https://soundcloud.com/sparksd2145/requiem-of-space
@@ -265,6 +293,7 @@ Referenced Tracks:
 Track: Revelations
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 8/12/2011
 Duration: 2:15
 URLs:
 - https://soundcloud.com/sparksd2145/revelations
@@ -275,6 +304,7 @@ Referenced Tracks:
 Track: Sburb
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 8/12/2011
 Duration: 2:27
 URLs:
 - https://soundcloud.com/sparksd2145/sburb
@@ -287,6 +317,7 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 ---
 Track: Schrodinger's Session
+Date First Released: 8/12/2011
 Duration: 2:07
 URLs:
 - https://soundcloud.com/sparksd2145/schrodingers-session
@@ -306,6 +337,7 @@ Referenced Tracks:
 Track: Strife
 Suffix Directory: true
 Always Reference By Directory: true
+Date First Released: 8/12/2011
 Duration: 3:15
 URLs:
 - https://soundcloud.com/sparksd2145/strife
@@ -316,6 +348,7 @@ Referenced Tracks:
 - Beatdown (Strider Style)
 ---
 Track: Sweet-Tart Theme
+Date First Released: 10/30/2011
 Duration: 1:13
 URLs:
 - https://soundcloud.com/sparksd2145/sweet-tart-theme
@@ -325,6 +358,7 @@ Commentary: |-
     A composition done especially for my friend and fellow tumblr-blogger (askthwigglers, [pother](https://pother.tumblr.com)). My first attempt at a cutesy theme. :D
 ---
 Track: 'The Felt: Rise of Lord English'
+Date First Released: 6/27/2012
 Duration: 2:50
 URLs:
 - https://soundcloud.com/sparksd2145/the-felt-rise-of-lord
@@ -341,6 +375,7 @@ Description: >-
     Additional tracks present on [the SoundCloud set/album](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
 ---
 Track: Irradiated (Animation Version)
+Date First Released: 10/13/2011
 Duration: 1:46
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-animation-version
@@ -352,6 +387,7 @@ Commentary: |-
     The reworked version of Irradiated used in my homestuck fan animation.
 ---
 Track: Sweet-Tart Theme (Extended)
+Date First Released: 7/17/2012
 Duration: 1:43
 URLs:
 - https://soundcloud.com/sparksd2145/sweet-tart-theme-3
@@ -363,6 +399,7 @@ Commentary: |-
     Extended track for the wiggler's sweet-tart theme.
 ---
 Track: Adieu
+Date First Released: 4/13/2016
 Directory: adieu-shenanigans-mspa
 Always Reference By Directory: true
 Duration: 0:40

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -492,6 +492,7 @@ Commentary: |-
     Exactly, that's exactly what happened. Bandcamp was an attempt to, solidify the album? That didn't work either as I added Adieu and a few others later on. Adieu specifically was a simple song intended to remark on the end of the Homestuck comic, posting on about the same day it ended? I used the theme from [[flash:980|"good dog best friend"]] to signify the fun I shared with the experience, and really the acceptance of it ending.
 ---
 Section: Exclusive to Bandcamp
+Has Track Numbers: false
 Description: >-
     Additional tracks present on [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/).
 ---

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -58,9 +58,9 @@ Referenced Tracks:
 - Curtain Roll
 - Overture of Paradox Space
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/curtain-roll-extended-mix))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/curtain-roll-extended-mix))
 
-   Thought I'd put [[track:curtain-roll|the original Curtain Roll mix]] and [[track:overture-of-paradox-space|the Overture to Paradox Space orchestral mix]] together! This is what I came up with.
+    Thought I'd put [[track:curtain-roll|the original Curtain Roll mix]] and [[track:overture-of-paradox-space|the Overture to Paradox Space orchestral mix]] together! This is what I came up with.
 ---
 Track: Downtime
 Directory: downtime-shenanigans
@@ -87,9 +87,9 @@ Referenced Tracks:
 - Carefree Victory
 - Ohgodwhat
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/feathered))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/feathered))
 
-   An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
+    An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
 ---
 Track: Flowers and Fireflies
 Duration: 4:14
@@ -99,9 +99,9 @@ Referenced Tracks:
 - Lotus
 - Lotus Land Story
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/flowers-and-fireflies))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/flowers-and-fireflies))
 
-   An inspired track loosely based around the [[track:lotus|"Lotus"]]] and [[track:lotus-land-story|"Lotus Land Story"]] tracks from MSPA's Homestuck.
+    An inspired track loosely based around the [[track:lotus|"Lotus"]]] and [[track:lotus-land-story|"Lotus Land Story"]] tracks from MSPA's Homestuck.
 ---
 Track: Interlude
 Directory: interlude-shenanigans
@@ -119,9 +119,9 @@ Referenced Tracks:
 - Sburban Jungle
 - track:carefree-action
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated))
 
-   The original [[track:irradated|Irradiated]] remix, updated and given new life for the homestuck fan music album 2.
+    The original [[track:irradated|Irradiated]] remix, updated and given new life for the homestuck fan music album 2.
 ---
 Track: John - Walk along the Ruins
 Additional Names:
@@ -135,9 +135,9 @@ URLs:
 Referenced Tracks:
 - Showtime (Original Mix)
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sample-john-walk-along-the))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sample-john-walk-along-the))
 
-   As he ventures into the post-apocalyptic ruins of Earth, John discovers truth; that even the Heir of Breath cannot restore life and happiness into the world alone.
+    As he ventures into the post-apocalyptic ruins of Earth, John discovers truth; that even the Heir of Breath cannot restore life and happiness into the world alone.
 ---
 Track: Lotus
 Directory: lotus-shenanigans
@@ -148,9 +148,9 @@ URLs:
 Referenced Tracks:
 - Lotus
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/lotus))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/lotus))
 
-   A deviation of the [[track:lotus|Lotus theme]] originally from Homestuck, arriving at a completely new tune with orchestral hints of the former. :D
+    A deviation of the [[track:lotus|Lotus theme]] originally from Homestuck, arriving at a completely new tune with orchestral hints of the former. :D
 ---
 Track: Mjolinir
 Duration: 2:00
@@ -165,9 +165,9 @@ URLs:
 Referenced Tracks:
 - Curtain Roll
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/overture-of-paradox-space))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/overture-of-paradox-space))
 
-   Based largely on an edited version of [[track:curtain-roll|curtain roll]], Overture of Paradox Space focuses on the melodic nature of [[track:showtime-piano-refrain|Showtime]] by the MSPA Team.
+    Based largely on an edited version of [[track:curtain-roll|curtain roll]], Overture of Paradox Space focuses on the melodic nature of [[track:showtime-piano-refrain|Showtime]] by the MSPA Team.
 ---
 Track: Pilot Light
 Directory: pilot-light-shenanigans
@@ -184,13 +184,13 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 - Showtime (Piano Refrain)
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify))
 
-   Rectify, by AutoDevote. (now completed!)
+    Rectify, by AutoDevote. (now completed!)
 
-   - I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
+    - I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
 
-   I present my track for Jack Noir, Rectify. This is my second entry for the Homestuck Music Contest, and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
+    I present my track for Jack Noir, Rectify. This is my second entry for the Homestuck Music Contest, and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
 ---
 Track: Requiem of Space
 Duration: 1:40
@@ -254,9 +254,9 @@ Duration: 1:13
 URLs:
 - https://soundcloud.com/sparksd2145/sweet-tart-theme
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme))
 
-   A composition done especially for my friend and fellow tumblr-blogger (askthwigglers, [pother](https://pother.tumblr.com)). My first attempt at a cutesy theme. :D
+    A composition done especially for my friend and fellow tumblr-blogger (askthwigglers, [pother](https://pother.tumblr.com)). My first attempt at a cutesy theme. :D
 ---
 Track: 'The Felt: Rise of Lord English'
 Duration: 2:50
@@ -266,6 +266,6 @@ Referenced Tracks:
 - track:MeGaLoVania
 - Liquid Negrocity
 Commentary: |-
-   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
 
-   The updated Rise of Lord English track for use in the [[album:lofam2|second Land of Fans and Music album.]]
+    The updated Rise of Lord English track for use in the [[album:lofam2|second Land of Fans and Music album.]]

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -112,7 +112,14 @@ Duration: 1:53
 Referenced Tracks:
 - Explore
 ---
-Track: Irradated
+Track: Irradiated
+Directory: irradiated-shenanigans-mspa
+Always Reference By Directory: true
+Additional Names:
+- Name: >-
+    Irradated
+  Annotation: >-
+    [Bandcamp](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/)
 Duration: 2:16
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-updated
@@ -124,7 +131,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated))
 
-    The original [[track:irradated|Irradiated]] remix, updated and given new life for the homestuck fan music album 2.
+    The original [[track:irradiated-shenanigans-mspa|Irradiated]] remix, updated and given new life for the homestuck fan music album 2.
 ---
 Track: John - Walk along the Ruins
 Additional Names:

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -32,7 +32,8 @@ Referenced Tracks:
 - The Ballad of Jack Noir
 ---
 Track: Advance
-Directory: advance-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 3:18
 URLs:
 - https://soundcloud.com/sparksd2145/advance
@@ -63,7 +64,7 @@ Commentary: |-
     Thought I'd put [[track:curtain-roll|the original Curtain Roll mix]] and [[track:overture-of-paradox-space|the Overture to Paradox Space orchestral mix]] together! This is what I came up with.
 ---
 Track: Downtime
-Directory: downtime-shenanigans
+Suffix Directory: true
 Main Release: Land of Fans and Music
 Duration: 2:15
 URLs:
@@ -79,7 +80,8 @@ Referenced Tracks:
 - Showtime (Original Mix)
 ---
 Track: Feathered
-Directory: feathered-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 1:47
 URLs:
 - https://soundcloud.com/sparksd2145/feathered
@@ -104,7 +106,8 @@ Commentary: |-
     An inspired track loosely based around the [[track:lotus|"Lotus"]]] and [[track:lotus-land-story|"Lotus Land Story"]] tracks from MSPA's Homestuck.
 ---
 Track: Interlude
-Directory: interlude-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 1:53
 Referenced Tracks:
 - Explore
@@ -140,7 +143,7 @@ Commentary: |-
     As he ventures into the post-apocalyptic ruins of Earth, John discovers truth; that even the Heir of Breath cannot restore life and happiness into the world alone.
 ---
 Track: Lotus
-Directory: lotus-shenanigans
+Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:56
 URLs:
@@ -170,12 +173,13 @@ Commentary: |-
     Based largely on an edited version of [[track:curtain-roll|curtain roll]], Overture of Paradox Space focuses on the melodic nature of [[track:showtime-piano-refrain|Showtime]] by the MSPA Team.
 ---
 Track: Pilot Light
-Directory: pilot-light-shenanigans
+Suffix Directory: true
 Main Release: 'coloUrs and mayhem: Universe B'
 Duration: 2:51
 ---
 Track: Rectify
-Directory: rectify-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 2:52
 URLs:
 - https://soundcloud.com/sparksd2145/rectify
@@ -201,7 +205,8 @@ Referenced Tracks:
 - Pyrocumulus (Sicknasty)
 ---
 Track: Revelations
-Directory: revelations-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 2:15
 URLs:
 - https://soundcloud.com/sparksd2145/revelations
@@ -210,7 +215,8 @@ Referenced Tracks:
 - Sburban Jungle
 ---
 Track: Sburb
-Directory: sburb-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 2:27
 URLs:
 - https://soundcloud.com/sparksd2145/sburb
@@ -231,7 +237,8 @@ Referenced Tracks:
 - Showtime (Original Mix)
 ---
 Track: Shatter
-Directory: shatter-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 2:00
 URLs:
 - https://www.youtube.com/watch?v=KPhSjyajhuU
@@ -239,7 +246,8 @@ Referenced Tracks:
 - Shatterface
 ---
 Track: Strife
-Directory: strife-shenanigans
+Suffix Directory: true
+Always Reference By Directory: true
 Duration: 3:15
 URLs:
 - https://soundcloud.com/sparksd2145/strife

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -116,10 +116,7 @@ Duration: 2:16
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-updated
 Referenced Tracks:
-- Harlequin
-- Liquid Negrocity
-- Sburban Jungle
-- track:carefree-action
+- track:irradiated-thomas-ibarra
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated), 6/20/2012)
 
@@ -131,7 +128,7 @@ Commentary: |-
 
     <i>Quasar Nebula:</i> (wiki editor)
 
-    As the SoundCloud description and comment there indicate, this isn't the original version of Irradiated. It does appear to be the same version as included in [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/) of Shenanigans: MSPA, with matching 2:16 duration and included in [the SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
+    [[track:irradiated-thomas-ibarra|The original]] was also released on SoundCloud back in August, alongside a handful of other remixes (which stuck around on this album). However, it dates to earlier than [[track:irradiated-animation-version|the animation version]] from February 2011, so this updated version follows the original by at least fourteen months.
 ---
 Track: Downtime
 Suffix Directory: true
@@ -232,11 +229,15 @@ Duration: 1:46
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-animation-version
 Referenced Tracks:
-- track:irradiated-shenanigans-mspa
+- track:irradiated-thomas-ibarra
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-animation-version))
 
-    The reworked version of Irradiated used in my homestuck fan animation.
+    The reworked version of Irradiated used in [[flash:fan-animation-homestuck|my homestuck fan animation]].
+
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    This is a rearranged version of [[track:irradiated-thomas-ibarra|the original]], and its release on SoundCloud precedes the [[track:irradiated-shenanigans-mspa|updated version]] - closely aligned with the original - by eight months. However, this version of the track dates back at least to February 2011 (when [[flash:fan-animation-homestuck|the animation]] was released). Since the composer describes this track as a rework, the original Irradiated was written even earlier.
 ---
 Track: Revelations
 Suffix Directory: true

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -7,7 +7,11 @@ URLs:
 - https://soundcloud.com/sparksd2145/sets/homestuck-mixes
 Cover Artists:
 - Thomas Ibarra
+Default Track Cover Artists:
+- Thomas Ibarra
+Default Track Dimensions: 314x473
 Cover Art File Extension: png
+Track Art File Extension: png
 Color: '#bca5bc'
 Groups:
 - Fandom
@@ -24,7 +28,12 @@ Commentary: |-
 
     Gracious thanks to the talented individuals running MS Paint Adventures, their hard work inspired me to write these recomposed works.
 
-    <i>Quasar Nebula:</i> (wiki editor)
+    <i>Thomas Ibarra:</i> (art booklet opening)
+
+    I hope that my work inspires you to create.<br>
+    This is my thanks to you for inspiring me.
+
+    <i>Quasar Nebula:</i> (wiki editor, 10/2/2024)
 
     This album is a rather early fandom release. Its entry on the wiki is mostly modeled around [the SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes), which appears to be where these tracks were originally released. Shenanigans: MSPA was also released [on Bandcamp](tps://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/); this release is no longer directly available, but is rehosted [on skaia.net](http://dl.skaia.net/albums). (Albeit, missing the track art booklet and Irradiated animation rendering, which are currently lost media.)
 
@@ -42,13 +51,34 @@ Commentary: |-
     - [[track:interlude-shenanigans-mspa]]
     - [[track:mjollnir-shenanigans-mspa]]
     - [[track:shatter-shenanigans-mspa]]
+
+    <i>Quasar Nebula:</i> (wiki editor, 11/6/2025)
+
+    All track art in this album is extracted from the track art booklet, which was directly shared with us, with permission to archive, by the artist, [[artist:thomas-ibarra]].
+
+    <i>Thomas Ibarra:</i> (wiki communications over DMs, excerpt, 11/6/2025)
+
+    oh also! I think it would also be worthwhile to mention that the quality of the original track art was bad because it was originally posted on the old MSPA forums, and also because I had no idea what I was doing when it came to resolution.
+
+    *(continued in [[track:adieu-shenanigans-mspa]])*
 Additional Files:
-- Title: Track Art Booklet
+- Title: Track art booklet
   Description: >-
     Booklet containing all original track art.
-- Title: Irradiated Animation Rendering
+  Files:
+  - booklet.pdf
+# - Title: '"Irradiated" animation rendering'
+#   Description: >-
+#     Near-perfect rendering of the [[flash:fan-animation-homestuck|Irradiated]] animation.
+- Title: Additional track artwork
   Description: >-
-    Near-perfect rendering of the [[flash:fan-animation-homestuck|Irradiated]] animation.
+    Track art embedded in the art booklet, which hasn't yet been associated with any track in the album itself.
+  Files:
+  - jack-1.png
+  - lotus-land-story.png
+  - jack-2.png
+  - royal-flush.png
+  - binary-reunion.png
 ---
 Section: Main album
 Description: >-
@@ -66,11 +96,9 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 - Showtime (Piano Refrain)
 Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify), 1/23/2012)
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify), excerpt, 1/23/2012)
 
-    Rectify, by AutoDevote. (now completed!)
-
-    \- I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
+    I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
 
     I present my track for Jack Noir, Rectify. This is my second entry for [[album:coloUrs-and-mayhem-universe-a|the Homestuck Music Contest]], and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
 ---
@@ -101,6 +129,10 @@ Date First Released: 8/12/2011
 Duration: 1:31
 URLs:
 - https://soundcloud.com/sparksd2145/curtainroll
+Art Tags:
+- Jack Noir
+- Royal Deringer
+- Beat Mesa
 Referenced Tracks:
 - Showtime (Original Mix)
 - Atomyk Ebonpyre
@@ -117,8 +149,12 @@ Additional Names:
 Duration: 2:16
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-updated
-Referenced Tracks:
-- track:irradiated-thomas-ibarra
+Track Artwork:
+- Tags:
+  - Jack Noir
+- Label: Alternate art
+  Directory: alt
+  Attach Above: true
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated), 6/20/2012)
 
@@ -128,9 +164,13 @@ Commentary: |-
 
     This was the first Homestuck fansong I ever found... literally one year ago, I discovered this song, loved it, and looked for more fanmusic until realizing how big the fanmusic community really was. Hearing this song again one year later is so cool.
 
-    <i>Quasar Nebula:</i> (wiki editor)
+    <i>Quasar Nebula:</i> (wiki editor, 10/3/2024)
 
     [[track:irradiated-thomas-ibarra|The original]] was also released on SoundCloud back in August 2011, alongside a handful of other remixes (which stuck around on this album). However, it dates to earlier than [[track:irradiated-animation-version|the animation version]] from February 2011, so this updated version follows the original by at least fourteen months.
+
+    <i>Quasar Nebula:</i> (wiki editor, 11/6/2025)
+
+    Both artworks for this track are featured in the art booklet next to each other, so while it's possible that one each was intended for this track and [[track:irradiated-animation-version|the animation version]], we can't guess which would belong with which. We also can't *really* say which is the "main" and which is "alternate"... but figure the ones we chose, with "Irradiated" spelled correctly (i.e. maybe revised) in the "main" one.
 ---
 Track: Downtime
 Suffix Directory: true
@@ -142,13 +182,27 @@ URLs:
 - https://soundcloud.com/sparksd2145/downtime
 ---
 Track: 'The Felt: Rise of Lord English'
+Directory: rise-of-lord-english
 Date First Released: 6/27/2012
+Additional Names:
+- Name: >-
+    The Felt - Rise of Lord English (updated)
+  Annotation: >-
+    [SoundCloud title](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord)
 Duration: 2:50
 URLs:
 - https://soundcloud.com/sparksd2145/the-felt-rise-of-lord
+Track Artwork:
+- Tags:
+  - Jack Noir
+  - Magic 8 Ball
+- Label: Alternate art
+  Directory: alt
+  Attach Above: true
 Referenced Tracks:
 - track:MeGaLoVania
 - Liquid Negrocity
+- Lotus # 1:16
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
 
@@ -159,6 +213,8 @@ Date First Released: 8/12/2011
 Duration: 1:40
 URLs:
 - https://soundcloud.com/sparksd2145/requiem-of-space
+Art Tags:
+- Space
 Referenced Tracks:
 - Skaian Skuffle
 - Pyrocumulus (Sicknasty)
@@ -167,6 +223,7 @@ Track: Sburb
 Suffix Directory: true
 Always Reference By Directory: true
 Date First Released: 8/12/2011
+Has Cover Art: false
 Duration: 2:27
 URLs:
 - https://soundcloud.com/sparksd2145/sburb
@@ -180,6 +237,7 @@ Referenced Tracks:
 ---
 Track: Schrodinger's Session
 Date First Released: 8/12/2011
+Has Cover Art: false
 Duration: 2:07
 URLs:
 - https://soundcloud.com/sparksd2145/schrodingers-session
@@ -194,6 +252,10 @@ Date First Released: 8/12/2011
 Duration: 3:15
 URLs:
 - https://soundcloud.com/sparksd2145/strife
+Art Tags:
+- Regisword
+- Gate
+- Sburb
 Referenced Tracks:
 - Showtime (Original Mix)
 - Aggrieve
@@ -205,6 +267,11 @@ Date First Released: 11/25/2011
 Duration: 2:54
 URLs:
 - https://soundcloud.com/sparksd2145/curtain-roll-extended-mix
+Art Tags:
+- Jack Noir
+- Royal Deringer
+Referenced Artworks:
+- Curtain Roll
 Referenced Tracks:
 - Curtain Roll
 - Overture of Paradox Space
@@ -227,6 +294,7 @@ Commentary: |-
 ---
 Track: Irradiated (Animation Version)
 Date First Released: 10/13/2011
+Has Cover Art: false
 Duration: 1:46
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-animation-version
@@ -237,7 +305,7 @@ Commentary: |-
 
     The reworked version of Irradiated used in [[flash:fan-animation-homestuck|my homestuck fan animation]].
 
-    <i>Quasar Nebula:</i> (wiki editor)
+    <i>Quasar Nebula:</i> (wiki editor, 10/3/2024)
 
     This is a rearranged version of [[track:irradiated-thomas-ibarra|the original]], and its release on SoundCloud precedes the [[track:irradiated-shenanigans-mspa|updated version]] - closely aligned with the original - by eight months. However, this version of the track dates back at least to February 2011 (when [[flash:fan-animation-homestuck|the animation]] was released). Since the composer describes this track as a rework, the original Irradiated was written even earlier.
 ---
@@ -248,6 +316,11 @@ Date First Released: 8/12/2011
 Duration: 2:15
 URLs:
 - https://soundcloud.com/sparksd2145/revelations
+Art Tags:
+- Karkat
+- John
+- Sgrub
+- Sburb
 Referenced Tracks:
 - track:frost-vol6
 - Sburban Jungle
@@ -259,11 +332,17 @@ Date First Released: 10/20/2011
 Duration: 3:18
 URLs:
 - https://soundcloud.com/sparksd2145/advance
+Art Tags:
+- Caledfwlch
 Referenced Tracks:
 - Liquid Negrocity
 - Atomyk Ebonpyre
 - track:MeGaLoVania
 - Showtime (Original Mix)
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/advance))
+
+    Black, remixed yet again :D
 ---
 Track: Sweet-Tart Theme
 Date First Released: 10/30/2011
@@ -284,6 +363,8 @@ URLs:
 - https://soundcloud.com/sparksd2145/lotus
 Referenced Tracks:
 - Lotus
+Art Tags:
+- Lotus
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/lotus))
 
@@ -297,6 +378,8 @@ URLs:
 Referenced Tracks:
 - Lotus
 - Lotus Land Story
+Art Tags:
+- Lotus
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/flowers-and-fireflies))
 
@@ -309,6 +392,8 @@ Date First Released: 1/1/2012
 Duration: 1:47
 URLs:
 - https://soundcloud.com/sparksd2145/feathered
+Art Tags:
+- Crowsprite
 Referenced Tracks:
 - Carefree Victory
 - Ohgodwhat
@@ -317,13 +402,14 @@ Commentary: |-
 
     An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
 ---
-Track: John - Walk along the Ruins
+Track: 'John: Walk along the Ruins'
 Date First Released: 7/31/2012
 Additional Names:
 - Name: >-
-    John: Walk along the Ruins
+    John - Walk along the Ruins
   Annotation: >-
-    [SoundCloud release](https://soundcloud.com/sparksd2145/sample-john-walk-along-the)
+    [Bandcamp](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/)
+Has Cover Art: false
 Duration: 2:45
 URLs:
 - https://soundcloud.com/sparksd2145/sample-john-walk-along-the
@@ -336,6 +422,7 @@ Commentary: |-
 ---
 Track: Sweet-Tart Theme (Extended)
 Date First Released: 7/17/2012
+# artwork is reused from Sweet-Tart Theme
 Duration: 1:43
 URLs:
 - https://soundcloud.com/sparksd2145/sweet-tart-theme-3
@@ -348,6 +435,7 @@ Commentary: |-
 ---
 Track: Electric Fireflies
 Date First Released: 1/28/2013
+Has Cover Art: false
 Duration: 3:39
 URLs:
 - https://soundcloud.com/sparksd2145/electric-fireflies
@@ -355,14 +443,32 @@ Referenced Tracks:
 - Firefly Cloud
 - Doctor
 - Showtime (Original Mix)
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/electric-fireflies), excerpt)
+
+    Based on [[Firefly Cloud]], of the [[album:one-year-older|One Year Older]] album, Electric Fireflies capitalizes on the soft piano twill to bring the familiar [[Doctor]] and [[track:showtime-original-mix|Showtime]] mixes together in a way that was difficult for me to capture previously. I believe it turned out pretty great, but I'll let you be the judge of that. :)
 ---
 Track: Adieu
 Date First Released: 4/13/2016
 Suffix Directory: true
 Always Reference By Directory: true
+Track Artwork:
+- File Extension: jpg
+  Source: >-
+    [SoundCloud](https://soundcloud.com/sparksd2145/adieu)
 Duration: 0:40
 URLs:
 - https://soundcloud.com/sparksd2145/adieu
+Referenced Tracks:
+- Carefree Action
+Commentary: |-
+    <i>Thomas Ibarra, Quasar Nebula|[[artist:thomas-ibarra]]:</i> (wiki communications over DMs, excerpt, 11/6/2025)
+
+    *(continued from [[album:shenanigans-mspa|album commentary]])*
+
+    > <i>[[artist:quasar-nebula|Lan]]:</i> Do you remember if you were posting your tracks to the forum as you finished them, similar as they showed up on soundcloud gradually?
+
+    Exactly, that's exactly what happened. Bandcamp was an attempt to, solidify the album? That didn't work either as I added Adieu and a few others later on. Adieu specifically was a simple song intended to remark on the end of the Homestuck comic, posting on about the same day it ended? I used the theme from [[flash:980|"good dog best friend"]] to signify the fun I shared with the experience, and really the acceptance of it ending.
 ---
 Section: Exclusive to Bandcamp
 Description: >-
@@ -378,6 +484,8 @@ Track: Interlude
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:53
+Art Tags:
+- Jack Noir
 Referenced Tracks:
 - Explore
 ---
@@ -385,6 +493,8 @@ Track: Mjollnir
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:00
+Art Tags:
+- Hammerkind
 Referenced Tracks:
 - Sunsetter
 - Skaian Skuffle
@@ -393,6 +503,8 @@ Track: Shatter
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:00
+Art Tags:
+- Trusty Knife
 URLs:
 - https://www.youtube.com/watch?v=KPhSjyajhuU
 Referenced Tracks:

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -107,7 +107,7 @@ Referenced Tracks:
 ---
 Track: Irradiated
 Suffix Directory: true
-Always Reference By Directory: true
+Main Release: Land of Fans and Music 2
 Date First Released: 6/20/2012
 Additional Names:
 - Name: >-
@@ -130,7 +130,7 @@ Commentary: |-
 
     <i>Quasar Nebula:</i> (wiki editor)
 
-    [[track:irradiated-thomas-ibarra|The original]] was also released on SoundCloud back in August, alongside a handful of other remixes (which stuck around on this album). However, it dates to earlier than [[track:irradiated-animation-version|the animation version]] from February 2011, so this updated version follows the original by at least fourteen months.
+    [[track:irradiated-thomas-ibarra|The original]] was also released on SoundCloud back in August 2011, alongside a handful of other remixes (which stuck around on this album). However, it dates to earlier than [[track:irradiated-animation-version|the animation version]] from February 2011, so this updated version follows the original by at least fourteen months.
 ---
 Track: Downtime
 Suffix Directory: true

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -10,7 +10,7 @@ Color: '#bca5bc'
 Groups:
 - Fandom
 Commentary: |-
-    <i>Thomas Ibarra:</i> ([Bandcamp about blurb](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/))
+    <i>Thomas Ibarra:</i> ([Bandcamp download blurb](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/))
 
     Comes complete with a near-perfect rendering of the [[flash:fan-animation-homestuck|"Irradiated"]] animation (in celebration of nearly 100,000 hits as of this writing), and a printable booklet of all original track art!
 
@@ -131,7 +131,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated))
 
-    The original [[track:irradiated-shenanigans-mspa|Irradiated]] remix, updated and given new life for the homestuck fan music album 2.
+    The original Irradiated remix, updated and given [[track:irradiated-lofam2|new life]] for [[album:lofam2|the homestuck fan music album 2]].
 ---
 Track: John - Walk along the Ruins
 Additional Names:

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -91,6 +91,7 @@ Date First Released: 1/23/2012
 Duration: 2:52
 URLs:
 - https://soundcloud.com/sparksd2145/rectify
+- https://archive.org/details/shenanigans-mspa/Rectify.wav
 Referenced Tracks:
 - Liquid Negrocity
 - Atomyk Ebonpyre
@@ -113,6 +114,7 @@ Additional Names:
 Duration: 2:51
 URLs:
 - https://soundcloud.com/sparksd2145/pilot-light-the-witchs
+- https://archive.org/details/shenanigans-mspa/Pilot+Light.wav
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
 
@@ -129,6 +131,7 @@ Date First Released: 8/12/2011
 Duration: 1:31
 URLs:
 - https://soundcloud.com/sparksd2145/curtainroll
+- https://archive.org/details/shenanigans-mspa/Curtain+Roll.wav
 Art Tags:
 - Jack Noir
 - Royal Deringer
@@ -149,6 +152,7 @@ Additional Names:
 Duration: 2:16
 URLs:
 - https://soundcloud.com/sparksd2145/irradiated-updated
+- https://archive.org/details/shenanigans-mspa/Irradiated.wav
 Track Artwork:
 - Tags:
   - Jack Noir
@@ -180,6 +184,7 @@ Date First Released: 8/12/2011
 Duration: 2:15
 URLs:
 - https://soundcloud.com/sparksd2145/downtime
+- https://archive.org/details/shenanigans-mspa/Downtime.wav
 ---
 Track: 'The Felt: Rise of Lord English'
 Directory: rise-of-lord-english
@@ -192,6 +197,7 @@ Additional Names:
 Duration: 2:50
 URLs:
 - https://soundcloud.com/sparksd2145/the-felt-rise-of-lord
+- https://archive.org/details/shenanigans-mspa/The+Felt+-+Rise+of+Lord+English.wav
 Track Artwork:
 - Tags:
   - Jack Noir
@@ -213,6 +219,7 @@ Date First Released: 8/12/2011
 Duration: 1:40
 URLs:
 - https://soundcloud.com/sparksd2145/requiem-of-space
+- https://archive.org/details/shenanigans-mspa/Requiem+of+Space.wav
 Art Tags:
 - Space
 Referenced Tracks:
@@ -227,6 +234,7 @@ Has Cover Art: false
 Duration: 2:27
 URLs:
 - https://soundcloud.com/sparksd2145/sburb
+- https://archive.org/details/shenanigans-mspa/Sburb.wav
 Referenced Tracks:
 - Sburban Jungle
 - Beatdown (Strider Style)
@@ -241,6 +249,7 @@ Has Cover Art: false
 Duration: 2:07
 URLs:
 - https://soundcloud.com/sparksd2145/schrodingers-session
+- https://archive.org/details/shenanigans-mspa/Schrodinger's+Session.flac
 Referenced Tracks:
 - Atomyk Ebonpyre
 - Showtime (Original Mix)
@@ -252,6 +261,7 @@ Date First Released: 8/12/2011
 Duration: 3:15
 URLs:
 - https://soundcloud.com/sparksd2145/strife
+- https://archive.org/details/shenanigans-mspa/Strife.wav
 Art Tags:
 - Regisword
 - Gate
@@ -267,6 +277,7 @@ Date First Released: 11/25/2011
 Duration: 2:54
 URLs:
 - https://soundcloud.com/sparksd2145/curtain-roll-extended-mix
+- https://archive.org/details/shenanigans-mspa/Curtain+Roll+-+Extended+Mix.wav
 Art Tags:
 - Jack Noir
 - Royal Deringer
@@ -285,6 +296,7 @@ Date First Released: 10/11/2011
 Duration: 1:27
 URLs:
 - https://soundcloud.com/sparksd2145/overture-of-paradox-space
+- https://archive.org/details/shenanigans-mspa/Overture+of+Paradox+Space.wav
 Referenced Tracks:
 - Curtain Roll
 Commentary: |-
@@ -332,6 +344,7 @@ Date First Released: 10/20/2011
 Duration: 3:18
 URLs:
 - https://soundcloud.com/sparksd2145/advance
+- https://archive.org/details/shenanigans-mspa/Revelations.wav
 Art Tags:
 - Caledfwlch
 Referenced Tracks:
@@ -349,6 +362,7 @@ Date First Released: 10/30/2011
 Duration: 1:13
 URLs:
 - https://soundcloud.com/sparksd2145/sweet-tart-theme
+- https://archive.org/details/shenanigans-mspa/Sweet-Tart+Theme.wav
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme))
 
@@ -361,6 +375,7 @@ Date First Released: 12/2/2011
 Duration: 2:56
 URLs:
 - https://soundcloud.com/sparksd2145/lotus
+- https://archive.org/details/shenanigans-mspa/Lotus.wav
 Referenced Tracks:
 - Lotus
 Art Tags:
@@ -375,6 +390,7 @@ Date First Released: 10/2/2011
 Duration: 4:14
 URLs:
 - https://soundcloud.com/sparksd2145/flowers-and-fireflies
+- https://archive.org/details/shenanigans-mspa/Flowers+and+Fireflies.wav
 Referenced Tracks:
 - Lotus
 - Lotus Land Story
@@ -392,6 +408,7 @@ Date First Released: 1/1/2012
 Duration: 1:47
 URLs:
 - https://soundcloud.com/sparksd2145/feathered
+- https://archive.org/details/shenanigans-mspa/Feathered.wav
 Art Tags:
 - Crowsprite
 Referenced Tracks:
@@ -413,6 +430,7 @@ Has Cover Art: false
 Duration: 2:45
 URLs:
 - https://soundcloud.com/sparksd2145/sample-john-walk-along-the
+- https://archive.org/details/shenanigans-mspa/John+-+Walk+along+the+Ruins.wav
 Referenced Tracks:
 - Showtime (Original Mix)
 Commentary: |-
@@ -426,6 +444,7 @@ Date First Released: 7/17/2012
 Duration: 1:43
 URLs:
 - https://soundcloud.com/sparksd2145/sweet-tart-theme-3
+- https://archive.org/details/shenanigans-mspa/Sweet-Tart+Theme+-+Extended.wav
 Referenced Tracks:
 - Sweet-Tart Theme
 Commentary: |-
@@ -439,6 +458,7 @@ Has Cover Art: false
 Duration: 3:39
 URLs:
 - https://soundcloud.com/sparksd2145/electric-fireflies
+- https://archive.org/details/shenanigans-mspa/Electric+Fireflies.wav
 Referenced Tracks:
 - Firefly Cloud
 - Doctor
@@ -459,6 +479,7 @@ Track Artwork:
 Duration: 0:40
 URLs:
 - https://soundcloud.com/sparksd2145/adieu
+- https://archive.org/details/shenanigans-mspa/Adieu.wav
 Referenced Tracks:
 - Carefree Action
 Commentary: |-
@@ -476,6 +497,8 @@ Description: >-
 ---
 Track: Ace of Spades
 Duration: 3:40
+URLs:
+- https://archive.org/details/shenanigans-mspa/Ace+of+Spades.wav
 Referenced Tracks:
 - Liquid Negrocity
 - The Ballad of Jack Noir
@@ -484,6 +507,8 @@ Track: Interlude
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:53
+URLs:
+- https://archive.org/details/shenanigans-mspa/Interlude.wav
 Art Tags:
 - Jack Noir
 Referenced Tracks:
@@ -493,6 +518,8 @@ Track: Mjollnir
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:00
+URLs:
+- https://archive.org/details/shenanigans-mspa/Mjollnir.wav
 Art Tags:
 - Hammerkind
 Referenced Tracks:
@@ -503,9 +530,9 @@ Track: Shatter
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:00
+URLs:
+- https://archive.org/details/shenanigans-mspa/Shatter.wav
 Art Tags:
 - Trusty Knife
-URLs:
-- https://www.youtube.com/watch?v=KPhSjyajhuU
 Referenced Tracks:
 - Shatterface

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -3,7 +3,8 @@ Directory: shenanigans-mspa
 Artists:
 - Thomas Ibarra
 Date: September 22, 2012
-Has Track Numbers: false
+URLs:
+- https://soundcloud.com/sparksd2145/sets/homestuck-mixes
 Cover Artists:
 - Thomas Ibarra
 Cover Art File Extension: png
@@ -64,26 +65,47 @@ Additional Files:
 ---
 Section: Main album
 Description: >-
-    In alphabetical order, matching [Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/).
+    In composer-selected order, matching [SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
 ---
-Track: Ace of Spades
-Duration: 3:40
-Referenced Tracks:
-- Liquid Negrocity
-- The Ballad of Jack Noir
----
-Track: Advance
+Track: Rectify
 Suffix Directory: true
 Always Reference By Directory: true
-Date First Released: 10/20/2011
-Duration: 3:18
+Date First Released: 1/23/2012
+Duration: 2:52
 URLs:
-- https://soundcloud.com/sparksd2145/advance
+- https://soundcloud.com/sparksd2145/rectify
 Referenced Tracks:
 - Liquid Negrocity
 - Atomyk Ebonpyre
-- track:MeGaLoVania
-- Showtime (Original Mix)
+- Showtime (Piano Refrain)
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify), 1/23/2012)
+
+    Rectify, by AutoDevote. (now completed!)
+
+    \- I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
+
+    I present my track for Jack Noir, Rectify. This is my second entry for [[album:coloUrs-and-mayhem-universe-a|the Homestuck Music Contest]], and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
+---
+Track: Pilot Light
+Suffix Directory: true
+Date First Released: 1/10/2012
+Additional Names:
+- Name: >-
+    Pilot Light: The Witch's Cauldron
+  Annotation: >-
+    [SoundCloud](https://soundcloud.com/sparksd2145/pilot-light-the-witchs)
+Duration: 2:51
+URLs:
+- https://soundcloud.com/sparksd2145/pilot-light-the-witchs
+Referenced Tracks:
+- Flare
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
+
+    Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
+
+    This is my first attempt at an entry for [[album:coloUrs-and-mayhem-universe-a|the 2012 Homestuck Music Contest]].
 ---
 Track: Curtain Roll
 Date First Released: 8/12/2011
@@ -94,74 +116,8 @@ Referenced Tracks:
 - Showtime (Original Mix)
 - Atomyk Ebonpyre
 ---
-Track: Curtain Roll - Extended Mix
-Date First Released: 11/25/2011
-Duration: 2:54
-URLs:
-- https://soundcloud.com/sparksd2145/curtain-roll-extended-mix
-Referenced Tracks:
-- Curtain Roll
-- Overture of Paradox Space
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/curtain-roll-extended-mix))
-
-    Thought I'd put [[track:curtain-roll|the original Curtain Roll mix]] and [[track:overture-of-paradox-space|the Overture to Paradox Space orchestral mix]] together! This is what I came up with.
----
-Track: Downtime
-Suffix Directory: true
-Main Release: Land of Fans and Music
-Date First Released: 8/12/2011
-Duration: 2:15
-URLs:
-- https://soundcloud.com/sparksd2145/downtime
----
-Track: Electric Fireflies
-Date First Released: 1/28/2013
-Duration: 3:39
-URLs:
-- https://soundcloud.com/sparksd2145/electric-fireflies
-Referenced Tracks:
-- Firefly Cloud
-- Doctor
-- Showtime (Original Mix)
----
-Track: Feathered
-Suffix Directory: true
-Always Reference By Directory: true
-Date First Released: 1/1/2012
-Duration: 1:47
-URLs:
-- https://soundcloud.com/sparksd2145/feathered
-Referenced Tracks:
-- Carefree Victory
-- Ohgodwhat
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/feathered))
-
-    An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
----
-Track: Flowers and Fireflies
-Date First Released: 10/2/2011
-Duration: 4:14
-URLs:
-- https://soundcloud.com/sparksd2145/flowers-and-fireflies
-Referenced Tracks:
-- Lotus
-- Lotus Land Story
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/flowers-and-fireflies))
-
-    An inspired track loosely based around the [[track:lotus|"Lotus"]]] and [[track:lotus-land-story|"Lotus Land Story"]] tracks from MSPA's Homestuck.
----
-Track: Interlude
-Suffix Directory: true
-Always Reference By Directory: true
-Duration: 1:53
-Referenced Tracks:
-- Explore
----
 Track: Irradiated
-Directory: irradiated-shenanigans-mspa
+Suffix Directory: true
 Always Reference By Directory: true
 Date First Released: 6/20/2012
 Additional Names:
@@ -190,96 +146,27 @@ Commentary: |-
 
     As the SoundCloud description and comment there indicate, this isn't the original version of Irradiated. It does appear to be the same version as included in [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/) of Shenanigans: MSPA, with matching 2:16 duration and included in [the SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
 ---
-Track: John - Walk along the Ruins
-Date First Released: 7/31/2012
-Additional Names:
-- Name: >-
-    John: Walk along the Ruins
-  Annotation: >-
-    [SoundCloud release](https://soundcloud.com/sparksd2145/sample-john-walk-along-the)
-Duration: 2:45
-URLs:
-- https://soundcloud.com/sparksd2145/sample-john-walk-along-the
-Referenced Tracks:
-- Showtime (Original Mix)
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sample-john-walk-along-the))
-
-    As he ventures into the post-apocalyptic ruins of Earth, John discovers truth; that even the Heir of Breath cannot restore life and happiness into the world alone.
----
-Track: Lotus
+Track: Downtime
 Suffix Directory: true
 Always Reference By Directory: true
-Date First Released: 12/2/2011
-Duration: 2:56
+Main Release: Land of Fans and Music
+Date First Released: 8/12/2011
+Duration: 2:15
 URLs:
-- https://soundcloud.com/sparksd2145/lotus
-Referenced Tracks:
-- Lotus
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/lotus))
-
-    A deviation of the [[track:lotus|Lotus theme]] originally from Homestuck, arriving at a completely new tune with orchestral hints of the former. :D
+- https://soundcloud.com/sparksd2145/downtime
 ---
-Track: Mjollnir
-Directory: mjollnir-shenanigans-mspa
-Always Reference By Directory: true
-Duration: 2:00
-Referenced Tracks:
-- Sunsetter
-- Skaian Skuffle
----
-Track: Overture of Paradox Space
-Date First Released: 10/11/2011
-Duration: 1:27
+Track: 'The Felt: Rise of Lord English'
+Date First Released: 6/27/2012
+Duration: 2:50
 URLs:
-- https://soundcloud.com/sparksd2145/overture-of-paradox-space
+- https://soundcloud.com/sparksd2145/the-felt-rise-of-lord
 Referenced Tracks:
-- Curtain Roll
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/overture-of-paradox-space))
-
-    Based largely on an edited version of [[track:curtain-roll|curtain roll]], Overture of Paradox Space focuses on the melodic nature of [[track:showtime-piano-refrain|Showtime]] by the MSPA Team.
----
-Track: Pilot Light
-Suffix Directory: true
-Date First Released: 1/10/2012
-Additional Names:
-- Name: >-
-    Pilot Light: The Witch's Cauldron
-  Annotation: >-
-    [SoundCloud](https://soundcloud.com/sparksd2145/pilot-light-the-witchs)
-Duration: 2:51
-URLs:
-- https://soundcloud.com/sparksd2145/pilot-light-the-witchs
-Referenced Tracks:
-- Flare
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
-
-    Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
-
-    This is my first attempt at an entry for [[album:coloUrs-and-mayhem-universe-a|the 2012 Homestuck Music Contest]].
----
-Track: Rectify
-Suffix Directory: true
-Always Reference By Directory: true
-Date First Released: 1/23/2012
-Duration: 2:52
-URLs:
-- https://soundcloud.com/sparksd2145/rectify
-Referenced Tracks:
+- track:MeGaLoVania
 - Liquid Negrocity
-- Atomyk Ebonpyre
-- Showtime (Piano Refrain)
 Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify), 1/23/2012)
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
 
-    Rectify, by AutoDevote. (now completed!)
-
-    \- I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
-
-    I present my track for Jack Noir, Rectify. This is my second entry for [[album:coloUrs-and-mayhem-universe-a|the Homestuck Music Contest]], and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
+    The updated Rise of Lord English track for use in the [[album:lofam2|second Land of Fans and Music album.]]
 ---
 Track: Requiem of Space
 Date First Released: 8/12/2011
@@ -289,17 +176,6 @@ URLs:
 Referenced Tracks:
 - Skaian Skuffle
 - Pyrocumulus (Sicknasty)
----
-Track: Revelations
-Suffix Directory: true
-Always Reference By Directory: true
-Date First Released: 8/12/2011
-Duration: 2:15
-URLs:
-- https://soundcloud.com/sparksd2145/revelations
-Referenced Tracks:
-- track:frost-vol6
-- Sburban Jungle
 ---
 Track: Sburb
 Suffix Directory: true
@@ -325,15 +201,6 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 - Showtime (Original Mix)
 ---
-Track: Shatter
-Suffix Directory: true
-Always Reference By Directory: true
-Duration: 2:00
-URLs:
-- https://www.youtube.com/watch?v=KPhSjyajhuU
-Referenced Tracks:
-- Shatterface
----
 Track: Strife
 Suffix Directory: true
 Always Reference By Directory: true
@@ -347,32 +214,30 @@ Referenced Tracks:
 - Dissension (Original)
 - Beatdown (Strider Style)
 ---
-Track: Sweet-Tart Theme
-Date First Released: 10/30/2011
-Duration: 1:13
+Track: Curtain Roll - Extended Mix
+Date First Released: 11/25/2011
+Duration: 2:54
 URLs:
-- https://soundcloud.com/sparksd2145/sweet-tart-theme
-Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme))
-
-    A composition done especially for my friend and fellow tumblr-blogger (askthwigglers, [pother](https://pother.tumblr.com)). My first attempt at a cutesy theme. :D
----
-Track: 'The Felt: Rise of Lord English'
-Date First Released: 6/27/2012
-Duration: 2:50
-URLs:
-- https://soundcloud.com/sparksd2145/the-felt-rise-of-lord
+- https://soundcloud.com/sparksd2145/curtain-roll-extended-mix
 Referenced Tracks:
-- track:MeGaLoVania
-- Liquid Negrocity
+- Curtain Roll
+- Overture of Paradox Space
 Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/curtain-roll-extended-mix))
 
-    The updated Rise of Lord English track for use in the [[album:lofam2|second Land of Fans and Music album.]]
+    Thought I'd put [[track:curtain-roll|the original Curtain Roll mix]] and [[track:overture-of-paradox-space|the Overture to Paradox Space orchestral mix]] together! This is what I came up with.
 ---
-Section: Exclusive to SoundCloud
-Description: >-
-    Additional tracks present on [the SoundCloud set/album](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
+Track: Overture of Paradox Space
+Date First Released: 10/11/2011
+Duration: 1:27
+URLs:
+- https://soundcloud.com/sparksd2145/overture-of-paradox-space
+Referenced Tracks:
+- Curtain Roll
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/overture-of-paradox-space))
+
+    Based largely on an edited version of [[track:curtain-roll|curtain roll]], Overture of Paradox Space focuses on the melodic nature of [[track:showtime-piano-refrain|Showtime]] by the MSPA Team.
 ---
 Track: Irradiated (Animation Version)
 Date First Released: 10/13/2011
@@ -386,6 +251,99 @@ Commentary: |-
 
     The reworked version of Irradiated used in my homestuck fan animation.
 ---
+Track: Revelations
+Suffix Directory: true
+Always Reference By Directory: true
+Date First Released: 8/12/2011
+Duration: 2:15
+URLs:
+- https://soundcloud.com/sparksd2145/revelations
+Referenced Tracks:
+- track:frost-vol6
+- Sburban Jungle
+---
+Track: Advance
+Suffix Directory: true
+Always Reference By Directory: true
+Date First Released: 10/20/2011
+Duration: 3:18
+URLs:
+- https://soundcloud.com/sparksd2145/advance
+Referenced Tracks:
+- Liquid Negrocity
+- Atomyk Ebonpyre
+- track:MeGaLoVania
+- Showtime (Original Mix)
+---
+Track: Sweet-Tart Theme
+Date First Released: 10/30/2011
+Duration: 1:13
+URLs:
+- https://soundcloud.com/sparksd2145/sweet-tart-theme
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme))
+
+    A composition done especially for my friend and fellow tumblr-blogger (askthwigglers, [pother](https://pother.tumblr.com)). My first attempt at a cutesy theme. :D
+---
+Track: Lotus
+Suffix Directory: true
+Always Reference By Directory: true
+Date First Released: 12/2/2011
+Duration: 2:56
+URLs:
+- https://soundcloud.com/sparksd2145/lotus
+Referenced Tracks:
+- Lotus
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/lotus))
+
+    A deviation of the [[track:lotus|Lotus theme]] originally from Homestuck, arriving at a completely new tune with orchestral hints of the former. :D
+---
+Track: Flowers and Fireflies
+Date First Released: 10/2/2011
+Duration: 4:14
+URLs:
+- https://soundcloud.com/sparksd2145/flowers-and-fireflies
+Referenced Tracks:
+- Lotus
+- Lotus Land Story
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/flowers-and-fireflies))
+
+    An inspired track loosely based around the [[track:lotus|"Lotus"]]] and [[track:lotus-land-story|"Lotus Land Story"]] tracks from MSPA's Homestuck.
+---
+Track: Feathered
+Suffix Directory: true
+Always Reference By Directory: true
+Date First Released: 1/1/2012
+Duration: 1:47
+URLs:
+- https://soundcloud.com/sparksd2145/feathered
+Referenced Tracks:
+- Carefree Victory
+- Ohgodwhat
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/feathered))
+
+    An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
+---
+Track: John - Walk along the Ruins
+Date First Released: 7/31/2012
+Additional Names:
+- Name: >-
+    John: Walk along the Ruins
+  Annotation: >-
+    [SoundCloud release](https://soundcloud.com/sparksd2145/sample-john-walk-along-the)
+Duration: 2:45
+URLs:
+- https://soundcloud.com/sparksd2145/sample-john-walk-along-the
+Referenced Tracks:
+- Showtime (Original Mix)
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sample-john-walk-along-the))
+
+    As he ventures into the post-apocalyptic ruins of Earth, John discovers truth; that even the Heir of Breath cannot restore life and happiness into the world alone.
+---
 Track: Sweet-Tart Theme (Extended)
 Date First Released: 7/17/2012
 Duration: 1:43
@@ -398,10 +356,54 @@ Commentary: |-
 
     Extended track for the wiggler's sweet-tart theme.
 ---
+Track: Electric Fireflies
+Date First Released: 1/28/2013
+Duration: 3:39
+URLs:
+- https://soundcloud.com/sparksd2145/electric-fireflies
+Referenced Tracks:
+- Firefly Cloud
+- Doctor
+- Showtime (Original Mix)
+---
 Track: Adieu
 Date First Released: 4/13/2016
-Directory: adieu-shenanigans-mspa
+Suffix Directory: true
 Always Reference By Directory: true
 Duration: 0:40
 URLs:
 - https://soundcloud.com/sparksd2145/adieu
+---
+Section: Exclusive to Bandcamp
+Description: >-
+    Additional tracks present on [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/).
+---
+Track: Ace of Spades
+Duration: 3:40
+Referenced Tracks:
+- Liquid Negrocity
+- The Ballad of Jack Noir
+---
+Track: Interlude
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 1:53
+Referenced Tracks:
+- Explore
+---
+Track: Mjollnir
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 2:00
+Referenced Tracks:
+- Sunsetter
+- Skaian Skuffle
+---
+Track: Shatter
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 2:00
+URLs:
+- https://www.youtube.com/watch?v=KPhSjyajhuU
+Referenced Tracks:
+- Shatterface

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -3,6 +3,7 @@ Directory: shenanigans-mspa
 Artists:
 - Thomas Ibarra
 Date: September 22, 2012
+Has Track Numbers: false
 Cover Artists:
 - Thomas Ibarra
 Cover Art File Extension: png
@@ -17,6 +18,42 @@ Commentary: |-
     <i>Thomas Ibarra:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/))
 
     Gracious thanks to the talented individuals running MS Paint Adventures, their hard work inspired me to write these recomposed works.
+
+    <i>Thomas Ibarra:</i> ([SoundCloud album description](https://soundcloud.com/sparksd2145/sets/homestuck-mixes))
+
+    Homestuck remixes, lots of them.
+
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    This album is a rather early fandom release. Its entry on the wiki is mostly modeled around [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/); this release is no longer directly available, but is rehosted [on skaia.net](http://dl.skaia.net/albums). Shenanigans: MSPA is also an [album/set on SoundCloud](https://soundcloud.com/sparksd2145/sets/homestuck-mixes) (by the composer), and this is still online.
+
+    The track list on Bandcamp is the one reflected on the wiki, where tracks are alphabetical. On SoundCloud the tracks are ordered by chronological release, and a handful of tracks there were not on Bandcamp:
+
+    1. [[track:rectify-shenanigans-mspa]]
+    2. [[track:pilot-light-shenanigans-mspa|Pilot Light: The Witch's Cauldron]]
+    3. [[track:curtain-roll]]
+    4. [[track:irradiated-shenanigans-mspa|Irradiated - Updated]]
+    5. [[track:downtime-shenanigans-mspa]]
+    6. [[track:the-felt-rise-of-lord-english|The Felt - Rise of Lord English (updated)]]
+    7. [[track:requiem-of-space]]
+    8. [[track:sburb-shenanigans-mspa]]
+    9. [[track:schrodingers-session]]
+    10. [[track:strife-shenanigans-mspa]]
+    11. [[track:curtain-roll-extended-mix]]
+    12. [[track:overture-of-paradox-space]]
+    13. [[track:irradiated-animation-version]] (SoundCloud-only)
+    14. [[track:revelations-shenanigans-mspa]]
+    15. [[track:advance-shenanigans-mspa]]
+    16. [[track:sweet-tart-theme]]
+    17. [[track:lotus-shenanigans-mspa]]
+    18. [[track:flowers-and-fireflies]]
+    19. [[track:feathered-shenanigans-mspa]]
+    20. [[track:john-walk-along-the-ruins|John: Walk along the Ruins]]
+    21. [[track:sweet-tart-theme-extended]] (SoundCloud-only)
+    22. [[track:electric-fireflies]]
+    23. [[track:adieu-shenanigans-mspa]] (SoundCloud-only)
+
+    Bandcamp-exclusive tracks include [[track:ace-of-spades]], [[track:interlude-shenanigans-mspa]], [[track:mjollnir-shenanigans-mspa]], and [[track:shatter-shenanigans-mspa]].
 Additional Files:
 - Title: Track Art Booklet
   Description: >-
@@ -24,6 +61,10 @@ Additional Files:
 - Title: Irradiated Animation Rendering
   Description: >-
     Near-perfect rendering of the [[flash:fan-animation-homestuck|Irradiated]] animation.
+---
+Section: Main album
+Description: >-
+    In alphabetical order, matching [Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/).
 ---
 Track: Ace of Spades
 Duration: 3:40
@@ -129,9 +170,17 @@ Referenced Tracks:
 - Sburban Jungle
 - track:carefree-action
 Commentary: |-
-    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated))
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated), 6/20/2012)
 
     The original Irradiated remix, updated and given [[track:irradiated-lofam2|new life]] for [[album:lofam2|the homestuck fan music album 2]].
+
+    <i>B. A. Baker:</i> ([SoundCloud comment](https://soundcloud.com/sparksd2145/irradiated-updated), 6/23/2012)
+
+    This was the first Homestuck fansong I ever found... literally one year ago, I discovered this song, loved it, and looked for more fanmusic until realizing how big the fanmusic community really was. Hearing this song again one year later is so cool.
+
+    <i>Quasar Nebula:</i> (wiki editor)
+
+    As the SoundCloud description and comment there indicate, this isn't the original version of Irradiated. It does appear to be the same version as included in [the Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/) of Shenanigans: MSPA, with matching 2:16 duration and included in [the SoundCloud album/set](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
 ---
 Track: John - Walk along the Ruins
 Additional Names:
@@ -162,7 +211,9 @@ Commentary: |-
 
     A deviation of the [[track:lotus|Lotus theme]] originally from Homestuck, arriving at a completely new tune with orchestral hints of the former. :D
 ---
-Track: Mjolinir
+Track: Mjollnir
+Directory: mjollnir-shenanigans-mspa
+Always Reference By Directory: true
 Duration: 2:00
 Referenced Tracks:
 - Sunsetter
@@ -284,3 +335,36 @@ Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
 
     The updated Rise of Lord English track for use in the [[album:lofam2|second Land of Fans and Music album.]]
+---
+Section: Exclusive to SoundCloud
+Description: >-
+    Additional tracks present on [the SoundCloud set/album](https://soundcloud.com/sparksd2145/sets/homestuck-mixes).
+---
+Track: Irradiated (Animation Version)
+Duration: 1:46
+URLs:
+- https://soundcloud.com/sparksd2145/irradiated-animation-version
+Referenced Tracks:
+- track:irradiated-shenanigans-mspa
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-animation-version))
+
+    The reworked version of Irradiated used in my homestuck fan animation.
+---
+Track: Sweet-Tart Theme (Extended)
+Duration: 1:43
+URLs:
+- https://soundcloud.com/sparksd2145/sweet-tart-theme-3
+Referenced Tracks:
+- Sweet-Tart Theme
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme-3))
+
+    Extended track for the wiggler's sweet-tart theme.
+---
+Track: Adieu
+Directory: adieu-shenanigans-mspa
+Always Reference By Directory: true
+Duration: 0:40
+URLs:
+- https://soundcloud.com/sparksd2145/adieu

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -74,25 +74,27 @@ Commentary: |-
 
     I present my track for Jack Noir, Rectify. This is my second entry for [[album:coloUrs-and-mayhem-universe-a|the Homestuck Music Contest]], and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
 ---
-Track: Pilot Light
-Suffix Directory: true
+Track: "Pilot Light: The Witch's Cauldron"
+Main Release: Pilot Light # on coloUrs and Mayhem: Universe B
 Date First Released: 1/10/2012
 Additional Names:
 - Name: >-
-    Pilot Light: The Witch's Cauldron
+    Pilot Light
   Annotation: >-
-    [SoundCloud](https://soundcloud.com/sparksd2145/pilot-light-the-witchs)
+    [Bandcamp](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/)
 Duration: 2:51
 URLs:
 - https://soundcloud.com/sparksd2145/pilot-light-the-witchs
-Referenced Tracks:
-- Flare
 Commentary: |-
     <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/pilot-light-the-witchs))
 
     Centered around Jade as she makes her way to the heart of the forge, this track portrays the ignition and thawing of the land surrounding the mythical device of creation. The world begins to thaw in the warmth of the forge, and its inhabitants spur to life.
 
     This is my first attempt at an entry for [[album:coloUrs-and-mayhem-universe-a|the 2012 Homestuck Music Contest]].
+
+    <i>Quasar Nebula:</i> (wiki editor, 11/6/2025)
+
+    This track is named just [[track:pilot-light|'Pilot Light']] on coloUrs and mayhem: Universe B. (It made it in!) The same name is preserved / reflected on the later Bandcamp release of this album (Shenanigans: MSPA). It's an interesting way that a later, different-context release of a track played back into a rerelease or revision of the original context!
 ---
 Track: Curtain Roll
 Date First Released: 8/12/2011

--- a/album/shenanigans-mspa.yaml
+++ b/album/shenanigans-mspa.yaml
@@ -1,0 +1,271 @@
+Album: 'Shenanigans: MSPA'
+Directory: shenanigans-mspa
+Artists:
+- Thomas Ibarra
+Date: September 22, 2012
+Cover Artists:
+- Thomas Ibarra
+Cover Art File Extension: png
+Color: '#bca5bc'
+Groups:
+- Fandom
+Commentary: |-
+    <i>Thomas Ibarra:</i> ([Bandcamp about blurb](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/))
+
+    Comes complete with a near-perfect rendering of the [[flash:fan-animation-homestuck|"Irradiated"]] animation (in celebration of nearly 100,000 hits as of this writing), and a printable booklet of all original track art!
+
+    <i>Thomas Ibarra:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/))
+
+    Gracious thanks to the talented individuals running MS Paint Adventures, their hard work inspired me to write these recomposed works.
+Additional Files:
+- Title: Track Art Booklet
+  Description: >-
+    Booklet containing all original track art.
+- Title: Irradiated Animation Rendering
+  Description: >-
+    Near-perfect rendering of the [[flash:fan-animation-homestuck|Irradiated]] animation.
+---
+Track: Ace of Spades
+Duration: 3:40
+Referenced Tracks:
+- Liquid Negrocity
+- The Ballad of Jack Noir
+---
+Track: Advance
+Directory: advance-shenanigans
+Duration: 3:18
+URLs:
+- https://soundcloud.com/sparksd2145/advance
+Referenced Tracks:
+- Liquid Negrocity
+- Atomyk Ebonpyre
+- track:MeGaLoVania
+- Showtime (Original Mix)
+---
+Track: Curtain Roll
+Duration: 1:31
+URLs:
+- https://soundcloud.com/sparksd2145/curtainroll
+Referenced Tracks:
+- Showtime (Original Mix)
+- Atomyk Ebonpyre
+---
+Track: Curtain Roll - Extended Mix
+Duration: 2:54
+URLs:
+- https://soundcloud.com/sparksd2145/curtain-roll-extended-mix
+Referenced Tracks:
+- Curtain Roll
+- Overture of Paradox Space
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/curtain-roll-extended-mix))
+
+   Thought I'd put [[track:curtain-roll|the original Curtain Roll mix]] and [[track:overture-of-paradox-space|the Overture to Paradox Space orchestral mix]] together! This is what I came up with.
+---
+Track: Downtime
+Directory: downtime-shenanigans
+Main Release: Land of Fans and Music
+Duration: 2:15
+URLs:
+- https://soundcloud.com/sparksd2145/downtime
+---
+Track: Electric Fireflies
+Duration: 3:39
+URLs:
+- https://soundcloud.com/sparksd2145/electric-fireflies
+Referenced Tracks:
+- Firefly Cloud
+- Doctor
+- Showtime (Original Mix)
+---
+Track: Feathered
+Directory: feathered-shenanigans
+Duration: 1:47
+URLs:
+- https://soundcloud.com/sparksd2145/feathered
+Referenced Tracks:
+- Carefree Victory
+- Ohgodwhat
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/feathered))
+
+   An older piece largely based on the [[Carefree Victory]] and [[track:ohgodwhat|Omgwhat]] tracks, originating from Homestuck. :D
+---
+Track: Flowers and Fireflies
+Duration: 4:14
+URLs:
+- https://soundcloud.com/sparksd2145/flowers-and-fireflies
+Referenced Tracks:
+- Lotus
+- Lotus Land Story
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/flowers-and-fireflies))
+
+   An inspired track loosely based around the [[track:lotus|"Lotus"]]] and [[track:lotus-land-story|"Lotus Land Story"]] tracks from MSPA's Homestuck.
+---
+Track: Interlude
+Directory: interlude-shenanigans
+Duration: 1:53
+Referenced Tracks:
+- Explore
+---
+Track: Irradated
+Duration: 2:16
+URLs:
+- https://soundcloud.com/sparksd2145/irradiated-updated
+Referenced Tracks:
+- Harlequin
+- Liquid Negrocity
+- Sburban Jungle
+- track:carefree-action
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/irradiated-updated))
+
+   The original [[track:irradated|Irradiated]] remix, updated and given new life for the homestuck fan music album 2.
+---
+Track: John - Walk along the Ruins
+Additional Names:
+- Name: >-
+    John: Walk along the Ruins
+  Annotation: >-
+    [SoundCloud release](https://soundcloud.com/sparksd2145/sample-john-walk-along-the)
+Duration: 2:45
+URLs:
+- https://soundcloud.com/sparksd2145/sample-john-walk-along-the
+Referenced Tracks:
+- Showtime (Original Mix)
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sample-john-walk-along-the))
+
+   As he ventures into the post-apocalyptic ruins of Earth, John discovers truth; that even the Heir of Breath cannot restore life and happiness into the world alone.
+---
+Track: Lotus
+Directory: lotus-shenanigans
+Always Reference By Directory: true
+Duration: 2:56
+URLs:
+- https://soundcloud.com/sparksd2145/lotus
+Referenced Tracks:
+- Lotus
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/lotus))
+
+   A deviation of the [[track:lotus|Lotus theme]] originally from Homestuck, arriving at a completely new tune with orchestral hints of the former. :D
+---
+Track: Mjolinir
+Duration: 2:00
+Referenced Tracks:
+- Sunsetter
+- Skaian Skuffle
+---
+Track: Overture of Paradox Space
+Duration: 1:27
+URLs:
+- https://soundcloud.com/sparksd2145/overture-of-paradox-space
+Referenced Tracks:
+- Curtain Roll
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/overture-of-paradox-space))
+
+   Based largely on an edited version of [[track:curtain-roll|curtain roll]], Overture of Paradox Space focuses on the melodic nature of [[track:showtime-piano-refrain|Showtime]] by the MSPA Team.
+---
+Track: Pilot Light
+Directory: pilot-light-shenanigans
+Main Release: 'coloUrs and mayhem: Universe B'
+Duration: 2:51
+---
+Track: Rectify
+Directory: rectify-shenanigans
+Duration: 2:52
+URLs:
+- https://soundcloud.com/sparksd2145/rectify
+Referenced Tracks:
+- Liquid Negrocity
+- Atomyk Ebonpyre
+- Showtime (Piano Refrain)
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/rectify))
+
+   Rectify, by AutoDevote. (now completed!)
+
+   - I had an idea after I watched [[flash:4109|[S] Cascade]], and though I know it would go against Jack's present nature, I really feel like if he had the motivation to redirect his bloodthirsty warpath in the name of helping the kids (due to some unprecedented character development) he might. That being said, I sat down and began thinking. I've noticed a majority of the entries I've seen so far are covers of present songs, and while I was trying to stray away from using melodies and motifs that were already in existence, I decided to try my hand at it.
+
+   I present my track for Jack Noir, Rectify. This is my second entry for the Homestuck Music Contest, and I really like the way this one turned out. I've logged twelve hours and nine minutes on this track so far, and I intend to polish it up just a bit further before I submit it officially. :D
+---
+Track: Requiem of Space
+Duration: 1:40
+URLs:
+- https://soundcloud.com/sparksd2145/requiem-of-space
+Referenced Tracks:
+- Skaian Skuffle
+- Pyrocumulus (Sicknasty)
+---
+Track: Revelations
+Directory: revelations-shenanigans
+Duration: 2:15
+URLs:
+- https://soundcloud.com/sparksd2145/revelations
+Referenced Tracks:
+- track:frost-vol6
+- Sburban Jungle
+---
+Track: Sburb
+Directory: sburb-shenanigans
+Duration: 2:27
+URLs:
+- https://soundcloud.com/sparksd2145/sburb
+Referenced Tracks:
+- Sburban Jungle
+- Beatdown (Strider Style)
+- Liquid Negrocity
+- Harlequin
+- Showtime (Piano Refrain)
+- Atomyk Ebonpyre
+---
+Track: Schrodinger's Session
+Duration: 2:07
+URLs:
+- https://soundcloud.com/sparksd2145/schrodingers-session
+Referenced Tracks:
+- Atomyk Ebonpyre
+- Showtime (Original Mix)
+---
+Track: Shatter
+Directory: shatter-shenanigans
+Duration: 2:00
+URLs:
+- https://www.youtube.com/watch?v=KPhSjyajhuU
+Referenced Tracks:
+- Shatterface
+---
+Track: Strife
+Directory: strife-shenanigans
+Duration: 3:15
+URLs:
+- https://soundcloud.com/sparksd2145/strife
+Referenced Tracks:
+- Showtime (Original Mix)
+- Aggrieve
+- Dissension (Original)
+- Beatdown (Strider Style)
+---
+Track: Sweet-Tart Theme
+Duration: 1:13
+URLs:
+- https://soundcloud.com/sparksd2145/sweet-tart-theme
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/sweet-tart-theme))
+
+   A composition done especially for my friend and fellow tumblr-blogger (askthwigglers, [pother](https://pother.tumblr.com)). My first attempt at a cutesy theme. :D
+---
+Track: 'The Felt: Rise of Lord English'
+Duration: 2:50
+URLs:
+- https://soundcloud.com/sparksd2145/the-felt-rise-of-lord
+Referenced Tracks:
+- track:MeGaLoVania
+- Liquid Negrocity
+Commentary: |-
+   <i>Thomas Ibarra:</i> ([SoundCloud description](https://soundcloud.com/sparksd2145/the-felt-rise-of-lord))
+
+   The updated Rise of Lord English track for use in the [[album:lofam2|second Land of Fans and Music album.]]

--- a/artists.yaml
+++ b/artists.yaml
@@ -14488,6 +14488,10 @@ Aliases:
 - AutoDevote
 URLs:
 - https://soundcloud.com/sparksd2145
+- https://www.youtube.com/@ThomasIbarra
+Dead URLs:
+- https://www.deviantart.com/sparksd2145
+- https://github.com/SparksD2145  # Active, just it's GitHub...
 ---
 Artist: Thomas Oliphant
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -5541,7 +5541,7 @@ Flash: Fan Animation - Homestuck
 Directory: fan-animation-homestuck
 Date: February 10, 2011
 Featured Tracks:
-- track:irradiated-shenanigans-mspa
+- track:irradiated-animation-version
 URLs:
 - https://www.youtube.com/watch?v=hnG10rk9lqg
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -5928,7 +5928,7 @@ Date: December 15, 2022
 Cover Art File Extension: png
 Featured Tracks:
 - Terezi Owns
-- Pilot Light
+- track:pilot-light
 URLs:
 - https://youtu.be/t9oMhFzoL2c
 Contributors:
@@ -5993,7 +5993,7 @@ Featured Tracks:
 - please support The Trevor Project
 - Clockwork
 - Bed of Rose's / Dreams of Derse
-- Pilot Light
+- track:pilot-light
 - WORST END
 - Shade
 - Black Rose / Green Sun
@@ -6031,7 +6031,7 @@ Featured Tracks:
 - Red Disc
 - Homestuck
 - Ruins Rising
-- Pilot Light
+- track:pilot-light
 URLs:
 - https://youtu.be/IvemeefuzpU
 Contributors:

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -5541,7 +5541,7 @@ Flash: Fan Animation - Homestuck
 Directory: fan-animation-homestuck
 Date: February 10, 2011
 Featured Tracks:
-- Irradated
+- track:irradiated-shenanigans-mspa
 URLs:
 - https://www.youtube.com/watch?v=hnG10rk9lqg
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -5928,7 +5928,7 @@ Date: December 15, 2022
 Cover Art File Extension: png
 Featured Tracks:
 - Terezi Owns
-- track:pilot-light
+- Pilot Light
 URLs:
 - https://youtu.be/t9oMhFzoL2c
 Contributors:
@@ -5993,7 +5993,7 @@ Featured Tracks:
 - please support The Trevor Project
 - Clockwork
 - Bed of Rose's / Dreams of Derse
-- track:pilot-light
+- Pilot Light
 - WORST END
 - Shade
 - Black Rose / Green Sun
@@ -6031,7 +6031,7 @@ Featured Tracks:
 - Red Disc
 - Homestuck
 - Ruins Rising
-- track:pilot-light
+- Pilot Light
 URLs:
 - https://youtu.be/IvemeefuzpU
 Contributors:

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -5541,7 +5541,7 @@ Flash: Fan Animation - Homestuck
 Directory: fan-animation-homestuck
 Date: February 10, 2011
 Featured Tracks:
-- track:irradiated-lofam2
+- Irradated
 URLs:
 - https://www.youtube.com/watch?v=hnG10rk9lqg
 ---

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -573,7 +573,6 @@ Content: |-
     <details><summary><b>Toggle Directorylog</b> (general changes)</summary>
     - changed directory of [[track:maibasojen-lofam]] from `maibasojen` to `maibasojen-lofam`
     - changed directory of [[track:electric-fireflies-lofam3]] from `electric-fireflies` to `electric-fireflies-lofam3`
-    - changed directory of [[track:denizen-lofam4]] from `denizen` to `denizen-lofam4`
     - changed directory of [[track:thread-the-needle-stlap2]] from `thread-the-needle` to `thread-the-needle-stlap2`
     - changed directory of [[track:cloudscape-dialed-to-11]] from `cloudscape` to `cloudscape-dialed-to-11`
     - changed directory of [[track:the-respect-you-rightfully-deserve-single]] from `the-respect-you-rightfully-deserve-soundcloud` to `the-respect-you-rightfully-deserve-single`

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -148,6 +148,7 @@ Content: |-
     - added [[album:palokrai-i]] and [[album:palokrai-ii]] by [[artist:isorakathed-zorethan-f]]! (thanks, Lilith, Lavender!)
     - added [[album:so-i-herd-you-liek-homestuck]] by [[artist:sidewalkbanana]] (thanks, Lilith!)
     - added [[album:centauromachy]] and [[album:sbargrist]] by [[artist:curricle]]! (thanks, Jebb!)
+    - added [[album:shenanigans-mspa]] and [[album:shenanigans-mspa-chiptuned]] by [[artist:thomas-ibarra]] (thanks, <<Lilith:album data, research, presentation>>, <<Lan:album data, presentation, research>>, <<Sparks:lots of advice, commentary, files>>, plus <<Snowy:pointed toward "Strife - Chiptuned">>, <<Lavender:code stuff, changelog>>!)
     - added [[album:some-artifacts-may-occur]] by [[artist:shinokabe]] (thanks, Lilith, Lan!)
     - added [[album:vaporstuck]] by [[artist:the-hypergiants-asmr]] (thanks, Lilith!)
     - added [[album:janestuck-volume-100]] and [[album:janestuck-volume-2]]! (thanks, Lilith, Jackie!)
@@ -301,8 +302,11 @@ Content: |-
     - touched up commentary in [[track:showtime-svix-mix]] (thanks, Tangle!)
     - moved stuff from commentary into crediting and referencing sources in [[track:showtime-svix-mix]], [[track:versus-hardmode-remix]], [[track:the-showdown-single-version]], [[track:adventurous-ascent-single-version]], [[track:the-showdown-album-version]], [[track:adventurous-ascent-lofam5a2-version]], [[track:infinite-cataclysm]], [[track:vivid-spectrum]], [[track:old-world]], and [[track:losing-heart]] (thanks, Tangle, Lanolin!)
     - removed a bunch of commentary from [[track:adventurous-ascent-lofam5a2-version]] that was just duplicated from the LOFAM5A2 album booklet
+    <!-- new previous productions -->
+    - added [[track:irradiated-thomas-ibarra]] (original SoundCloud release) as a previous production for [[track:irradiated-lofam2]] ([[album:lofam2]] and [[album:shenanigans-mspa]]; thanks, Lan!)
     <!-- tracks newly marked as a secondary release -->
     - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
+    - marked [[track:rectify-lofam2]] ([[album:lofam2]]) newly as a secondary release (thanks, Lan!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
     - marked [[track:frost-and-frogs-lofam5a2]] ([[album:lofam5a2]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:fallen-down]] ([[album:i-miss-you-earthbound-2012]] newly as a secondary release (thanks, ruby!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -572,7 +572,8 @@ Content: |-
     <h3>directory changes</h3>
     <details><summary><b>Toggle Directorylog</b> (general changes)</summary>
     - changed directory of [[track:maibasojen-lofam]] from `maibasojen` to `maibasojen-lofam`
-    - changed directory of [[track:denizen-lofam4]] from `denizen` to `denizen-lofam`
+    - changed directory of [[track:electric-fireflies-lofam3]] from `electric-fireflies` to `electric-fireflies-lofam3`
+    - changed directory of [[track:denizen-lofam4]] from `denizen` to `denizen-lofam4`
     - changed directory of [[track:thread-the-needle-stlap2]] from `thread-the-needle` to `thread-the-needle-stlap2`
     - changed directory of [[track:cloudscape-dialed-to-11]] from `cloudscape` to `cloudscape-dialed-to-11`
     - changed directory of [[track:the-respect-you-rightfully-deserve-single]] from `the-respect-you-rightfully-deserve-soundcloud` to `the-respect-you-rightfully-deserve-single`


### PR DESCRIPTION
Adds Shenanigans: MSPA ~~(formerly from Bandcamp)~~ (well, the SoundCloud release is the current model, but the Bandcamp exclusive tracks are in their own track list), but also makes the following changes:
- moved track references from the [LOFAM2](https://github.com/hsmusic/hsmusic-data/blob/preview/album/lofam2.yaml) releases of rectify, irradiated, and the [LOFAM3](https://github.com/hsmusic/hsmusic-data/blob/preview/album/lofam3.yaml) release of electric fireflies to [hsmusic-data/album/shenanigans-mspa](https://github.com/hsmusic/hsmusic-data/blob/preview/album/shenanigans-mspa.yaml)
- new directory names for rectify (LOFAM2) and electric fireflies (LOFAM3):
``rectify-lofam2`` and ``electric-fireflies-lofam3``
~~- added Pilot Light additional name from SoundCloud release to [hsmusic-data/album/coloUrs-and-mayhem-universe-b](https://github.com/hsmusic/hsmusic-data/blob/preview/album/coloUrs-and-mayhem-universe-b.yaml) as well as commentary from said SoundCloud~~ (additional name was moved to SoundCloud release of Pilot Light)
~~- changed Irradiated (LOFAM2) track feature to Irradated in [hsmusic-data/flashes](https://github.com/hsmusic/hsmusic-data/blob/preview/flashes.yaml), as well in the Rectify (LOFAM2) commentary~~
Irradated was a funny typo on the Bandcamp release, but it is currently in place as an additional name for Irradiated instead.

Merge alongside [hsmusic-media#75](https://github.com/hsmusic/hsmusic-media/pull/75)
