### PR TITLE
Artist update: celestialKarakul (formerly Kara Roas)

### DIFF
--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -731,7 +731,7 @@ URLs:
 - https://homestuck.bandcamp.com/track/pyrocumulus-sicknasty-2
 - https://youtu.be/4BqRC-ZPovM
 Cover Artists:
-- Kara Roas
+- celestialKarakul
 Cover Art File Extension: jpg
 Art Tags:
 - John

--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -2597,7 +2597,7 @@ URLs:
 - https://unofficialmspafans.bandcamp.com/track/frost-and-frogs
 - https://www.youtube.com/watch?v=fEi3Z2QQeKE
 Cover Artists:
-- Kara Roas
+- celestialKarakul
 Art Tags:
 - Jade
 - Frogs
@@ -2608,7 +2608,7 @@ Commentary: |-
     <i>autumnalEquinox:</i>
     This track was inspired by an orchestral piece that we had to play in band and its most primarily heard in the call and response between the flutes and the horns!
 
-    <i>Kara Roas:</i>
+    <i>celestialKarakul:</i>
     The moment I heard the intro to this track, I immediately fell in love with it and had a visual in my head. Given the "back and forth" mentioned for the composition of the song, it made me think of the Jade out collecting frogs on her planet... so that's what I went with! ♥
 ---
 Track: dog

--- a/album/squiddles.yaml
+++ b/album/squiddles.yaml
@@ -97,7 +97,7 @@ Commentary: |-
     [[artist:paige-turner]] (lead animator)<br>
     [[artist:rebecca-harding]]<br>
     [[artist:brett-muller]]<br>
-    [[artist:celestialkarakul|Kara Roas]]<br>
+    [[artist:celestialkarakul]]<br>
     [[artist:michael-firman]]<br>
     [[artist:cindy-dominguez]]<br>
     [[artist:hanni-brosh|SaffronScarf]]<br>

--- a/album/squiddles.yaml
+++ b/album/squiddles.yaml
@@ -97,7 +97,7 @@ Commentary: |-
     [[artist:paige-turner]] (lead animator)<br>
     [[artist:rebecca-harding]]<br>
     [[artist:brett-muller]]<br>
-    [[artist:kara-roas]]<br>
+    [[artist:celestialkarakul|Kara Roas]]<br>
     [[artist:michael-firman]]<br>
     [[artist:cindy-dominguez]]<br>
     [[artist:hanni-brosh|SaffronScarf]]<br>

--- a/artists.yaml
+++ b/artists.yaml
@@ -1859,6 +1859,37 @@ URLs:
 ---
 Artist: Celeste
 ---
+Artist: celestialKarakul
+Aliases:
+- Kara Roas
+- Jessica Allison
+- Rutares
+- prismahays
+- purgatoryrose
+- b4kara
+- KaraRoasVTuber
+URLs:
+- https://bsky.app/profile/celestialkarakul.bsky.social
+- https://celestialkarakul.carrd.co
+- https://www.tiktok.com/@celestialkarakul
+- https://www.instagram.com/celestialkarakul/
+Dead URLs:
+- https://bsky.app/profile/kararoas.bsky.social #rebranded
+- https://kararoasart.carrd.co #rebranded
+- https://twitter.com/KaraRoas #rebranded
+- https://www.furaffinity.net/user/kararoas/
+- https://www.furaffinity.net/user/purgatoryrose/
+- https://www.deviantart.com/purgatoryrose
+- https://twitter.com/PurgatoryRose
+- https://www.twitch.tv/purgatoryrose
+- http://prismahays.tumblr.com/
+- http://rutares.deviantart.com/
+- https://www.tiktok.com/@b4kara
+- https://www.twitch.tv/kararoas
+- https://b4kara.tumblr.com/
+- https://kararoas.tumblr.com/ #rebranding
+- https://twitter.com/KaraRoasVTuber
+---
 Artist: Celestriarts
 Aliases:
 - life.tales
