### PR TITLE
Artist merging of Solarbear with Twirlin' Curtis, and Rachel Lundin with Rachel Lake

### DIFF
--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -673,12 +673,18 @@ Art Tags:
 - Ruined Earth
 - Can Town
 Commentary: |-
-    <i>Twirlin' Curtis:</i> (composer, [Twitter](https://x.com/TwirlinCurtis/status/1779569011820204306), 4/13/2024)
+    <i>Twirlin' Curtis:</i> (composer, [Twitter](https://x.com/TwirlinCurtis/status/1779209373887103050), 4/13/2024)
     Happy Homestuck Day.
 
     One of the Homestuck albums I wrote music for is apparently Music of Asia. Geography is very mysterious indeed.
 
     <img src="media/misc/coloUrs-and-mayhem-universe-b-music-of-asia.png" width="322">
+
+    <i>Twirlin' Curtis:</i> (composer, [Twitter](https://x.com/TwirlinCurtis/status/1779219653723611218), 4/13/2024)
+
+    > What!?!??! Me and my homestuck buddies had you blasting on a car stereo!
+
+    yea yea yea!!! I used to make chiptune under the name Solarbear!!
 
     <i>Twirlin' Curtis:</i> (composer, [Twitter](https://x.com/TwirlinCurtis/status/1779569011820204306), 4/14/2024)
 

--- a/album/coloUrs-and-mayhem-universe-b.yaml
+++ b/album/coloUrs-and-mayhem-universe-b.yaml
@@ -71,7 +71,7 @@ Commentary: |-
     [[artist:elliot-colp|Elliot "TheLastBanana" Colp]]<br>
     [[artist:will-kommor]]<br>
     [[artist:kris-flacke|Kris "Astartus" Flacke]]<br>
-    [[artist:solarbear]]<br>
+    [[artist:twirlin-curtis|Solarbear]]<br>
     [[artist:marcy-nabors|Marcy "Shadolith" Nabors]]<br>
     [[artist:haunter]]<br>
     [[artist:pixelseph|viaSatellite]] & [[artist:paradiddlesjosh|infiniteKnife]]<br>
@@ -660,7 +660,7 @@ MIDI Project Files:
 ---
 Track: 'WV: Become the Mayor of Cans'
 Artists:
-- Solarbear
+- Twirlin' Curtis
 Duration: '4:00'
 URLs:
 - https://homestuck.bandcamp.com/track/wv-become-the-mayor-of-cans-2
@@ -673,6 +673,19 @@ Art Tags:
 - Ruined Earth
 - Can Town
 Commentary: |-
