### PR TITLE
Minor track addition/split: Final Savage Sister, Flandre S.

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -9608,9 +9608,15 @@ Track: U.N. Owen Was Her?
 Artists:
 - Touhou Project
 - ZUN
-Duration: '5:20'
+Duration: '4:09'
 URLs:
-- https://www.youtube.com/watch?v=8jJZA-O_B78
+- https://www.youtube.com/watch?v=ssdcX1vVBTo
+Commentary: |-
+    <i>Lilithtreasure:</i> (wiki editor)
+
+    So the whole deal with the [unofficial full/long version of U.N. Owen Was Her?](https://www.youtube.com/watch?v=8jJZA-O_B78) is that after U.N. Owen Was Her? plays out, it goes straight to [[Final Savage Sister, Flandre S.]].
+
+    To put it shortly, the original in-game track (and the slightly different Dolls in Pseudo Paradise version, by extension) is much shorter than the unofficial full version, and does not contain beatMARIO's Final Savage Sister, Flandre S., in any capacity.
 ---
 Track: Ultimate Koopa
 # JP: クッパ3号
@@ -25372,7 +25378,7 @@ Duration: '2:37'
 URLs:
 - https://www.youtube.com/watch?v=4MKrYxtCLyY
 Referenced Tracks:
-- U.N. Owen Was Her?
+- track:final-savage-sister-flandre-s
 ---
 Track: Final Savage All Voice
 # JP: 最終鬼畜全部声
@@ -25391,6 +25397,21 @@ URLs:
 - https://www.youtube.com/watch?v=Za0kamPfdeE
 Referenced Tracks:
 - track:final-savage-all-voice
+---
+Track: Final Savage Sister, Flandre S.
+# JP: 最終鬼畜妹フランドール・Ｓ
+# Official release:
+#   Touhou Strike
+#   東方ストライク
+# Reference:
+#   https://vgmdb.net/album/4280
+Artists:
+- beatMARIO
+Duration: '3:26'
+URLs:
+- https://www.youtube.com/watch?v=R_lYJpMqsiQ
+Referenced Tracks:
+- track:un-owen-was-her
 ---
 Track: Fireflies
 Directory: fireflies-owl-city

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -9614,9 +9614,9 @@ URLs:
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor)
 