@@ -5617,37 +5648,6 @@ Artist: Kaori Shimizu
 Artist: Kaoru Kubota
 ---
 Artist: Kaoru Okubo
----
-Artist: celestialKarakul
-Aliases:
-- Kara Roas
-- Jessica Allison
-- Rutares
-- prismahays
-- purgatoryrose
-- b4kara
-- KaraRoasVTuber
-URLs:
-- https://bsky.app/profile/celestialkarakul.bsky.social
-- https://celestialkarakul.carrd.co
-- https://www.tiktok.com/@celestialkarakul
-- https://www.instagram.com/celestialkarakul/
-Dead URLs:
-- https://bsky.app/profile/kararoas.bsky.social #rebranded
-- https://kararoasart.carrd.co #rebranded
-- https://twitter.com/KaraRoas #rebranded
-- https://www.furaffinity.net/user/kararoas/
-- https://www.furaffinity.net/user/purgatoryrose/
-- https://www.deviantart.com/purgatoryrose
-- https://twitter.com/PurgatoryRose
-- https://www.twitch.tv/purgatoryrose
-- http://prismahays.tumblr.com/
-- http://rutares.deviantart.com/
-- https://www.tiktok.com/@b4kara
-- https://www.twitch.tv/kararoas
-- https://b4kara.tumblr.com/
-- https://kararoas.tumblr.com/ #rebranding
-- https://twitter.com/KaraRoasVTuber
 ---
 Artist: karelianArmy
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -5618,8 +5618,9 @@ Artist: Kaoru Kubota
 ---
 Artist: Kaoru Okubo
 ---
-Artist: Kara Roas
+Artist: celestialKarakul
 Aliases:
+- Kara Roas
 - Jessica Allison
 - Rutares
 - prismahays
@@ -5627,15 +5628,14 @@ Aliases:
 - b4kara
 - KaraRoasVTuber
 URLs:
-- https://bsky.app/profile/kararoas.bsky.social
-- https://b4kara.tumblr.com/
-- https://kararoas.tumblr.com/
-- https://twitter.com/KaraRoasVTuber
-- https://kararoasart.carrd.co
-- https://www.twitch.tv/kararoas
-- https://www.tiktok.com/@b4kara
+- https://bsky.app/profile/celestialkarakul.bsky.social
+- https://celestialkarakul.carrd.co
+- https://www.tiktok.com/@celestialkarakul
+- https://www.instagram.com/celestialkarakul/
 Dead URLs:
-- https://twitter.com/KaraRoas
+- https://bsky.app/profile/kararoas.bsky.social #rebranded
+- https://kararoasart.carrd.co #rebranded
+- https://twitter.com/KaraRoas #rebranded
 - https://www.furaffinity.net/user/kararoas/
 - https://www.furaffinity.net/user/purgatoryrose/
 - https://www.deviantart.com/purgatoryrose
@@ -5643,6 +5643,11 @@ Dead URLs:
 - https://www.twitch.tv/purgatoryrose
 - http://prismahays.tumblr.com/
 - http://rutares.deviantart.com/
