### PR TITLE
Artist update: Em Essex (formerly Emma Essex)

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -37112,7 +37112,7 @@ Lyrics: |-
 ---
 Track: Rubber Band
 Artists:
-- Emma Essex
+- Em Essex
 - Jackal Queenston
 Duration: '3:34'
 Lyrics: |-
@@ -37521,7 +37521,7 @@ Referenced Tracks:
 Track: SELF-COFFINIZING (prototype ver.)
 Duration: 3:05
 Artists:
-- Emma Essex
+- Em Essex
 - KITCALIBER
 URLs:
 - https://lapfox.bandcamp.com/track/self-coffinizing-prototype-ver
@@ -44063,7 +44063,7 @@ Lyrics: |-
 ---
 Track: White Nuxxle Driver
 Artists:
-- Emma Essex
+- Em Essex
 - Rotteen
 Duration: '2:27'
 URLs:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -37112,7 +37112,7 @@ Lyrics: |-
 ---
 Track: Rubber Band
 Artists:
-- Em Essex
+- msx
 - Jackal Queenston
 Duration: '3:34'
 Lyrics: |-
@@ -37521,7 +37521,7 @@ Referenced Tracks:
 Track: SELF-COFFINIZING (prototype ver.)
 Duration: 3:05
 Artists:
-- Em Essex
+- msx
 - KITCALIBER
 URLs:
 - https://lapfox.bandcamp.com/track/self-coffinizing-prototype-ver
@@ -44063,7 +44063,7 @@ Lyrics: |-
 ---
 Track: White Nuxxle Driver
 Artists:
-- Em Essex
+- msx
 - Rotteen
 Duration: '2:27'
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -3516,16 +3516,6 @@ Aliases:
 - Marshall Bruce Mathers III
 - Slim Shady
 ---
-Artist: Em Essex
-Aliases:
-- Emma Essex
-Context Notes: |-
-    Releases music under a variety of names, including on this wiki: [[artist:jackal-queenston]], [[artist:kitcaliber]], [[artist:rotteen]].
-URLs:
-- https://msx.horse
-Dead URLs:
-- https://twitter.com/heckscaper
----
 Artist: Emma Glaze
 URLs:
 - https://bedsafely.tumblr.com/
@@ -7531,6 +7521,18 @@ Aliases:
 Artist: Ms. Roq
 Aliases:
 - Racquel Weaver
+---
+Artist: msx
+Aliases:
+- em essex
+- Emma Essex
+Context Notes: |-
+    Releases music under a variety of names, including on this wiki: [[artist:jackal-queenston]], [[artist:kitcaliber]], [[artist:rotteen]].
+URLs:
+- https://lapfox.bandcamp.com
+- https://msx.horse
+Dead URLs:
+- https://twitter.com/heckscaper
 ---
 Artist: MtH
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -3516,9 +3516,13 @@ Aliases:
 - Marshall Bruce Mathers III
 - Slim Shady
 ---
-Artist: Emma Essex
+Artist: Em Essex
+Aliases:
+- Emma Essex
 Context Notes: |-
     Releases music under a variety of names, including on this wiki: [[artist:jackal-queenston]], [[artist:kitcaliber]], [[artist:rotteen]].
+URLs:
+- https://msx.horse
 Dead URLs:
 - https://twitter.com/heckscaper
 ---
@@ -4933,7 +4937,7 @@ Artist: Jack Lenz
 ---
 Artist: Jackal Queenston
 Context Notes: |-
-    Alias of [[artist:emma-essex]].
+    Alias of [[artist:em-essex]].
 ---
 Artist: Jackaxed
 URLs:
@@ -5571,7 +5575,7 @@ Artist: Kikuo
 ---
 Artist: KITCALIBER
 Context Notes: |-
-    Alias of [[artist:emma-essex]].
+    Alias of [[artist:em-essex]].
 ---
 Artist: Kadi Fedoruk
 URLs:
@@ -9332,7 +9336,7 @@ Artist: Ross Bagdasarian
 ---
 Artist: Rotteen
 Context Notes: |-
-    Alias of [[artist:emma-essex]].
+    Alias of [[artist:em-essex]].
 ---
 Artist: RowBird
 URLs:


### PR DESCRIPTION
Drops the second M and singular A from Em's name; and everything aside from the changelog has been changed to reflect this.

Also added their personal website to URLs.