-    So the whole deal with the [unofficial full/long version](https://www.youtube.com/watch?v=8jJZA-O_B78) is that it's just U.N. Owen Was Her? and beatMARIO's [[Final Savage Sister, Flandre S.]] slapped together as a medley, one after the other, and the description doesn't even mention this.
+    So the whole deal with the [unofficial full/long version](https://www.youtube.com/watch?v=8jJZA-O_B78) is that it's just U.N. Owen Was Her? and beatMARIO's [[Final Savage Sister, Flandre S.]] slapped together as a medley, one after the other, and the YouTube description doesn't even mention this.
 
-    The original in-game track (and the slightly different Dolls in Pseudo Paradise version, by extension) is much shorter than the unofficial full version medley, and does not contain Final Savage Sister, Flandre S. in any capacity.
+    The original in-game track (and the slightly different [Dolls in Pseudo Paradise](https://en.touhouwiki.net/wiki/Dolls_in_Pseudo_Paradise) version, by extension) is much shorter than the unofficial full version medley, and does not contain Final Savage Sister, Flandre S. in any capacity.
 ---
 Track: Ultimate Koopa
 # JP: クッパ3号

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -9614,9 +9614,9 @@ URLs:
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor)
 
-    So the whole deal with the [unofficial full/long version of U.N. Owen Was Her?](https://www.youtube.com/watch?v=8jJZA-O_B78) is that after U.N. Owen Was Her? plays out, it goes straight to [[Final Savage Sister, Flandre S.]].
+    So the whole deal with the [unofficial full/long version](https://www.youtube.com/watch?v=8jJZA-O_B78) is that it's just U.N. Owen Was Her? and beatMARIO's [[Final Savage Sister, Flandre S.]] slapped together as a medley, one after the other, and the description doesn't even mention this.
 
-    To put it shortly, the original in-game track (and the slightly different Dolls in Pseudo Paradise version, by extension) is much shorter than the unofficial full version, and does not contain beatMARIO's Final Savage Sister, Flandre S., in any capacity.
+    The original in-game track (and the slightly different Dolls in Pseudo Paradise version, by extension) is much shorter than the unofficial full version medley, and does not contain Final Savage Sister, Flandre S. in any capacity.
 ---
 Track: Ultimate Koopa
 # JP: クッパ3号

--- a/album/v8lume.yaml
+++ b/album/v8lume.yaml
@@ -1662,7 +1662,7 @@ Referenced Tracks:
 - Crank That
 - Michael Bowman Remix
 - track:final-savage-all-voice-ska-punk-flavor
-- U.N. Owen Was Her?
+- track:final-savage-sister-flandre-s
 - This Saturnine Existence
 - track:moshi-moshi
 - First Contact

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -55,9 +55,11 @@ Content: |-
     - moved [[track:thunderhead-loftlocked]] from [[album:more-homestuck-fandom]] to [[album:loftlocked-vol-1]] (thanks, Lilith!)
     <h3>data fixes</h3>
     - fixed [[track:fiduspawn-go]] not referencing [[track:title-screen-pokemon-red-blue]] (thanks, Morris!)
+    - fixed [[track:arise-canmt]] referencing [[track:un-owen-was-her]] instead of [[track:final-savage-sister-flandre-s]] (thanks, Lilith!)
     - fixed [[track:anarchy-gravity-makes-the-flame-rise]] not sampling [[track:nothing-but-the-best]] (thanks, Morris!)
     - fixed [[track:cheer-up-crabface-its-halloween]] not referencing [[track:crustacean]] and [[track:rex-duodecim-angelus]] (thanks, Lilith!)
     - fixed [[track:valor-toby-fox]] not referencing [[track:showtime-original-mix]] (thanks, Lilith!)
+    - fixed [[track:final-savage-all-voice]] ([[artist:beat-throat-mario]]) referencing [[track:un-owen-was-her]] instead of [[track:final-savage-sister-flandre-s]] (thanks, Lilith!)
     - fixed some [[group:official]] tracks' names not aligning with Homestuck's Bandcamp (thanks, Lilith!)
         - fixed [[track:walls-covered-in-blood]] being named "Walls Covered in Blood" (lowercase "in")
         - fixed [[track:requiem-of-sunshine-and-rainbows]] being named "Requiem of Sunshine and Rainbows" (lowercase "of", "and")
@@ -67,6 +69,7 @@ Content: |-
         - fixed [[track:revelations-i]], [[track:revelations-ii]], and [[track:revelations-iii]] being named "Revelations I", "Revelations II", and "Revelations III" (no comma)
         - original names on Homestuck discography (also for [[track:lies-with-the-sea]] and [[track:chain-of-prospit]]) are included as additiional names
     - fixed [[track:cheer-up-crabface-its-halloween]] being named "Cheer up, crabface, it's Halloween!", and added this as an additional name with details in commentary (thanks, Lilith!)
+    - fixed YouTube listening link for [[track:un-owen-was-her]] (was to [unofficial "full version"](https://www.youtube.com/watch?v=8jJZA-O_B78); thanks, Lilith!)
     - added [[tag:bowman]] tag to [[album:gravity-makes-the-flame-rise]] and [[album:ulterior-motives]]
     - fixed spacing in lyrics for [[track:squiddles-the-movie-trailer-the-day-the-unicorns-couldnt-play]]
     <h3>directory changes</h3>


### PR DESCRIPTION
Split off from the U.N. Owen Was Her? entry is **Final Savage Sister, Flandre S.** by beatMARIO, the other component in the unofficial "long version" of U.N. Owen Was Her?, which, in-game, as well as in Dolls in Pseudo Paradise and Touhou 17.5; is just U.N. Owen Was Her? and nothing more.

Doesn't really affect much except for
V8lume's Arise (U.N. Owen Was Her? reference changed to Final Savage Sister, Flandre S.) and references-beyond-homestuck's Final Savage All Voice (by Beat Throat Mario; also changed to reference Final Savage Sister, Flandre S.)

Said "long version" is now contained in the wiki editor commentary as opposed to being the main URL; which now, the main URL is to just U.N. Owen Was Her? and nothing more.