+    <i>Twirlin' Curtis:</i> (composer, [Twitter](https://x.com/TwirlinCurtis/status/1779569011820204306), 4/13/2024)
+    Happy Homestuck Day.
+
+    One of the Homestuck albums I wrote music for is apparently Music of Asia. Geography is very mysterious indeed.
+
+    <img src="media/misc/coloUrs-and-mayhem-universe-b-music-of-asia.png" width="322">
+
+    <i>Twirlin' Curtis:</i> (composer, [Twitter](https://x.com/TwirlinCurtis/status/1779569011820204306), 4/14/2024)
+
+    > HOLY SHIT???
+
+    YEA! I wrote a tune under the name Solarbear for that album!
+
     <i>Derples:</i> (track artist, [Tumblr](https://melongifts.tumblr.com/post/21013986036/hey-guys))
 
     <img src="media/misc/wv-become-the-mayor-of-cans-bonus.jpg" width="171" height="103" pixelate inline alt="Fuck you radiation.png">

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -124,7 +124,7 @@ Commentary: |-
     [[artist:shan-murphy]]<br>
     [[artist:mika-b]]<br>
     [[artist:sera-b]]<br>
-    [[artist:rachel-lundin]]<br>
+    [[artist:rachel-lake|Rachel Lundin]]<br>
     [[artist:seth-massey]]<br>
     [[artist:nico-j-dolloso]]<br>
     [[artist:david-litt]]<br>
@@ -513,7 +513,7 @@ URLs:
 - https://homestuck.bandcamp.com/track/aggrievocation-2
 - https://youtu.be/JB3kKp7jRag
 Cover Artists:
-- Rachel Lundin
+- Rachel Lake
 Art Tags:
 - Rose
 Referenced Tracks:
@@ -523,7 +523,7 @@ Commentary: |-
 
     While [[Harlequin|"Harlequin"]] was the first piece of mine to appear in Homestuck, the first piece I actually wrote for it was [[Aggrieve|"Aggrieve"]], and so I felt it was only fitting to make another mix of it for the final album. Plus it gave me an excuse to try writing it in a metal style! I'm not sure it could still be considered Rose's "official theme" anymore (not after the mountain of excellent music the team's written for her over the years), but I still like to think of it that way.
 
-    <i>Rachel Lundin:</i> (track artist)
+    <i>Rachel Lake:</i> (track artist)
 
     Just, put, like, "It was cool to work on this," I don't know!
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -11522,10 +11522,9 @@ Aliases:
 - Solarbear
 URLs:
 - https://twitter.com/twirlincurtis
-- https://solarbearchiptunes.bandcamp.com/ #previous links
-- https://soundcloud.com/solarbearchiptune #under
-- https://www.youtube.com/user/solarbearchiptune #solarbear
-#wasn't sure how to do this, cause like... well.. these links are still accessible, just dormant
+- https://solarbearchiptunes.bandcamp.com/
+- https://soundcloud.com/solarbearchiptune
+- https://www.youtube.com/user/solarbearchiptune
 ---
 Artist: Twix Stix
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -8827,8 +8827,12 @@ URLs:
 - https://twitter.com/Rabooski1
 ---
 Artist: Rachel Lake
+Aliases:
+- Rachel Lundin
 URLs:
 - https://twitter.com/rachelklake
+Dead URLs:
+- http://maybegirl.com/
 ---
 Artist: RaChoTamer
 URLs:
@@ -8836,11 +8840,6 @@ URLs:
 - https://twitter.com/rachotamer
 ---
 Artist: Rachel Jost
----
-Artist: Rachel Lundin
-URLs:
-- http://maybegirl.com/
-- https://twitter.com/rachelklake
 ---
 Artist: Rachel Rose Mitchell
 URLs:
@@ -10297,12 +10296,6 @@ Dead URLs:
 ---
 Artist: Sol Marcus
 ---
-Artist: Solarbear
-URLs:
-- https://solarbearchiptunes.bandcamp.com/
-- https://soundcloud.com/solarbearchiptune
-- https://www.youtube.com/user/solarbearchiptune
----
 Artist: Solatorobo
 ---
 Artist: Solatrus
@@ -11525,8 +11518,14 @@ URLs:
 - https://twitter.com/lian_qa
 ---
 Artist: Twirlin' Curtis
+Aliases:
+- Solarbear
 URLs:
 - https://twitter.com/twirlincurtis
+- https://solarbearchiptunes.bandcamp.com/ #previous links
+- https://soundcloud.com/solarbearchiptune #under
+- https://www.youtube.com/user/solarbearchiptune #solarbear
+#wasn't sure how to do this, cause like... well.. these links are still accessible, just dormant
 ---
 Artist: Twix Stix
 URLs:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -49,6 +49,7 @@ Content: |-
     - added commentary blurbs from Bandcamp and YouTube, as well as additional names mostly from YouTube, across [[album:the-funk-mclovin-homestuck-experience]], [[album:class-act]], and [[album:class-act-b-side]]
     - added album release commentary to [[album:gravity-makes-the-flame-rise]] and [[album:ulterior-motives]]
     - added album release photoset to [[album:ulterior-motives]]
+    - added Twitter commentary from [[artist:twirlin-curtis]] to [[track:wv-become-the-mayor-of-cans]] (thanks, Makin, Lilith!)
     - added SoundCloud commentary from [[artist:difarem]], additional name, and listening link to [[track:chronic-infection]] (thanks, Lilith!)
     - added Tumblr commentary from [[artist:toby-fox]] and listening link to [[track:valor-toby-fox]] (thanks, Lilith!)
     - added Tumblr commentary from [[artist:malcolm-brown]] and listening link to [[track:cheer-up-crabface-its-halloween]] and [[track:flight-of-the-white-wolf]] (thanks, Lilith!)
@@ -69,6 +70,8 @@ Content: |-
     - fixed [[track:valor-toby-fox]] not referencing [[track:showtime-original-mix]] (thanks, Lilith!)
     - fixed [[track:final-savage-all-voice]] ([[artist:beat-throat-mario]]) referencing [[track:un-owen-was-her]] instead of [[track:final-savage-sister-flandre-s]] (thanks, Lilith!)
     - fixed [[track:hankage-fantazumu-2]] not crediting [[artist:difarem]] - nor anyone at all! - as artist (thanks, Lilith!)
+    - fixed [[artist:rachel-lake]] having some credits under another name (thanks, Rainy, Lilith!)
+    - fixed [[artist:twirlin-curtis]] having some credits under another name (thanks, Makin, Lilith!)
     - fixed some [[group:official]] tracks' names not aligning with Homestuck's Bandcamp (thanks, Lilith!)
         - fixed [[track:walls-covered-in-blood]] being named "Walls Covered in Blood" (lowercase "in")
         - fixed [[track:requiem-of-sunshine-and-rainbows]] being named "Requiem of Sunshine and Rainbows" (lowercase "of", "and")


### PR DESCRIPTION
Merges artist entries of Solarbear, and Rachel Lundin, with Twirlin' Curtis and Rachel Lake respectively.

per https://discord.com/channels/749042497610842152/935007764042874931/1241781053216002059 (rachel lundin -> rachel lake, placed dead maybegirl.com site in dead URLs)
and https://discord.com/channels/749042497610842152/935007764042874931/1240696386157019136 (makin found solarbear; it's twirlin' curtis from the homestuck 2 album; added citation from Twitter on Twirlin' Curtis and Solarbear being one and the same on WV: Become the Mayor of Cans; including replies; transferred solarbear-era urls to twirlin' curtis)

and of course, adjusted coloUrs and mayhem: universe b and Homestuck Vol. 10 accordingly

merge with https://github.com/hsmusic/hsmusic-media/pull/81
