### PR TITLE
Slight change: Bandcamp capitalized official OST names replacements

### DIFF
--- a/album/_.yaml
+++ b/album/_.yaml
@@ -514,7 +514,7 @@ Referenced Tracks:
 - Softbit
 - Twinkle Elementary School
 - Ocean Stars
-- Walls Covered in Blood
+- Walls Covered In Blood
 ---
 Track: the wheel boss
 Artists:

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -380,12 +380,7 @@ Commentary: |-
 
     <img src="media/misc/psych0ruins.png" width="300">
 ---
-Track: Walls Covered in Blood
-Additional Names:
-- Name: >-
-    Walls Covered In Blood
-  Annotation: >-
-    [Bandcamp](https://homestuck.bandcamp.com/track/walls-covered-in-blood-2)
+Track: Walls Covered In Blood
 Duration: '2:00'
 URLs:
 - https://homestuck.bandcamp.com/track/walls-covered-in-blood-2

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -396,7 +396,7 @@ Sampled Tracks:
 MIDI Project Files:
 - Title: MIDI by Unknown
   Files:
-  - 'Walls Covered in Blood - Unknown.mid'
+  - 'Walls Covered In Blood - Unknown.mid'
 Commentary: |-
     <i>Toby Fox:</i> (booklet commentary)
 
@@ -814,7 +814,7 @@ Art Tags:
 - Alternia
 - 'cw: blood'
 Referenced Tracks:
-- Walls Covered in Blood
+- Walls Covered In Blood
 Commentary: |-
     <i>Homestuck:</i> (original track art)
 

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -381,6 +381,11 @@ Commentary: |-
     <img src="media/misc/psych0ruins.png" width="300">
 ---
 Track: Walls Covered in Blood
+Additional Names:
+- Name: >-
+    Walls Covered In Blood
+  Annotation: >-
+    [Bandcamp](https://homestuck.bandcamp.com/track/walls-covered-in-blood-2)
 Duration: '2:00'
 URLs:
 - https://homestuck.bandcamp.com/track/walls-covered-in-blood-2

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -741,13 +741,13 @@ Art Tags:
 - Alternia
 - 'cw: blood (abstract)'
 Referenced Tracks:
-- Walls Covered in Blood
+- Walls Covered In Blood
 Commentary: |-
     <i>Toby Fox:</i> (booklet commentary)
 
     (Nepeta Walkabout)
 
-    Beep beep, meow... it's a remix of [[Walls Covered in Blood]] if you didn't notice~
+    Beep beep, meow... it's a remix of [[Walls Covered In Blood|Walls Covered in Blood]] if you didn't notice~
 
     The original Walls was actually pretty divisive - either people loved it or they thought the Mario Paint instruments were too much to bear. Here we get the best of both worlds - the catchy theme without the weird instrumentation! (And if you liked the original better... well... great! Because it still exists.)
 
@@ -775,7 +775,7 @@ Art Tags:
 - 'cw: asphyxiation (abstract)'
 Referenced Tracks:
 - Horschestra
-- Walls Covered in Blood
+- Walls Covered In Blood
 Commentary: |-
     <i>Alex Rosetti:</i> (booklet commentary)
 
@@ -795,7 +795,7 @@ Commentary: |-
 
     Did I mention we're in love?
 
-    Also, the SNES funeral section interspersed with a small amount of [[Walls Covered in Blood]] at the end is just brilliant.
+    Also, the SNES funeral section interspersed with a small amount of [[Walls Covered In Blood|Walls Covered in Blood]] at the end is just brilliant.
 
     <i>Homestuck:</i> (original track art)
 
@@ -981,7 +981,7 @@ Referenced Tracks:
 - dESPERADO ROCKET CHAIRS,
 - Virgin Orb
 - Horschestra
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Keepers
 - The La2t Frontiier
 - psych0ruins
@@ -1023,7 +1023,7 @@ Commentary: |-
 
     3:15 - Kanaya, being quite graceful and yet incredibly deadly ([[Virgin Orb]]). She pretty much stops the music and focuses all attention on her - Something she'll do again in the future. I really like the opening of Kanaya's theme, so this is one of my fave bits. The chainsaw is also quite a fun touch.
 
-    3:34 - Equius decides to step in and show people how it's done with the might and efficiency only a highb100d could bring, and indeed he probably would, but Nepeta keeps being silly and sneaking in some attacks ([[Horschestra]] & [[Walls Covered in Blood]]). It was a bit of a faff combining these two, but I liked the idea of Equius' almost military like anthem being interrupted by Nepeta's calypso funkiness.
+    3:34 - Equius decides to step in and show people how it's done with the might and efficiency only a highb100d could bring, and indeed he probably would, but Nepeta keeps being silly and sneaking in some attacks ([[Horschestra]] & [[Walls Covered In Blood|Walls Covered in Blood]]). It was a bit of a faff combining these two, but I liked the idea of Equius' almost military like anthem being interrupted by Nepeta's calypso funkiness.
 
     3:53 - Feferi and Eridan move in ([[Keepers]]). These two have worked together before, and provide a potent force against the King.
 

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -568,12 +568,7 @@ Commentary: |-
 
     <img src="media/misc/darling-kanaya.png" width="300" warning="blood">
 ---
-Track: Requiem of Sunshine and Rainbows
-Additional Names:
-- Name: >-
-    Requiem Of Sunshine And Rainbows
-  Annotation: >-
-    [Bandcamp](https://homestuck.bandcamp.com/track/requiem-of-sunshine-and-rainbows-2)
+Track: Requiem Of Sunshine And Rainbows
 Artists:
 - Paige Turner
 Duration: '2:44'

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -569,6 +569,11 @@ Commentary: |-
     <img src="media/misc/darling-kanaya.png" width="300" warning="blood">
 ---
 Track: Requiem of Sunshine and Rainbows
+Additional Names:
+- Name: >-
+    Requiem Of Sunshine And Rainbows
+  Annotation: >-
+    [Bandcamp](https://homestuck.bandcamp.com/track/requiem-of-sunshine-and-rainbows-2)
 Artists:
 - Paige Turner
 Duration: '2:44'

--- a/album/ancestral.yaml
+++ b/album/ancestral.yaml
@@ -639,7 +639,7 @@ Art Tags:
 Referenced Tracks:
 - Jade Mother
 - Iron Infidel
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Serenade
 - Gold Pilot
 Commentary: |-
@@ -1581,7 +1581,7 @@ Art Tags:
 - The Signless
 - 'cw: blood'
 Referenced Tracks:
-- Walls Covered in Blood
+- Walls Covered In Blood
 - track:olive-scribe
 - Flare
 Lyrics: |-

--- a/album/canwc-sound-test-1.yaml
+++ b/album/canwc-sound-test-1.yaml
@@ -689,7 +689,7 @@ URLs:
 - https://youtu.be/SMmGVSvSk5w
 Referenced Tracks:
 - Upward Movement (Dave Owns)
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Olive Rogue
 - Endless Climb
 Sampled Tracks:

--- a/album/cool-and-new-volume-s-x.yaml
+++ b/album/cool-and-new-volume-s-x.yaml
@@ -2008,14 +2008,14 @@ URLs:
 Referenced Tracks:
 - Olive Rogue
 - Maybe I'm a Lion
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Hardchorale
 - Nyanyanyanyanyanyanya!
 - Serenade
 Sampled Tracks:
 - Olive Rogue
 - Maybe I'm a Lion
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Hardchorale
 - Nyanyanyanyanyanyanya!
 - Serenade

--- a/album/cool-and-new-voulem1.yaml
+++ b/album/cool-and-new-voulem1.yaml
@@ -1049,7 +1049,7 @@ Sampled Tracks:
 - Breeze
 - Starfall
 - Ascend
-- Lilith in Starlight
+- Lilith In Starlight
 - Thanks for Playing
 - Renewed Return
 - THIS Pumpkin

--- a/album/diverging-delicacies.yaml
+++ b/album/diverging-delicacies.yaml
@@ -255,7 +255,7 @@ Art Tags:
 - Green Sun
 Referenced Tracks:
 - Black Rose / Green Sun
-- Lilith in Starlight
+- Lilith In Starlight
 - At The Price of Oblivion
 - Aggrieve
 - Flare

--- a/album/homestuck-15th-anniversary-medley.yaml
+++ b/album/homestuck-15th-anniversary-medley.yaml
@@ -49,7 +49,7 @@ Referenced Tracks:
 - Pursuit - Corner the Culprit
 - Doctor
 - Your Best Friend
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Dogsong
 - Trickster Mode (Blast Off)
 - Upward Movement (Dave Owns)

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -1086,12 +1086,7 @@ Commentary: |-
 
     Edit: Apparently this was [[artist:makin|makinporing]], the mod from the /r/Homestuck subreddit? If so, cool!
 ---
-Track: Lilith in Starlight
-Additional Names:
-- Name: >-
-    Lilith In Starlight
-  Annotation: >-
-    [Bandcamp](https://homestuck.bandcamp.com/track/lilith-in-starlight-2)
+Track: Lilith In Starlight
 Artists:
 - Malcolm Brown
 Duration: '3:51'

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -1106,7 +1106,7 @@ Referenced Tracks:
 Sheet Music Files:
 - Title: Sheet music by EuniverseCat
   Files:
-  - 'Lilith in Starlight - EuniverseCat.pdf'
+  - 'Lilith In Starlight - EuniverseCat.pdf'
 Commentary: |-
     <i>Malcolm Brown:</i> (composer, booklet commentary)
 

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -1087,6 +1087,11 @@ Commentary: |-
     Edit: Apparently this was [[artist:makin|makinporing]], the mod from the /r/Homestuck subreddit? If so, cool!
 ---
 Track: Lilith in Starlight
+Additional Names:
+- Name: >-
+    Lilith In Starlight
+  Annotation: >-
+    [Bandcamp](https://homestuck.bandcamp.com/track/lilith-in-starlight-2)
 Artists:
 - Malcolm Brown
 Duration: '3:51'

--- a/album/lofam.yaml
+++ b/album/lofam.yaml
@@ -964,7 +964,7 @@ Referenced Tracks:
 - The La2t Frontiier
 - Terezi's Theme
 - dESPERADO ROCKET CHAIRS,
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Homestuck Anthem
 - Heir Transparent
 - Horschestra

--- a/album/lofam4.yaml
+++ b/album/lofam4.yaml
@@ -2041,7 +2041,7 @@ Referenced Tracks:
 - Heat
 - Beta Version
 - Let's All Rock the Heist
-- Revelations II
+- Revelations, II
 - Aimless Morning Gold
 - Core of Darkness
 - Escape Pod
@@ -2108,7 +2108,7 @@ Commentary: |-
     - [[album:medium|Medium]] - [[Heat]] - [[artist:clark-powell]] (04:03–04:21)
     - [[album:mobius-trip-and-hadron-kaleido|Mobius Trip and Hadron Kaleido]] - [[Beta Version]] - [[artist:michael-guy-bowman]] (04:22–04:39)
     - [[album:homestuck-vol-7|Homestuck Vol. 7]] - [[Let's All Rock the Heist]] - [[artist:robert-j-lake]] (04:22–04:39)
-    - [[album:sburb|Sburb]] - [[Revelations II]] - [[artist:james-dever]] (04:39–04:56)
+    - [[album:sburb|Sburb]] - [[track:revelations-ii|Revelations II]] - [[artist:james-dever]] (04:39–04:56)
     - [[album:the-wanderers|The Wanderers]] - [[Aimless Morning Gold]] - [[artist:michael-guy-bowman]] (04:46–04:56)
     - [[album:prospit-and-derse|Prospit & Derse]] - [[Core of Darkness]] - [[artist:solatrus]] (04:56–05:27)
     - [[album:homestuck-vol-8|Homestuck Vol. 8]] - [[Escape Pod]] - [[artist:michael-guy-bowman]] (05:03–05:10)

--- a/album/lofam4.yaml
+++ b/album/lofam4.yaml
@@ -1329,7 +1329,7 @@ Referenced Tracks:
 - Sburban Jungle
 - Theme
 - Crustacean
-- Walls Covered in Blood
+- Walls Covered In Blood
 - The Lemonsnout Turnabout
 - Spider's Claw
 - English
@@ -1420,7 +1420,7 @@ Commentary: |-
     - [[Sburban Jungle]] - [[artist:michael-guy-bowman]] (2:01–2:06)
     - [[Theme]] - [[artist:toby-fox]] (2:07–2:30)
     - [[Crustacean]] - [[artist:toby-fox]] (2:15–2:19, 2:31–2:36)
-    - [[Walls Covered in Blood]] - [[artist:toby-fox]] (2:36–2:38)
+    - [[Walls Covered In Blood|Walls Covered in Blood]] - [[artist:toby-fox]] (2:36–2:38)
     - [[The Lemonsnout Turnabout]] - [[artist:toby-fox]] (2:38–2:40)
     - [[Spider's Claw]] - [[artist:toby-fox]] (2:40–2:42)
     - [[English]] - [[artist:toby-fox]] (2:42–2:43, 4:57–5:07, 6:13–6:18)

--- a/album/lofam5.yaml
+++ b/album/lofam5.yaml
@@ -134,7 +134,7 @@ Art Tags:
 - Equius
 Referenced Tracks:
 - Olive Rogue
-- Walls Covered in Blood
+- Walls Covered In Blood
 Sampled Tracks:
 - Fox Hunt (1996) https://www.youtube.com/watch?v=LGF7cehJkWQ&t=3730s
 - OUR $3,400,000 MANSION! (House Tour)

--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -1468,7 +1468,7 @@ Art Tags:
 - Kanaya
 - 'cw: blood (abstract)'
 Referenced Tracks:
-- Requiem of Sunshine and Rainbows
+- Requiem Of Sunshine And Rainbows
 Commentary: |-
     <i>artist:kobacat:</i>
     before making this track, I never made an original song for a LoFaM album (my [[track:past-funk-is-worse-than-future-funk|previous one]] was taken from a [[album:9|CaNMT album]]), so my idea for this song was to remix a Homestuck song that didn't get much attention in the scene. one of my favorite songs from [[album:alterniabound|Alternabound]] was 'Requiem of Sunshine and Rainbows'. so my plan for this track was to create a remix more slow-paced but also felt more consistently intense compared to the original song. there's multiple melodies from the original song heard in this track, though it might be hard to hear them at first listen since some notes are changed slighly and the melodies are slowed, but i swear they're in there somewhere pls trust me

--- a/album/mobius-trip-and-hadron-kaleido.yaml
+++ b/album/mobius-trip-and-hadron-kaleido.yaml
@@ -352,7 +352,7 @@ Additional Names:
 - Name: >-
     Lies with the Sea
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20110603145529/https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido)
+    [original release](https://web.archive.org/web/20110606040223/http://homestuck.bandcamp.com/track/lies-with-the-sea)
 Duration: '4:46'
 URLs:
 - https://bowman.bandcamp.com/track/lies-with-the-sea
@@ -437,7 +437,7 @@ Additional Names:
 - Name: >-
     Chain of Prospit
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20110603145529/https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido)
+    [original release](https://web.archive.org/web/20110603145538/http://homestuck.bandcamp.com/track/chain-of-prospit)
 Duration: '4:37'
 URLs:
 - https://bowman.bandcamp.com/track/chain-of-prospit

--- a/album/mobius-trip-and-hadron-kaleido.yaml
+++ b/album/mobius-trip-and-hadron-kaleido.yaml
@@ -348,6 +348,11 @@ Commentary: |-
     ([Music video!](https://www.youtube.com/watch?v=CUDkBTYWtGk))
 ---
 Track: Lies With The Sea
+Additional Names:
+- Name: >-
+    Lies with the Sea
+  Annotation: >-
+    [original Bandcamp release](https://web.archive.org/web/20110603145529/https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido)
 Duration: '4:46'
 URLs:
 - https://bowman.bandcamp.com/track/lies-with-the-sea
@@ -428,6 +433,11 @@ Commentary: |-
     Originally, I think partly inspired by Plastic Beach, I was kind of interested in an underwater theme, characters like Eridan and Feferi and the sea kingdom thing... like, one of the first ideas I worked on that was Lies With The Sea.
 ---
 Track: Chain Of Prospit
+Additional Names:
+- Name: >-
+    Chain of Prospit
+  Annotation: >-
+    [original Bandcamp release](https://web.archive.org/web/20110603145529/https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido)
 Duration: '4:37'
 URLs:
 - https://bowman.bandcamp.com/track/chain-of-prospit

--- a/album/of-troles-and-chiptumes.yaml
+++ b/album/of-troles-and-chiptumes.yaml
@@ -112,7 +112,7 @@ Art Tags:
 - Nepeta
 - Cats
 Referenced Tracks:
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Olive Rogue
 - Davesprite
 - Catscratch

--- a/album/sburb.yaml
+++ b/album/sburb.yaml
@@ -100,12 +100,14 @@ Additional Files:
 ---
 Section: Sburb
 ---
-Track: The Prelude
+Track: Prelude
+Directory: the-prelude
+Always Reference By Directory: true
 Additional Names:
 - Name: >-
-    Prelude
+    The Prelude
   Annotation: >-
-    [Bandcamp rerelease](https://jamesdever.bandcamp.com/track/prelude)
+    [original release](https://web.archive.org/web/20110717134809/http://homestuck.bandcamp.com/track/the-prelude)
 Contributors:
 - Erik Scheele (performance)
 Duration: '1:43'
@@ -145,11 +147,11 @@ Sheet Music Files:
 Commentary: |-
     <i>James Dever:</i> (composer's notes)
 
-    This song begins with a c minor chord that both resolves [[The Prelude|the last piece]] and immediately sets the mood for this piece. Genesis marks the beginning of the biblical terms as well. The Book of Genesis is the first book of both the Hebrew Bible and Christian Old Testament. It is interpreted as the Chosen People being lead to the Promised Land. Sburb is the pathway that leads the kids into the game that is suppose to eventually grow a new universe. It starts off quietly and builds into a fast paced journey. Genesis also introduces my favorite music technique: hemiolas. The right hand plays a melody in triplets while the left hand harmonizes in eighth notes. This creates a strange rhythm and continues the juxtaposition theme created in [[The Prelude]]'s chords. Continuing the concept of two extremes but together, the song goes into legato, quiet phrases that are immediately followed by staccato, loud phrases.
+    This song begins with a c minor chord that both resolves [[track:the-prelude|the last piece]] and immediately sets the mood for this piece. Genesis marks the beginning of the biblical terms as well. The Book of Genesis is the first book of both the Hebrew Bible and Christian Old Testament. It is interpreted as the Chosen People being lead to the Promised Land. Sburb is the pathway that leads the kids into the game that is suppose to eventually grow a new universe. It starts off quietly and builds into a fast paced journey. Genesis also introduces my favorite music technique: hemiolas. The right hand plays a melody in triplets while the left hand harmonizes in eighth notes. This creates a strange rhythm and continues the juxtaposition theme created in [[track:the-prelude|The Prelude]]'s chords. Continuing the concept of two extremes but together, the song goes into legato, quiet phrases that are immediately followed by staccato, loud phrases.
 
     <i>James Dever:</i> (Bandcamp rerelease)
 
-    [[The Prelude|The previous track]] sets up the resolution that the opening measures provide here. This movement introduces the two against three polyrhythm idea that continues throughout the album as well as a few choice hemiolas. Coming from a percussion background, I find a lot of melodic potential in rhythmic content and this whole suite was a place for me to test that out.
+    [[track:the-prelude|The previous track]] sets up the resolution that the opening measures provide here. This movement introduces the two against three polyrhythm idea that continues throughout the album as well as a few choice hemiolas. Coming from a percussion background, I find a lot of melodic potential in rhythmic content and this whole suite was a place for me to test that out.
 ---
 Track: Eden
 Contributors:
@@ -322,12 +324,12 @@ Commentary: |-
 ---
 Section: Revelations
 ---
-Track: Revelations I
+Track: Revelations, I
 Additional Names:
 - Name: >-
-    Revelations, I
+    Revelations I
   Annotation: >-
-    [Bandcamp rerelease](https://jamesdever.bandcamp.com/track/revelations-i)
+    [original release](https://web.archive.org/web/20110717155046/http://homestuck.bandcamp.com/track/revelations-i)
 Contributors:
 - Erik Scheele (performance)
 Duration: '1:07'
@@ -351,12 +353,12 @@ Commentary: |-
 
     Revelations is a three part finale that is completely centered on the sextuplet dominant/tonic motive introduced earlier in the album. Each movement was more exploration of how I can use the same general accompaniment but completely change the melody.
 ---
-Track: Revelations II
+Track: Revelations, II
 Additional Names:
 - Name: >-
-    Revelations, II
+    Revelations II
   Annotation: >-
-    [Bandcamp rerelease](https://jamesdever.bandcamp.com/track/revelations-ii)
+    [original release](https://web.archive.org/web/20110717134802/http://homestuck.bandcamp.com/track/revelations-ii)
 Contributors:
 - Erik Scheele (performance)
 Duration: '2:41'
@@ -372,12 +374,12 @@ Commentary: |-
 
     Movement II is the process of solving it almost. It's the path to enlightenment; overcoming obstacles and finding yourself along the way is part of the challenge.
 ---
-Track: Revelations III
+Track: Revelations, III
 Additional Names:
 - Name: >-
-    Revelations, III
+    Revelations III
   Annotation: >-
-    [Bandcamp rerelease](https://jamesdever.bandcamp.com/track/revelations-iii)
+    [original release](https://web.archive.org/web/20110717155052/http://homestuck.bandcamp.com/track/revelations-iii)
 Contributors:
 - Erik Scheele (performance)
 Duration: '3:04'

--- a/album/stlap3.yaml
+++ b/album/stlap3.yaml
@@ -469,7 +469,7 @@ Referenced Tracks:
 - Candles and Clockwork
 - Guardian
 - Courser
-- Requiem of Sunshine and Rainbows
+- Requiem Of Sunshine And Rainbows
 - Eternity Served Cold
 - English
 - Crystalanthemums

--- a/album/the-green-box-set-1.yaml
+++ b/album/the-green-box-set-1.yaml
@@ -227,7 +227,7 @@ Cover Artists:
 Art Tags:
 - Nepeta
 Referenced Tracks:
-- Walls Covered in Blood
+- Walls Covered In Blood
 URLs:
 - https://iodbc.bandcamp.com/track/s-nepeta-hunt-unused
 Commentary: |-

--- a/album/theres-no-place-like-home.yaml
+++ b/album/theres-no-place-like-home.yaml
@@ -111,7 +111,7 @@ Referenced Tracks:
 - Crystalanthemums
 - Do You Remem8er Me
 - Knife's Edge
-- Walls Covered in Blood
+- Walls Covered In Blood
 - Ocean Stars
 - Dogfight
 - Iron Knight
@@ -146,7 +146,7 @@ Referenced Tracks:
 - Prospitian Folklore
 - A Taste for Adventure
 - Pumpkin Party in Sea Hitler's Water Apocalypse
-- Lilith in Starlight
+- Lilith In Starlight
 - Violet Prince
 - track:moonsetter
 - Gaia Queen

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -2844,7 +2844,7 @@ Flash: '[S] RISE.'
 Directory: rise-kgtac
 Date: May 22, 2022
 Featured Tracks:
-- Requiem of Sunshine and Rainbows
+- Requiem Of Sunshine And Rainbows
 URLs:
 - https://mspfa.com/?s=27317&p=1642
 - https://www.youtube.com/watch?v=QPYx56konIM
@@ -5069,8 +5069,8 @@ Featured Tracks:
 - Blackest Heart
 - Knife's Edge
 - Trollian Standoff
-- Requiem of Sunshine and Rainbows
-- Lilith in Starlight
+- Requiem Of Sunshine And Rainbows
+- Lilith In Starlight
 - At The Price of Oblivion
 URLs:
 - https://youtu.be/ZmQZLsi7AnM

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -51,12 +51,21 @@ Content: |-
     - added album release photoset to [[album:ulterior-motives]]
     - added Tumblr commentary and listening link from [[artist:toby-fox]] to [[track:valor-toby-fox]] (thanks, Lilith!)
     - added Tumblr commentary from [[artist:malcolm-brown]] to [[track:cheer-up-crabface-its-halloween]] and [[track:flight-of-the-white-wolf]] (thanks, Lilith!)
+    - added names on original releases as additional names for [[track:lies-with-the-sea]] and [[track:chain-of-prospit]], and for newly renamed [[track:the-prelude]], [[track:revelations-i]], [[track:revelations-ii]], and [[track:revelations-iii]] (thanks, Lilith!)
     - moved [[track:thunderhead-loftlocked]] from [[album:more-homestuck-fandom]] to [[album:loftlocked-vol-1]] (thanks, Lilith!)
     <h3>data fixes</h3>
     - fixed [[track:fiduspawn-go]] not referencing [[track:title-screen-pokemon-red-blue]] (thanks, Morris!)
     - fixed [[track:anarchy-gravity-makes-the-flame-rise]] not sampling [[track:nothing-but-the-best]] (thanks, Morris!)
     - fixed [[track:cheer-up-crabface-its-halloween]] not referencing [[track:crustacean]] and [[track:rex-duodecim-angelus]] (thanks, Lilith!)
     - fixed [[track:valor-toby-fox]] not referencing [[track:showtime-original-mix]] (thanks, Lilith!)
+    - fixed some [[group:official]] tracks' names not aligning with Homestuck's Bandcamp (thanks, Lilith!)
+        - fixed [[track:walls-covered-in-blood]] being named "Walls Covered in Blood" (lowercase "in")
+        - fixed [[track:requiem-of-sunshine-and-rainbows]] being named "Requiem of Sunshine and Rainbows" (lowercase "of", "and")
+        - fixed [[track:lilith-in-starlight]] being named "Lilith in Starlight" (lowercase "in")
+    - fixed some [[group:official]] tracks' names not aligning with later releases on composers' personal Bandcamps (thanks, Lilith!)
+        - fixed [[track:the-prelude]] being named "The Prelude"
+        - fixed [[track:revelations-i]], [[track:revelations-ii]], and [[track:revelations-iii]] being named "Revelations I", "Revelations II", and "Revelations III" (no comma)
+        - original names on Homestuck discography (also for [[track:lies-with-the-sea]] and [[track:chain-of-prospit]]) are included as additiional names
     - fixed [[track:cheer-up-crabface-its-halloween]] being named "Cheer up, crabface, it's Halloween!", and added this as an additional name with details in commentary (thanks, Lilith!)
     - added [[tag:bowman]] tag to [[album:gravity-makes-the-flame-rise]] and [[album:ulterior-motives]]
     - fixed spacing in lyrics for [[track:squiddles-the-movie-trailer-the-day-the-unicorns-couldnt-play]]


### PR DESCRIPTION
Replaces the wiki (except for Chain Of Prospit and Lies With The Sea; which, their capitalizations were different on the original Bandcamp release; but Bowman's capitalizations will stay as the main format) capitalizations for

- [x] Lilith in Starlight (Homestuck Vol. 10; Lilith In Starlight on Bandcamp) 
- [x] Walls Covered in Blood (Alternia; Walls Covered in Blood on Bandcamp) 
- [x] Requiem of Sunshine and Rainbows (AlterniaBound; Requiem Of Sunshine And Rainbows on Bandcamp)

**And adds additional titles in Mobius Trip and Hadron Kaleido**:
- [x] Lies With The Sea (Mobius Trip and Hadron Kaleido; Lies with the Sea on original Bandcamp release)
- [x] Chain Of Prospit (Mobius Trip and Hadron Kaleido; Chain of Prospit on original Bandcamp release) 

**Also changes the titles of Sburb to James Dever's 2019 rerelease- the original titles have been moved to additional titles: in particular**:
- [x] The Prelude --> Prelude (directory will be added as well as Always Reference By Directory)
- [x] Revelations I --> Revelations, I
- [x] Revelations II --> Revelations, II
- [x] Revelations III --> Revelations, III

Merge alongside hsmusic/hsmusic-media#80