### PR TITLE
Album addition: Loftlocked Vol. 1

### DIFF
--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -163,7 +163,7 @@ URLs:
 Track: 'INTERMISSION: Mimesiswing'
 Directory: mimesiswing
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: '03:28'
 Referenced Tracks:
 - SWING, SWING, SWING

--- a/album/lofam4.yaml
+++ b/album/lofam4.yaml
@@ -118,7 +118,7 @@ Commentary: |-
     [[artist:keyboard-cait]]<br>
     [[artist:kouta]]<br>
     [[artist:kris-flacke|Kris “Astartus” Flacke]]<br>
-    [[artist:kurtis-burton]]<br>
+    [[artist:rnd|Kurtis Burton]]<br>
     [[artist:kusoro]]<br>
     [[artist:lambda-elise-merryberry]]<br>
     [[artist:lark-mordancy]]<br>
@@ -526,7 +526,7 @@ Commentary: |-
 ---
 Track: Blind Pilot
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: '4:11'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/blind-pilot
@@ -818,7 +818,7 @@ Art Tags:
 Commentary: |-
     <i>Veritas Unae:</i> (composer, booklet commentary)
 
-    Originally, this piece was written for a good friend of mine, [[artist:patmandx|Patrick]]. He was running the fan adventure [[flash-act:loftlocked|Loftlocked]] at the time, and I'd supplied the comic with a lot of music in conjunction with [[artist:kurtis-burton|Kurtis]] (who is also on this album! Check him out!) Pat had approached me to write a haunting refrain for a harp playing character, Eliza. This theme would eventually form part of several songs written by Kurtis and myself, and the most prominent of which, Lamental, was made into another song, [[track:infinitys-lament|Infinity's Lament]]. It is a fun, jovial melody that turns darker as Eliza becomes less sure of herself and her playing. However, in a Homestuck specific context, consider Rose playing the rain, plucking strings but quickly finding herself at odds with her own land quest. Who knows? The beauty of music is that you can make your own interpretations.
+    Originally, this piece was written for a good friend of mine, [[artist:patmandx|Patrick]]. He was running the fan adventure [[flash-act:loftlocked|Loftlocked]] at the time, and I'd supplied the comic with a lot of music in conjunction with [[artist:rnd|Kurtis]] (who is also on this album! Check him out!) Pat had approached me to write a haunting refrain for a harp playing character, Eliza. This theme would eventually form part of several songs written by Kurtis and myself, and the most prominent of which, Lamental, was made into another song, [[track:infinitys-lament|Infinity's Lament]]. It is a fun, jovial melody that turns darker as Eliza becomes less sure of herself and her playing. However, in a Homestuck specific context, consider Rose playing the rain, plucking strings but quickly finding herself at odds with her own land quest. Who knows? The beauty of music is that you can make your own interpretations.
 
     <i>Circlejourney:</i> (track artist, booklet commentary)
 
@@ -3766,7 +3766,7 @@ Commentary: |-
 ---
 Track: Wicker Kingdom
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: '3:58'
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/wicker-kingdom
@@ -3784,7 +3784,7 @@ Referenced Tracks:
 Commentary: |-
     <i>PatManDX:</i> (track artist, booklet commentary)
 
-    [[artist:kurtis-burton|RND]] and I used to collaborate on projects years ago so we've become very familiar with the other's work. When I first heard this track, back about 3 years ago, I knew I had to do the art for it. The song felt very grand and frenetic, while giving a sense of regality and awe, so I did my best to capture those feelings into the track art. I knew that I had to put in the White King as the main focus on the picture, since the song is a remix to [[track:white-king|a certain other song]]. There is a great emphasis on texture and desaturated colors, to help make the piece feel almost like a worn tapestry. I added a bloom filter to add to this effect.
+    [[artist:rnd|RND]] and I used to collaborate on projects years ago so we've become very familiar with the other's work. When I first heard this track, back about 3 years ago, I knew I had to do the art for it. The song felt very grand and frenetic, while giving a sense of regality and awe, so I did my best to capture those feelings into the track art. I knew that I had to put in the White King as the main focus on the picture, since the song is a remix to [[track:white-king|a certain other song]]. There is a great emphasis on texture and desaturated colors, to help make the piece feel almost like a worn tapestry. I added a bloom filter to add to this effect.
 
     <i>Kal-la-kal-la:</i> (album help, booklet commentary)
 

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -17,7 +17,7 @@ Commentary: |-
 
    <i>PatManDX:</i> ([Bandcamp credits blurb](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
 
-   Music by the talents of [[artist:rnd|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:tiresiasarchivist]].
+   Music by the talents of [[artist:rnd|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:tiresiasarchivist|tiresiasArchivist (Matt)]].
 
    Track art by [[artist:patmandx|PatMan (Pat)]], [[artist:absolita|Absolita (Y. Rice)]], and [[artist:supersheep64|supersheep64 (James)]]
 Banner Artists:
@@ -238,17 +238,17 @@ Commentary: |-
     <i>Veritas Unae:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/thunderhead))
     The song is very chaotic, representing a world dominated by an [REDACTED] thunderstorm. I tried to bring a balance between tranquility and complete rage, counterbalancing the world of the player with the player [REDACTED].
 
-    <i>Veritas Unae:</i> ([SoundCloud description, excerpt](https://soundcloud.com/veritasunae/thunderhead))
+    <i>Veritas Unae:</i> ([SoundCloud description](https://soundcloud.com/veritasunae/thunderhead), excerpt, 3/3/2014)
 
     I made a song at the request of [[artist:patmandx|Pat]] for his fan adventure, Loftlocked. <i>(Succeeding paragraph same as Bandcamp description, up 'til...)</i>
 
     I used Sibelius and Pro Tools SE for this.
 
-    <i>Kevin Grant:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead))
+    <i>Kevin Grant:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead), 3/4/2014)
 
     Whoa, people still make HS fanmusic? Is it 2011? Where am I what's going on who are these nice men in the suits taking me away
 
-    <i>Veritas Unae:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead))
+    <i>Veritas Unae:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead), 3/6/2014)
 
     considering people still make HS fanventures... yeah, I guess so. oh wait where are you going oh goodbye friend i hope you enjoy your trip!!
 ---

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -207,11 +207,12 @@ Referenced Tracks:
 - Sunsetter
 - Ocean Stars Falling
 Commentary: |-