+- https://www.tiktok.com/@b4kara
+- https://www.twitch.tv/kararoas
+- https://b4kara.tumblr.com/
+- https://kararoas.tumblr.com/ #rebranding
+- https://twitter.com/KaraRoasVTuber
 ---
 Artist: karelianArmy
 URLs:

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -475,7 +475,7 @@ Page: '1931'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
-- Kara Roas (art)
+- celestialKarakul (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - Nic Carey (art)
@@ -511,7 +511,7 @@ Contributors:
 - clorinspats (art)
 - Eyes5 (art)
 - FauxMonstur (art)
-- Kara Roas (art)
+- celestialKarakul (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - myluckyseven (art)
@@ -563,7 +563,7 @@ Page: '2787'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
-- Kara Roas (art)
+- celestialKarakul (art)
 - Rebecca Harding (art)
 - Paige Turner (art)
 - Richard Gung (art)
@@ -601,7 +601,7 @@ Page: '2818'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
-- Kara Roas (art)
+- celestialKarakul (art)
 - Rebecca Harding (art)
 - Paige Turner (art)
 - Richard Gung (art)
@@ -694,7 +694,7 @@ Page: '3297'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
-- Kara Roas (art)
+- celestialKarakul (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - Paige Turner (art)
@@ -717,7 +717,7 @@ Page: '3321'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
-- Kara Roas (art)
+- celestialKarakul (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - Paige Turner (art)

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -474,8 +474,8 @@ Page: '1931'
 ---
 Contributors:
 - Brett Muller (art)
-- Eyes5 (art)
 - celestialKarakul (art)
+- Eyes5 (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - Nic Carey (art)
@@ -508,10 +508,10 @@ Page: '2070'
 ---
 Contributors:
 - Brett Muller (art)
+- celestialKarakul (art)
 - clorinspats (art)
 - Eyes5 (art)
 - FauxMonstur (art)
-- celestialKarakul (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - myluckyseven (art)
@@ -562,8 +562,8 @@ Page: '2787'
 ---
 Contributors:
 - Brett Muller (art)
-- Eyes5 (art)
 - celestialKarakul (art)
+- Eyes5 (art)
 - Rebecca Harding (art)
 - Paige Turner (art)
 - Richard Gung (art)
@@ -600,8 +600,8 @@ Page: '2818'
 ---
 Contributors:
 - Brett Muller (art)
-- Eyes5 (art)
 - celestialKarakul (art)
+- Eyes5 (art)
 - Rebecca Harding (art)
 - Paige Turner (art)
 - Richard Gung (art)
@@ -693,8 +693,8 @@ Page: '3297'
 ---
 Contributors:
 - Brett Muller (art)
-- Eyes5 (art)
 - celestialKarakul (art)
+- Eyes5 (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - Paige Turner (art)
@@ -716,8 +716,8 @@ Page: '3321'
 ---
 Contributors:
 - Brett Muller (art)
-- Eyes5 (art)
 - celestialKarakul (art)
+- Eyes5 (art)
 - Lexxy (art)
 - Rebecca Harding (art)
 - Paige Turner (art)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -1247,7 +1247,7 @@ Content: |-
     - added commentary booklet file to [[album:cool-and-new-volume-v]]
     - added links to album premiere stream recordings to [[album:cyclica]], [[album:call-and-new]], [[album:cool-and-new-volume-s-x]], [[album:canwc-sound-test-1]], [[album:basement-tale]], [[album:cool-and-new-volume-7]], [[album:s-hecka-jef]], and [[album:canwc-for-the-holidays]] (thanks for these, Ngame!)
     <h3>data changes</h3>
-    - fixed [[artist:kara-roas]] having some artist credits under a different name
+    - fixed [[artist:celestialkarakul]] having some artist credits under a different name
     - medley tracks [[track:something-familiar]], [[track:yet-cool-and-new]], and [[track:ophiuchus-full-suite]] now list their constituent songs as references
     - divided two especially large additional files into smaller files
         - second part of voice-over commentary for [[album:sburb-ost]]


### PR DESCRIPTION
https://discord.com/channels/749042497610842152/749042497610842158/1287324136825425961
Updates pretty much everything (except for changelog) regarding celestialKarakul: more specifically:

in [artists.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/artists.yaml):
- [x] moved Kara Roas to aliases; since celestialKarakul is the main URL
- [x] moved pretty much every Kara Roas-era URL to dead URLs cause of the rebrand; added celestialKarakul's carrd, tiktok, bsky, and instagram in their place

in [flashes.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/flashes.yaml):
- [x] updated affected artist fields to celestialKarakul

albums directory:
- [x] [album/homestuck-vol-8.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/homestuck-vol-8.yaml), and [album/lofam5a2.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/lofam5a2.yaml): updated affected artist and commentary fields to celestialKarakul
- [x] [album/squiddles.yaml](https://github.com/hsmusic/hsmusic-data/blob/preview/album/squiddles.yaml): updated affected artist field to celestialKarakul