-   <i>Unknown Artist:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/flower-child))
+   <i>PatManDX:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/flower-child))
 
    This track was a bit of a big leap for both the composer and the track artist. [[artist:rnd]] decided to experiment with sounds resembling traditional Indonesian Gamelan, whereas [[artist:patmandx|Pat]] had took his first steps into more painted-styled drawings. After some trial and error, both were pleasantly surprised with the result of their work and the work of the other's.
 
    It was really hot.
+#citation: Jebb's DMs to Pat: "Pat: honestly it was probably me, sound like me at age 17" "Jebb: Lmao"
 ---
 Track: Thunderhead
 Directory: thunderhead-loftlocked

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -1,0 +1,299 @@
+Album: Loftlocked Vol. 1
+Date: July 1, 2014
+URLs:
+- https://loftlocked.bandcamp.com/album/loftlocked-vol-1
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Color: '#fdc500'
+Groups:
+- Fandom
+Commentary: |-
+   <i>PatManDX:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
+
+   This album is a collaboration of people I've managed to fool into thinking that this comic was worth any of their time.
+
+   I'm greatly pleased to present to you 15 great songs (and 2 equally sweet bonus ones). Don't forget to take a gander at the cool track art we've made!
+
+   <i>PatManDX:</i> ([Bandcamp credits blurb](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
+
+   Music by the talents of [[artist:kurtis-burton|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:animeseinfeld|tiresiasArchivist (Audrey)]].
+
+   Track art by [[artist:patmandx|PatMan (Pat)]], [[artist:absolita|Absolita (Y. Rice)]], and [[artist:supersheep64|supersheep64 (James)]]
+Banner Artists:
+- PatManDX
+Banner Dimensions: 975x180
+Banner File Extension: png
+Additional Files:
+- Title: Loftlocked School Bus
+  Files:
+  - loftlocked school bus.png
+- Title: Bandcamp banner
+  Files:
+  - banner.png
+---
+Section: Main album
+---
+Track: Prelude
+Directory: prelude-loftlocked
+Always Reference By Directory: true
+Artists:
+- Veritas Unae
+Duration: 0:12
+URLs:
+- https://loftlocked.bandcamp.com/track/prelude
+Referenced Tracks:
+- Loftlocked
+- Ride on the Magic School Bus
+---
+Track: Written Page
+Artists:
+- Kurtis Burton
+Duration: 2:07
+Cover Artists:
+- PatManDX
+Cover Art File Extension: gif
+Art Tags:
+- Pat (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/written-page-2
+---
+Track: Concession
+Directory: concession-loftlocked
+Additional Names:
+- Concentration ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/concession))
+Always Reference By Directory: true
+Artists:
+- Kurtis Burton
+Duration: 1:49
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Pat (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/concession
+Referenced Tracks:
+- Unforgiving Terrain
+---
+Track: Agnostic Prognostic
+Artists:
+- Kurtis Burton
+Duration: 3:07
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Odi (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/agnostic-prognostic-3
+---
+Track: Hellbrosprite
+Artists:
+- Kurtis Burton
+Duration: 3:20
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Hellbrosprite (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/hellbrosprite-2
+---
+Track: Made of Void
+Artists:
+- Kurtis Burton
+Duration: 2:28
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Ella (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/made-of-void-2
+---
+Track: Empty One
+Artists:
+- Kurtis Burton
+Duration: 2:58
+Cover Artists:
+- Supersheep64
+Cover Art File Extension: png
+Art Tags:
+- Ella (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/empty-one
+Referenced Tracks:
+- Even in Death
+- Made of Void
+---
+Track: Heart Container
+Artists:
+- Kurtis Burton
+Duration: 2:45
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Plink (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/heart-container
+Referenced Tracks:
+- track:select-screen-the-legend-of-zelda-a-link-to-the-past
+---
+Track: Resolve
+Directory: resolve-loftlocked
+Always Reference By Directory: true
+Artists:
+- animeseinfeld
+Duration: 1:10
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Plink (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/resolve
+Referenced Tracks:
+- track:dark-world-the-legend-of-zelda-a-link-to-the-past
+- track:dark-mountain-forest
+---
+Track: Rouge Rogue
+Artists:
+- animeseinfeld
+Duration: 1:13
+Cover Artists:
+- Absolita
+Cover Art File Extension: png
+Art Tags:
+- Carmen (Loftlocked)
+- Underlings
+URLs:
+- https://loftlocked.bandcamp.com/track/rouge-rogue
+Referenced Tracks:
+- track:dr-wily-stage-1
+- track:MeGaLoVania
+---
+Track: Crystalmaniacal Countdown
+Artists:
+- Kurtis Burton
+Duration: 2:39
+Cover Artists:
+- PatManDX
+Cover Art File Extension: gif
+Art Tags:
+- Carmen (Loftlocked)
+- Earth
+URLs:
+- https://loftlocked.bandcamp.com/track/crystalmaniacal-countdown
+Referenced Tracks:
+- track:MeGaLoVania
+- Sburban Jungle
+- Crystalanthemums
+---
+Track: Flower Child
+Artists:
+- Kurtis Burton
+Duration: 2:36
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+Art Tags:
+- Lisa (Loftlocked)
+URLs:
+- https://loftlocked.bandcamp.com/track/flower-child
+Referenced Tracks:
+- Sunsetter
+- Ocean Stars Falling
+Commentary: |-
+   <i>Unknown Artist:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/flower-child))
+
+   This track was a bit of a big leap for both the composer and the track artist. [[artist:kurtis-burton|Rnd]] decided to experiment with sounds resembling traditional Indonesian Gamelan, whereas [[artist:patmandx|Pat]] had took his first steps into more painted-styled drawings. After some trial and error, both were pleasantly surprised with the result of their work and the work of the other's.
+
+   It was really hot.
+---
+Track: Thunderhead
+Directory: thunderhead-loftlocked
+Always Reference By Directory: true
+Artists:
+- Veritas Unae
+Duration: 3:21
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+URLs:
+- https://loftlocked.bandcamp.com/track/thunderhead
+Commentary: |-
+    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/thunderhead))
+    The song is very chaotic, representing a world dominated by an [REDACTED] thunderstorm. I tried to bring a balance between tranquility and complete rage, counterbalancing the world of the player with the player [REDACTED].
+
+    <i>Veritas Unae:</i> ([SoundCloud description](https://soundcloud.com/veritasunae/thunderhead))
+
+    I made a song at the request of [[artist:patmandx|Pat]] for his fan adventure, Loftlocked. The song is very chaotic, representing a world dominated by an [REDACTED] thunderstorm. I tried to bring a balance between tranquility and complete rage, counterbalancing the world of the player with the player [REDACTED].
+
+    I used Sibelius and Pro Tools SE for this.
+
+    <i>Kevin Grant:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead))
+
+    Whoa, people still make HS fanmusic? Is it 2011? Where am I what's going on who are these nice men in the suits taking me away
+
+    <i>Veritas Unae:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead))
+
+    considering people still make HS fanventures... yeah, I guess so. oh wait where are you going oh goodbye friend i hope you enjoy your trip!!
+---
+Track: Obsidian
+Directory: obsidian-loftlocked
+Always Reference By Directory: true
+Artists:
+- Kurtis Burton
+Duration: 2:51
+Cover Artists:
+- PatManDX
+Cover Art File Extension: png
+URLs:
+- https://loftlocked.bandcamp.com/track/obsidian-3
+---
+Track: Loftlocked
+Artists:
+- Veritas Unae
+Duration: 3:20
+Cover Artists:
+- PatManDX
+Cover Art File Extension: gif
+URLs:
+- https://loftlocked.bandcamp.com/track/loftlocked-2
+Commentary: |-
+   <i>Veritas Unae:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/loftlocked-2))
+
+   This song was tricky to nail, but when I got it, I ran with it, leaving its children and significant other behind in a flurry of musical excitement.<br>
+   Do you hear those suspended cymbal rolls? DO YOU HEAR THEM???
+---
+Section: Bonus tracks
+---
+Track: Clockwork Physician
+Artists:
+- Unknown Artist
+Duration: 2:45
+Cover Artists:
+- PatManDX
+Referenced Tracks:
+- Doctor
+- Time on My Side
+- Savior of the Waking World
+---
+Track: Savior of the Setting Sun
+Artists:
+- Kurtis Burton
+# Reference:
+#  https://soundcloud.com/ominous-sines/savior-of-the-setting-sun-1
+Duration: 3:08
+Cover Artists:
+- PatManDX
+Art Tags:
+- Lisa (Loftlocked)
+- 'cw: blood'
+- 'cw: corpse'
+Referenced Tracks:
+- Doctor
+- Sunsetter
+- Savior of the Waking World

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -15,9 +15,9 @@ Commentary: |-
 
    I'm greatly pleased to present to you 15 great songs (and 2 equally sweet bonus ones). Don't forget to take a gander at the cool track art we've made!
 
-   <i>PatManDX:</i> ([Bandcamp credits blurb](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
+   <i>PatManDX:</i> ([Bandcamp credits blurb, excerpt](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
 
-   Music by the talents of [[artist:kurtis-burton|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:animeseinfeld|tiresiasArchivist (Audrey)]].
+   Music by the talents of [[artist:rnd|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:unknown-artist|Anonymous]].
 
    Track art by [[artist:patmandx|PatMan (Pat)]], [[artist:absolita|Absolita (Y. Rice)]], and [[artist:supersheep64|supersheep64 (James)]]
 Banner Artists:
@@ -48,7 +48,7 @@ Referenced Tracks:
 ---
 Track: Written Page
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:07
 Cover Artists:
 - PatManDX
@@ -64,7 +64,7 @@ Additional Names:
 - Concentration ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/concession))
 Always Reference By Directory: true
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 1:49
 Cover Artists:
 - PatManDX
@@ -78,7 +78,7 @@ Referenced Tracks:
 ---
 Track: Agnostic Prognostic
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 3:07
 Cover Artists:
 - PatManDX
@@ -90,7 +90,7 @@ URLs:
 ---
 Track: Hellbrosprite
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 3:20
 Cover Artists:
 - PatManDX
@@ -102,7 +102,7 @@ URLs:
 ---
 Track: Made of Void
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:28
 Cover Artists:
 - PatManDX
@@ -114,7 +114,7 @@ URLs:
 ---
 Track: Empty One
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:58
 Cover Artists:
 - Supersheep64
@@ -129,7 +129,7 @@ Referenced Tracks:
 ---
 Track: Heart Container
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:45
 Cover Artists:
 - PatManDX
@@ -145,13 +145,14 @@ Track: Resolve
 Directory: resolve-loftlocked
 Always Reference By Directory: true
 Artists:
-- animeseinfeld
+- Unknown Artist
 Duration: 1:10
 Cover Artists:
 - PatManDX
 Cover Art File Extension: png
 Art Tags:
 - Plink (Loftlocked)
+- Underlings
 URLs:
 - https://loftlocked.bandcamp.com/track/resolve
 Referenced Tracks:
@@ -160,7 +161,7 @@ Referenced Tracks:
 ---
 Track: Rouge Rogue
 Artists:
-- animeseinfeld
+- Unknown Artist
 Duration: 1:13
 Cover Artists:
 - Absolita
@@ -176,7 +177,7 @@ Referenced Tracks:
 ---
 Track: Crystalmaniacal Countdown
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:39
 Cover Artists:
 - PatManDX
@@ -193,7 +194,7 @@ Referenced Tracks:
 ---
 Track: Flower Child
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:36
 Cover Artists:
 - PatManDX
@@ -208,7 +209,7 @@ Referenced Tracks:
 Commentary: |-
    <i>Unknown Artist:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/flower-child))
 
-   This track was a bit of a big leap for both the composer and the track artist. [[artist:kurtis-burton|Rnd]] decided to experiment with sounds resembling traditional Indonesian Gamelan, whereas [[artist:patmandx|Pat]] had took his first steps into more painted-styled drawings. After some trial and error, both were pleasantly surprised with the result of their work and the work of the other's.
+   This track was a bit of a big leap for both the composer and the track artist. [[artist:rnd]] decided to experiment with sounds resembling traditional Indonesian Gamelan, whereas [[artist:patmandx|Pat]] had took his first steps into more painted-styled drawings. After some trial and error, both were pleasantly surprised with the result of their work and the work of the other's.
 
    It was really hot.
 ---
@@ -245,7 +246,7 @@ Track: Obsidian
 Directory: obsidian-loftlocked
 Always Reference By Directory: true
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: 2:51
 Cover Artists:
 - PatManDX
@@ -283,7 +284,7 @@ Referenced Tracks:
 ---
 Track: Savior of the Setting Sun
 Artists:
-- Kurtis Burton
+- Rnd
 # Reference:
 #  https://soundcloud.com/ominous-sines/savior-of-the-setting-sun-1
 Duration: 3:08

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -17,7 +17,7 @@ Commentary: |-
 
    <i>PatManDX:</i> ([Bandcamp credits blurb, excerpt](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
 
-   Music by the talents of [[artist:rnd|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:unknown-artist|Anonymous]].
+   Music by the talents of [[artist:rnd|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:tiresiasarchivist]].
 
    Track art by [[artist:patmandx|PatMan (Pat)]], [[artist:absolita|Absolita (Y. Rice)]], and [[artist:supersheep64|supersheep64 (James)]]
 Banner Artists:
@@ -145,7 +145,7 @@ Track: Resolve
 Directory: resolve-loftlocked
 Always Reference By Directory: true
 Artists:
-- Unknown Artist
+- tiresiasArchivist
 Duration: 1:10
 Cover Artists:
 - PatManDX
@@ -161,7 +161,7 @@ Referenced Tracks:
 ---
 Track: Rouge Rogue
 Artists:
-- Unknown Artist
+- tiresiasArchivist
 Duration: 1:13
 Cover Artists:
 - Absolita
@@ -277,7 +277,7 @@ Section: Bonus tracks
 ---
 Track: Clockwork Physician
 Artists:
-- Unknown Artist
+- tiresiasArchivist
 Duration: 2:45
 Cover Artists:
 - PatManDX

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -213,6 +213,9 @@ Commentary: |-
 
    It was really hot.
 #citation: Jebb's DMs to Pat: "Pat: honestly it was probably me, sound like me at age 17" "Jebb: Lmao"
+   <i>Lilithtreasure:</i> (wiki editor)
+   
+   While Pat may've not remembered if it was him who wrote the commentary for Flower Child; it's mostly likely him given that the other track commentaries are from [[artist:veritas-unae]].
 ---
 Track: Thunderhead
 Directory: thunderhead-loftlocked
@@ -229,9 +232,9 @@ Commentary: |-
     <i>Veritas Unae:</i> ([Bandcamp about blurb](https://loftlocked.bandcamp.com/track/thunderhead))
     The song is very chaotic, representing a world dominated by an [REDACTED] thunderstorm. I tried to bring a balance between tranquility and complete rage, counterbalancing the world of the player with the player [REDACTED].
 
-    <i>Veritas Unae:</i> ([SoundCloud description](https://soundcloud.com/veritasunae/thunderhead))
+    <i>Veritas Unae:</i> ([SoundCloud description, excerpt](https://soundcloud.com/veritasunae/thunderhead))
 
-    I made a song at the request of [[artist:patmandx|Pat]] for his fan adventure, Loftlocked. The song is very chaotic, representing a world dominated by an [REDACTED] thunderstorm. I tried to bring a balance between tranquility and complete rage, counterbalancing the world of the player with the player [REDACTED].
+    I made a song at the request of [[artist:patmandx|Pat]] for his fan adventure, Loftlocked. <i>(Succeeding paragraph same as Bandcamp description, up 'til...)</i>
 
     I used Sibelius and Pro Tools SE for this.
 

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -212,9 +212,15 @@ Commentary: |-
    This track was a bit of a big leap for both the composer and the track artist. [[artist:rnd]] decided to experiment with sounds resembling traditional Indonesian Gamelan, whereas [[artist:patmandx|Pat]] had took his first steps into more painted-styled drawings. After some trial and error, both were pleasantly surprised with the result of their work and the work of the other's.
 
    It was really hot.
-#citation: Jebb's DMs to Pat: "Pat: honestly it was probably me, sound like me at age 17" "Jebb: Lmao"
+
+   <i>PatManDX:</i> (Discord, 9/20/24)
+   honestly it was probably me, sound like me at age 17
+
+   <i>Jebb:</i> (wiki editor, Discord, 9/20/24)
+   Lmao
+
    <i>Lilithtreasure:</i> (wiki editor)
-   
+
    While Pat may've not remembered if it was him who wrote the commentary for Flower Child; it's mostly likely him given that the other track commentaries are from [[artist:veritas-unae]].
 ---
 Track: Thunderhead

--- a/album/loftlocked-vol-1.yaml
+++ b/album/loftlocked-vol-1.yaml
@@ -15,7 +15,7 @@ Commentary: |-
 
    I'm greatly pleased to present to you 15 great songs (and 2 equally sweet bonus ones). Don't forget to take a gander at the cool track art we've made!
 
-   <i>PatManDX:</i> ([Bandcamp credits blurb, excerpt](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
+   <i>PatManDX:</i> ([Bandcamp credits blurb](https://loftlocked.bandcamp.com/album/loftlocked-vol-1))
 
    Music by the talents of [[artist:rnd|Rnd (Kurt)]], [[artist:veritas-unae|Veritas Unae (Scott)]], [[artist:tiresiasarchivist]].
 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1924,29 +1924,6 @@ Commentary: |-
     <i>Mathias Ramalho:</i> (Composer)
     Made for a MSPA-styled, DnD Session, named "Colored Castles"
 ---
-Track: Thunderhead
-Directory: thunderhead-loftlocked
-Always Reference By Directory: true
-Artists:
-- Veritas Unae
-Duration: '3:21'
-URLs:
-- https://loftlocked.bandcamp.com/track/thunderhead
-Commentary: |-
-    <i>Veritas Unae:</i> ([SoundCloud description](https://soundcloud.com/veritasunae/thunderhead))
-
-    I made a song at the request of [[artist:patmandx|Pat]] for his fan adventure, Loftlocked. The song is very chaotic, representing a world dominated by an [REDACTED] thunderstorm. I tried to bring a balance between tranquility and complete rage, counterbalancing the world of the player with the player [REDACTED].
-
-    I used Sibelius and Pro Tools SE for this.
-
-    <i>Kevin Grant:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead))
-
-    Whoa, people still make HS fanmusic? Is it 2011? Where am I what's going on who are these nice men in the suits taking me away
-
-    <i>Veritas Unae:</i> ([SoundCloud comment](https://soundcloud.com/veritasunae/thunderhead))
-
-    considering people still make HS fanventures... yeah, I guess so. oh wait where are you going oh goodbye friend i hope you enjoy your trip!!
----
 Track: Vacuum Spark
 Artists:
 - Monckat

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -3677,6 +3677,16 @@ Duration: '2:05'
 URLs:
 - https://www.youtube.com/watch?v=6cuDFYZXw0c
 ---
+Track: Dark Mountain Forest
+# Reference:
+#   https://vgmdb.net/album/885
+Artists:
+- The Legend of Zelda
+- Koji Kondo
+Duration: '1:52'
+URLs:
+- https://www.youtube.com/watch?v=jGbhi5U4Qb0
+---
 Track: 'Chapter 20: Destroyed Skyworld'
 # Reference:
 #   https://vgmdb.net/album/33508
@@ -3701,6 +3711,16 @@ Artists:
 - Anamanaguchi
 URLs:
 - https://www.youtube.com/watch?v=TNfItV62gD8
+---
+Track: 'Dark World (The Legend of Zelda: A Link to the Past)'
+# Reference:
+#   https://vgmdb.net/album/885
+Artists:
+- The Legend of Zelda
+- Koji Kondo
+Duration: '2:23'
+URLs:
+- https://www.youtube.com/watch?v=sslj06K-Nlw
 ---
 Track: Death Mountain (The Legend of Zelda)
 # Reference:
@@ -4068,6 +4088,16 @@ Artists:
 Duration: '1:44'
 URLs:
 - https://www.youtube.com/watch?v=Tud96HogGbo
+---
+Track: Dr. Wily Stage 1
+# Reference:
+#   https://vgmdb.net/album/33749
+Artists:
+- Mega Man
+- Takashi Tateishi
+Duration: '2:45'
+URLs:
+- https://www.youtube.com/watch?v=aTbfpkByIM8
 ---
 Track: Duck Get! (Duck Hunt)
 # Reference:
@@ -13467,6 +13497,50 @@ Artists:
 Duration: '4:01'
 URLs:
 - https://www.youtube.com/watch?v=Sv93yQE8bRo
+---
+Track: Ride on the Magic School Bus
+Artists:
+- Magic School Bus
+- Peter Lurye (composition)
+Contributors:
+- Little Richard (performance)
+Duration: '1:02'
+URLs:
+- https://www.youtube.com/watch?v=v53mhRXXT2g
+Lyrics: |-
+   (Seatbelts, everyone!)
+   (Please let this be a normal field trip...)
+   (With the Friz?)
+   (No way!)
+   (Aw...)
+
+   Cruising on that main street
+   You're relaxed, and feeling good (Yeah!)
+   Next thing that you know
+   You're seeing (Wah-ha-ha-ha-hoo!)
+   An octopus in the neighborhood?
+
+   Surfing on a sound wave
+   Swinging through the stars (Yeehaw!)
+   Take a left at your intestine
+   Take your second right past Mars
+   On the Magic School Bus
+   Navigate a nostril (Achoo!)
+
+   Climb on the Magic School Bus
+   Spank a plankton too (Take that!)
+   On our Magic School Bus
+   Raft a river of lava
+   On the Magic School Bus
+   It's such a fine thing to do (Woahhh!)
+
+   So strap your bones right to your seat
+   Come on, lean in, don't be shy (Come on!)
+   Just to make your day complete
+   You might get baked into a pie
+   On the Magic School Bus
+   Step inside, it's a wilder ride
+   Come on, ride on the Magic School Bus
 ---
 Track: Rose's Death
 Artists:

--- a/album/the-green-box-set-1.yaml
+++ b/album/the-green-box-set-1.yaml
@@ -121,7 +121,7 @@ Track: CONVERGENCE (Emmy's Theme)
 Duration: '02:27'
 Date First Released: January 2, 2018
 Cover Artists:
-- animeseinfeld
+- capmics
 Art Tags:
 - Emmy (Hexane)
 URLs:
@@ -129,7 +129,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/convergence-emmys-theme))
 
-    Commissioned by [[artist:animeseinfeld|animeseinfeld]].
+    Commissioned by [[artist:capmics|animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 
@@ -149,7 +149,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/requiem-of-renewal-laraminias-theme))
 
-    Commissioned by [[artist:animeseinfeld|animeseinfeld]].
+    Commissioned by [[artist:capmics|animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 
@@ -172,7 +172,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/reverse-engineering-qamarkinos-theme))
 
-    Commissioned by [[artist:animeseinfeld|animeseinfeld]].
+    Commissioned by [[artist:capmics|animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 
@@ -210,7 +210,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/phantasm-of-the-mind-thereminas-theme))
 
-    Commissioned by [[artist:animeseinfeld|animeseinfeld]].
+    Commissioned by [[artist:capmics|animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 

--- a/album/the-green-box-set-1.yaml
+++ b/album/the-green-box-set-1.yaml
@@ -121,7 +121,7 @@ Track: CONVERGENCE (Emmy's Theme)
 Duration: '02:27'
 Date First Released: January 2, 2018
 Cover Artists:
-- capmics
+- animeseinfeld
 Art Tags:
 - Emmy (Hexane)
 URLs:
@@ -129,7 +129,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/convergence-emmys-theme))
 
-    Commissioned by [[artist:capmics|animeseinfeld]].
+    Commissioned by [[artist:animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 
@@ -149,7 +149,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/requiem-of-renewal-laraminias-theme))
 
-    Commissioned by [[artist:capmics|animeseinfeld]].
+    Commissioned by [[artist:animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 
@@ -172,7 +172,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/reverse-engineering-qamarkinos-theme))
 
-    Commissioned by [[artist:capmics|animeseinfeld]].
+    Commissioned by [[artist:animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 
@@ -210,7 +210,7 @@ URLs:
 Commentary: |-
     <i>iodbc - The Black Box:</i> ([Bandcamp about blurb](https://iodbc.bandcamp.com/track/phantasm-of-the-mind-thereminas-theme))
 
-    Commissioned by [[artist:capmics|animeseinfeld]].
+    Commissioned by [[artist:animeseinfeld]].
 
     Intended for use in ["Hexane."](https://mspfa.com?s=1032)
 

--- a/album/vast-error-vol-3.yaml
+++ b/album/vast-error-vol-3.yaml
@@ -126,14 +126,14 @@ URLs:
 Track: 'Beyond the Wall (Intermission)'
 Directory: beyond-the-wall
 Artists:
-- Kurtis Burton
+- Rnd
 Duration: '03:13'
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-beyond-the-wall-2
 ---
 Track: Third Eye
 Artists:
-- Kurtis Burton
+- Rnd
 Cover Artists:
 - Sparaze
 Art Tags:
@@ -196,7 +196,7 @@ URLs:
 ---
 Track: Invigorated Wasteland
 Artists:
-- Kurtis Burton
+- Rnd
 Cover Artists:
 - Cosmic
 Duration: '02:24'
@@ -225,7 +225,7 @@ URLs:
 ---
 Track: Sickly Green Glow
 Artists:
-- Kurtis Burton
+- Rnd
 Cover Artists:
 - Ephemerald
 Duration: '02:42'

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -115,7 +115,7 @@ URLs:
 Track: The Crucible
 Duration: '2:19'
 Artists:
-- Kurtis Burton
+- Rnd
 Cover Artists:
 - groeuf
 URLs:
@@ -284,7 +284,7 @@ URLs:
 Track: Furbish
 Duration: '2:43'
 Artists:
-- Kurtis Burton
+- Rnd
 Cover Artists:
 - anemonta
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -567,6 +567,8 @@ Aliases:
 - tiresiasArchivist  # cite: https://mspafa.fandom.com/wiki/Hexane
 - Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
 - Audrey Hershenson  # see: https://audreyhershenson.netlify.app
+URLs:
+- https://capmics.itch.io
 Dead URLs:
 - https://animeseinfeld.tumblr.com #terminated in 2024
 - https://twitter.com/audreys_trick/  # unused

--- a/artists.yaml
+++ b/artists.yaml
@@ -560,9 +560,8 @@ Aliases:
 - tiresiasArchivist  # cite: https://mspafa.fandom.com/wiki/Hexane
 - Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
 - Audrey Hershenson  # see: https://audreyhershenson.netlify.app
-URLs:
-- https://animeseinfeld.tumblr.com
 Dead URLs:
+- https://animeseinfeld.tumblr.com #terminated in 2024
 - https://twitter.com/audreys_trick/  # unused
 - https://audreyhershenson.netlify.app/  # professional homepage
 - https://steamcommunity.com/id/audreys_trick  # linked from homepage above

--- a/artists.yaml
+++ b/artists.yaml
@@ -73,6 +73,12 @@ URLs:
 - https://www.youtube.com/channel/UCJc63RY7b5gvANBAPI-qiaA
 - https://abibeur.github.io
 ---
+Artist: Absolita
+Aliases:
+- Y. Rice
+URLs:
+- https://absolita.tumblr.com
+---
 Artist: Accel World
 ---
 Artist: 'ACE (TOMOri Kudo / CHiCO)'
@@ -6467,6 +6473,8 @@ Dead URLs:
 ---
 Artist: LISA
 ---
+Artist: Little Richard
+---
 Artist: Little Willie John
 ---
 Artist: Live A Live
@@ -6743,6 +6751,8 @@ Artist: Maggot
 URLs:
 - https://twitter.com/maggotboy22
 - https://comrademaggot.tumblr.com/
+---
+Artist: Magic School Bus
 ---
 Artist: Magnolia Porter
 URLs:
@@ -8491,6 +8501,8 @@ Artist: Peter Adams
 Artist: Peter Allen
 ---
 Artist: Peter Hont
+---
+Artist: Peter Lurye
 ---
 Artist: Peter Schroeder
 ---
@@ -10667,6 +10679,10 @@ Artist: Super Smash Bros.
 Artist: Super Smash Bros. Orchestra
 ---
 Artist: Superman
+---
+Artist: Supersheep64
+URLs:
+- https://www.deviantart.com/supersheep64
 ---
 Artist: Supertramp
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -559,10 +559,11 @@ Artist: Animal Collective
 ---
 Artist: Animal Crossing
 ---
-Artist: animeseinfeld
+Artist: capmics
 # Author of "Hexane", "Dungeons of Sunnydale".
 Aliases:
-- Audrey  # cite: Tumblr, MSPFA
+- animeseinfeld  # cite: Tumblr
+- Audrey  # cite: Tumblr, MSPFA, itch.io
 - tiresiasArchivist  # cite: https://mspafa.fandom.com/wiki/Hexane
 - Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
 - Audrey Hershenson  # see: https://audreyhershenson.netlify.app
@@ -6146,7 +6147,12 @@ URLs:
 - https://www.deviantart.com/kurimja
 - https://www.artstation.com/kurimja
 ---
-Artist: Kurtis Burton
+Artist: Rnd
+Aliases:
+- Kurtis Burton
+- Kurtis "Rnd" Burton
+Dead URLs:
+- https://rndsines.tumblr.com/
 ---
 Artist: Kurupt
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -559,6 +559,23 @@ Artist: Animal Collective
 ---
 Artist: Animal Crossing
 ---
+Artist: animeseinfeld
+# Author of "Hexane", "Dungeons of Sunnydale".
+Aliases:
+- capmics  # cite: itch.io, Discord
+- Audrey  # cite: Tumblr, MSPFA, itch.io
+- Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
+- Audrey Hershenson  # see: https://audreyhershenson.netlify.app
+Context Notes: |-
+    Some early works are also credited under [[artist:tiresiasarchivist]].
+URLs:
+- https://capmics.itch.io
+Dead URLs:
+- https://animeseinfeld.tumblr.com #terminated in 2024
+- https://twitter.com/audreys_trick/  # unused
+- https://audreyhershenson.netlify.app/  # professional homepage
+- https://steamcommunity.com/id/audreys_trick  # linked from homepage above
+---
 Artist: animmania
 Aliases:
 - ed
@@ -1723,22 +1740,6 @@ Aliases:
 URLs:
 - https://www.youtube.com/@stuckhometome
 - https://twitter.com/capitainjoe
----
-Artist: capmics
-# Author of "Hexane", "Dungeons of Sunnydale".
-Aliases:
-- animeseinfeld  # cite: Tumblr
-- Audrey  # cite: Tumblr, MSPFA, itch.io
-- tiresiasArchivist  # cite: https://mspafa.fandom.com/wiki/Hexane
-- Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
-- Audrey Hershenson  # see: https://audreyhershenson.netlify.app
-URLs:
-- https://capmics.itch.io
-Dead URLs:
-- https://animeseinfeld.tumblr.com #terminated in 2024
-- https://twitter.com/audreys_trick/  # unused
-- https://audreyhershenson.netlify.app/  # professional homepage
-- https://steamcommunity.com/id/audreys_trick  # linked from homepage above
 ---
 Artist: Captain_moonstone
 URLs:
@@ -11270,6 +11271,10 @@ Artist: TirantBacon
 URLs:
 - https://soundcloud.com/maxy3
 - https://soundcloud.com/tirantbacon
+---
+Artist: tiresiasArchivist
+Context Notes: |-
+    Early alias of [[artist:animeseinfeld]].
 ---
 Artist: TK
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -559,22 +559,6 @@ Artist: Animal Collective
 ---
 Artist: Animal Crossing
 ---
-Artist: capmics
-# Author of "Hexane", "Dungeons of Sunnydale".
-Aliases:
-- animeseinfeld  # cite: Tumblr
-- Audrey  # cite: Tumblr, MSPFA, itch.io
-- tiresiasArchivist  # cite: https://mspafa.fandom.com/wiki/Hexane
-- Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
-- Audrey Hershenson  # see: https://audreyhershenson.netlify.app
-URLs:
-- https://capmics.itch.io
-Dead URLs:
-- https://animeseinfeld.tumblr.com #terminated in 2024
-- https://twitter.com/audreys_trick/  # unused
-- https://audreyhershenson.netlify.app/  # professional homepage
-- https://steamcommunity.com/id/audreys_trick  # linked from homepage above
----
 Artist: animmania
 Aliases:
 - ed
@@ -1739,6 +1723,22 @@ Aliases:
 URLs:
 - https://www.youtube.com/@stuckhometome
 - https://twitter.com/capitainjoe
+---
+Artist: capmics
+# Author of "Hexane", "Dungeons of Sunnydale".
+Aliases:
+- animeseinfeld  # cite: Tumblr
+- Audrey  # cite: Tumblr, MSPFA, itch.io
+- tiresiasArchivist  # cite: https://mspafa.fandom.com/wiki/Hexane
+- Matt Hershenson    # cite: https://loftlocked.bandcamp.com/track/rouge-rogue
+- Audrey Hershenson  # see: https://audreyhershenson.netlify.app
+URLs:
+- https://capmics.itch.io
+Dead URLs:
+- https://animeseinfeld.tumblr.com #terminated in 2024
+- https://twitter.com/audreys_trick/  # unused
+- https://audreyhershenson.netlify.app/  # professional homepage
+- https://steamcommunity.com/id/audreys_trick  # linked from homepage above
 ---
 Artist: Captain_moonstone
 URLs:
@@ -6149,13 +6149,6 @@ URLs:
 - https://www.deviantart.com/kurimja
 - https://www.artstation.com/kurimja
 ---
-Artist: Rnd
-Aliases:
-- Kurtis Burton
-- Kurtis "Rnd" Burton
-Dead URLs:
-- https://rndsines.tumblr.com/
----
 Artist: Kurupt
 Aliases:
 - Ricardo Brown
@@ -9305,6 +9298,13 @@ URLs:
 - https://www.youtube.com/@ayybeff
 - https://twitter.com/rivermusic_
 - https://ko-fi.com/rivermusic
+---
+Artist: Rnd
+Aliases:
+- Kurtis Burton
+- Kurtis "Rnd" Burton
+Dead URLs:
+- https://rndsines.tumblr.com/
 ---
 Artist: Rob Cavallo
 ---

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -39,6 +39,7 @@ Content: |-
     <h2 id="1-jan-2099" class="major-release"><html:a href="#1-jan-2099">[[date:1 January 2099]] - Anachronist's Library</a></h2>
     <h3>site changes</h3>
     <h3>album additions</h3>
+    - added [[album:loftlocked-vol-1]]! (thanks, Lilith, Jebb, Pat, Audrey!)
     - added [[album:rooftop-paladin]] by [[artist:hazama-yuutou]]! (thanks, Lilith!)
     - added [[album:your-majesty]] by [[group:michael-guy-bowman]]!
     - added [[album:gba-pokemon-unbound-super-music-collection]] by [[group:the-paradox-music-team]]! (thanks, Morris!)
@@ -48,6 +49,7 @@ Content: |-
     - added commentary blurbs from Bandcamp and YouTube, as well as additional names mostly from YouTube, across [[album:the-funk-mclovin-homestuck-experience]], [[album:class-act]], and [[album:class-act-b-side]]
     - added album release commentary to [[album:gravity-makes-the-flame-rise]] and [[album:ulterior-motives]]
     - added album release photoset to [[album:ulterior-motives]]
+    - moved [[track:thunderhead-loftlocked]] from [[album:more-homestuck-fandom]] to [[album:loftlocked-vol-1]] (thanks, Lilith!)
     <h3>data fixes</h3>
     - fixed [[track:fiduspawn-go]] not referencing [[track:title-screen-pokemon-red-blue]] (thanks, Morris!)
     - fixed [[track:anarchy-gravity-makes-the-flame-rise]] not sampling [[track:nothing-but-the-best]] (thanks, Morris!)

--- a/tags.yaml
+++ b/tags.yaml
@@ -1482,6 +1482,24 @@ Color: '#95909f'
 Tag: LoSaC (Redditstuck)
 Color: '#eaeaea'
 ---
+Tag: Pat (Loftlocked)
+Color: '#3399ff'
+---
+Tag: Odi (Loftlocked)
+Color: '#349c34'
+---
+Tag: Ella (Loftlocked)
+Color: '#ff8c00'
+---
+Tag: Lisa (Loftlocked)
+Color: '#33cc99'
+---
+Tag: Carmen (Loftlocked)
+Color: '#cc3333'
+---
+Tag: Plink (Loftlocked)
+Color: '#cc6799'
+---
 Tag: alcohol
 Is CW: true
 ---

--- a/tags.yaml
+++ b/tags.yaml
@@ -1500,6 +1500,9 @@ Color: '#cc3333'
 Tag: Plink (Loftlocked)
 Color: '#cc6799'
 ---
+Tag: Hellbrosprite (Loftlocked)
+Color: '#99cc33'
+---
 Tag: alcohol
 Is CW: true
 ---


### PR DESCRIPTION
**(Special thanks to [Jebb](https://github.com/JebbJabroni) for forwarding the questions I had to ask Pat regarding musician data for Savior of the Setting Sun (it was Rnd), and Clockwork Physician!)**
### Adds Loftlocked Vol. 1 (by Rnd, Veri, and tiresiasArchivist), but also...

- adds Loftlocked kids (Pat, Odi, Ella, Lisa, Carmen, and Plink), plus Hellbrosprite as art tags

- moved Thunderhead from [album/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml) to `loftlocked-vol-1.yaml`
- added Dr. Wily Stage 1 from Mega Man 2, Dark World, and Dark Mountain Forest from The Legend of Zelda: A Link to the Past, as well as Ride on the Magic School Bus from, Magic School Bus to [album/references-beyond-homestuck.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/references-beyond-homestuck.yaml)

- adjusted artist links that had Rnd as `[[artist:kurtis-burton]]` to `[[artist:rnd]]` in
[album/dead-shufflers-anything-goes.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/dead-shufflers-anything-goes.yaml), [album/lofam4.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/lofam4.yaml), [album/vast-error-vol-3.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/vast-error-vol-3.yaml), and [album/vast-error-vol-4.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/vast-error-vol-4.yaml)
~~- adjusted artist links in [album/the-green-box-set-1.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/the-green-box-set-1.yaml) that had capmics as `[[artist:animeseinfeld]]` to `[[artist:capmics]]`~~ **(reverted change back to animeseinfeld)**

### [artist.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml) related changes

- newly added: Magic School Bus (yes, really), Little Richard, Peter Lurye, Supersheep64, and Absolita
- moved capmics's tumblr URL to dead URLs, ~~animeseinfeld moved to aliases~~ **(reverted change, but capmics will stay as an alias, but animeseinfeld is the main alias again)**; added capmics' itch.io page to URLs 
- **separated tiresiasArchivist from animeseinfeld**
- added Rnd's dead tumblr to dead URLs; moved Kurtis Burton to aliases; added Kurtis "Rnd" Burton to Rnd's aliases

Merge with: https://github.com/hsmusic/hsmusic-media/pull/77