### PR TITLE
Add canmt artwork references up to vol s*x

### DIFF
--- a/album/a-shade-of-blue.yaml
+++ b/album/a-shade-of-blue.yaml
@@ -12,6 +12,8 @@ Default Track Cover Artists:
 - jakkyr
 Cover Art File Extension: png
 Track Art File Extension: png
+Referenced Album Artworks:
+- Medium (composition)
 Color: '#2c8ccc'
 Groups:
 - Cool and New Music Team
@@ -60,6 +62,8 @@ URLs:
 - https://www.youtube.com/watch?v=b9g3x7YPsXs
 Art Tags:
 - Dave's bro
+Referenced Track Artworks:
+- Beatdown Round 2 (composition)
 Referenced Tracks:
 - Beatdown (Strider Style)
 ---

--- a/album/cool-and-new-homestuck.yaml
+++ b/album/cool-and-new-homestuck.yaml
@@ -341,6 +341,8 @@ URLs:
 - https://www.youtube.com/watch?v=7RFySwRO-aY
 Art Tags:
 - Jhon
+Referenced Track Artworks:
+- Harleboss (composition)
 Referenced Tracks:
 - Harleboss
 - Spider-Man
@@ -368,6 +370,8 @@ Art Tags:
 - Dave
 - Dave's bro
 - Earth
+Referenced Track Artworks:
+- Smackdown (composition)
 Referenced Tracks:
 - Smackdown
 Commentary: |-
@@ -567,6 +571,8 @@ Art Tags:
 - Dave
 - Dave's bro
 - Earth
+Referenced Track Artworks:
+- Smackdown (composition)
 Referenced Tracks:
 - Versus
 Commentary: |-
@@ -607,6 +613,8 @@ URLs:
 - https://www.youtube.com/watch?v=NeVD6cDJJEA
 Art Tags:
 - Bowman
+Referenced Track Artworks:
+- Three in the Morning (minor edit)
 Referenced Tracks:
 - Three in the Morning (4 1/3 Hours Late Remix)
 - Michael Bowman Remix
@@ -646,6 +654,8 @@ URLs:
 Art Tags:
 - Rose
 - LoLaR
+Referenced Track Artworks:
+- Endless Climb (minor edit)
 Referenced Tracks:
 - Endless Climb
 ---

--- a/album/cool-and-new-volume-2.yaml
+++ b/album/cool-and-new-volume-2.yaml
@@ -11,6 +11,8 @@ Art Tags:
 - Jhon
 - Hecka Jef
 - Dabe
+Referenced Album Artworks:
+- Strife! (composition)
 Cover Art File Extension: png
 Track Art File Extension: png
 Color: '#fa6006'
@@ -106,6 +108,8 @@ URLs:
 Art Tags:
 - Dirk
 - Earth
+Referenced Track Artworks:
+- Moonsetter (edit)
 Referenced Tracks:
 - track:moonsetter
 - RollerCoaster Tycoon Theme
@@ -458,6 +462,8 @@ URLs:
 Art Tags:
 - Dave
 - Bowman
+Referenced Track Artworks:
+- Unite Synchronization (minor edit)
 Referenced Tracks:
 - Unite Synchronization
 - track:synchronize-hush
@@ -769,6 +775,8 @@ Artists:
 - ostrichlittledungeon
 Cover Artists:
 - Hadron
+Referenced Track Artworks:
+- Quantum Breakdown (minor edit)
 Duration: '03:20'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/quantum-reversal
@@ -805,6 +813,8 @@ Art Tags:
 - LoHaC
 - LoFaF
 - Battlefield
+Referenced Album Artworks:
+- Homestuck Vol. 8 (minor edit)
 Referenced Tracks:
 - Cascade (Beta)
 - Bowman's Credit Score
@@ -882,6 +892,8 @@ URLs:
 Art Tags:
 - Dirk
 - Earth
+Referenced Track Artworks:
+- Moonsetter (edit)
 Referenced Tracks:
 - track:moonsetter
 ---
@@ -985,6 +997,9 @@ Artists:
 - Minish
 Cover Artists:
 - Minish
+Referenced Track Artworks:
+- References: You Killed My Father (Prepare To Die) 
+  Annotation: composition
 Duration: '04:22'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/you-killed-john-santa-prepare-to-die
@@ -1224,6 +1239,8 @@ Art Tags:
 - Jhon
 - Rose
 - Denizens
+Referenced Track Artworks:
+- The Will to Fight Further [Denizen Strife] (composition)
 Referenced Tracks:
 - The Will to Fight (Original Mix) [Denizen Strife]
 - Fighting Spirit

--- a/album/cool-and-new-volume-ii.yaml
+++ b/album/cool-and-new-volume-ii.yaml
@@ -33,6 +33,8 @@ Art Tags:
 - Germy
 - Lil Cal
 - Horses
+Referenced Album Artworks:
+- album:coloUrs-and-mayhem-universe-a (composition)
 Cover Art File Extension: png
 Track Art File Extension: png
 Color: '#ff8a84'
@@ -230,6 +232,8 @@ Art Tags:
 - Dave's bro
 - Earth
 - 'cw: racial slur'
+Referenced Track Artworks:
+- Beatdown DX (minor edit)
 Referenced Tracks:
 - Beatdown DX
 ---
@@ -446,6 +450,8 @@ URLs:
 - https://www.youtube.com/watch?v=-KpsUrsd8G0
 Art Tags:
 - Sollux
+Referenced Track Artworks:
+- The La2t Frontiier (minor edit)
 Referenced Tracks:
 - The La2t Frontiier
 Sampled Tracks:
@@ -676,6 +682,8 @@ URLs:
 Art Tags:
 - Vriska
 - Aradia
+Referenced Track Artworks:
+- Crystalmethequins (minor edit)
 Referenced Tracks:
 - Crystalmethequins
 Sampled Tracks:
@@ -708,6 +716,8 @@ URLs:
 Art Tags:
 - Vriska
 - Genesis Frog
+Referenced Track Artworks:
+- Killed by BR8K Spider!!!!!!!! (edit)
 Referenced Tracks:
 - Rex English
 - Umbral Ultimatum
@@ -733,8 +743,10 @@ Art Tags:
 - Swet Bro
 - 'cw: corpse'
 - 'cw: blood'
+Referenced Track Artworks:
+- Moonsetter (edit)
 Referenced Tracks:
-- track:moonsetter
+- Moonsetter
 ---
 Track: Conflict?
 Directory: conflict-question-mark
@@ -787,6 +799,8 @@ Art Tags:
 - Meteor
 - Earth
 - Ruined Earth
+Referenced Track Artworks:
+- 25x SHOWDOWN COMBO (minor edit)
 ---
 Track: Midnightcore Crew
 Artists:
@@ -860,6 +874,8 @@ URLs:
 - https://www.youtube.com/watch?v=HLZL5RNTeNk
 Art Tags:
 - Bowman
+Referenced Track Artworks:
+- Brodyquest (composition)
 Referenced Tracks:
 - Brodyquest
 - Bowman's Credit Score
@@ -1146,6 +1162,8 @@ URLs:
 - https://www.youtube.com/watch?v=d2S3SaHdjpo
 Art Tags:
 - Rose
+Referenced Track Artworks:
+- Sburban Jungle (minor edit)
 Referenced Tracks:
 - Penumbra Phantasm
 - track:MeGaLoVania
@@ -1416,6 +1434,8 @@ URLs:
 - https://www.youtube.com/watch?v=9YpJFhWxl2s
 Art Tags:
 - Karkat
+Referenced Track Artworks:
+- HEY MAN VOLUME 10 MAN HEY CHECK IT OUT (minor edit)
 Referenced Tracks:
 - Karkat's Theme
 ---

--- a/album/cool-and-new-volume-s-x.yaml
+++ b/album/cool-and-new-volume-s-x.yaml
@@ -11,6 +11,8 @@ Art Tags:
 - Jhon
 - Rose
 - Frogs
+Referenced Album Artworks:
+- album:homestuck-vol-6 (composition)
 Track Art File Extension: png
 Banner Artists:
 - miraculousAvantgarde
@@ -379,6 +381,8 @@ Cover Artists:
 Art Tags:
 - Bowman
 - Toby Fox
+Referenced Track Artworks:
+- Dord Waltz (edit)
 Duration: '1:42'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/derp-waltz
@@ -473,6 +477,8 @@ Cover Artists:
 Art Tags:
 - Bowman
 - 'cw: blood'
+Referenced Track Artworks:
+- Sarabande (edit)
 Duration: '2:13'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/sarabande-canon-edit
@@ -870,6 +876,8 @@ Cover Artists:
 - artist:avocado-canmt
 Art Tags:
 - Ruined Earth
+Referenced Track Artworks:
+- Explore (composition)
 Duration: '0:56'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/the-maymay-sonb
@@ -919,6 +927,8 @@ Cover Artists:
 - XenoZane
 Art Tags:
 - Karkat
+Referenced Track Artworks:
+- Iron Knight (edit)
 Duration: '4:07'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/iran-knight-meme-dumpverizon
@@ -1059,6 +1069,8 @@ Cover Art File Extension: jpg
 Art Tags:
 - Rose
 - Bowman
+Referenced Track Artworks:
+- Afraid of the Darko (minor edit)
 Duration: '2:54'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/afraid-of-the-spaghettio
@@ -1271,6 +1283,10 @@ Art Tags:
 - Jade
 - Squiddles
 - Skaia
+Referenced Album Artworks:
+- Homestuck Vol. 5 (minor edit)
+Referenced Track Artworks:
+- Moonsetter (minor edit)
 Duration: '1:45'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/monsoonsetter
@@ -1397,6 +1413,8 @@ Cover Artists:
 - jakkyr
 Art Tags:
 - MSPA Reader
+Referenced Track Artworks:
+- Snow halation (minor edit)
 Duration: '2:32'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/grievers-last-stand
@@ -1564,6 +1582,8 @@ Art Tags:
 - Dabe
 - Dadd
 - Earth
+Referenced Track Artworks:
+- Moonsetter (composition)
 Duration: '3:21'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/moonforgiver
@@ -1790,6 +1810,8 @@ Cover Artists:
 Art Tags:
 - Squiddles
 - Skaia
+Referenced Album Artworks:
+- Homestuck Vol. 5 (minor edit)
 Duration: '2:23'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/not-a-beefucker
@@ -1873,6 +1895,8 @@ Cover Artists:
 - artist:avocado-canmt
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (edit)
 Duration: '0:48'
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/doctor-chan

--- a/album/cool-and-new-volume-v.yaml
+++ b/album/cool-and-new-volume-v.yaml
@@ -132,6 +132,8 @@ URLs:
 - https://www.youtube.com/watch?v=PwNDAyxn4sg
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 Sampled Tracks:
@@ -149,6 +151,8 @@ URLs:
 - https://www.youtube.com/watch?v=oFaQwfcuRc8
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor Who Theme
 Commentary: |-
@@ -247,6 +251,9 @@ Art Tags:
 - Dadd
 - Femorafreack
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
+- Snow halation (minor edit)
 Referenced Tracks:
 - Doctor
 - Snow halation
@@ -454,6 +461,8 @@ URLs:
 - https://www.youtube.com/watch?v=2IyFaWoqVno
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - track:doctor-remix
 Commentary: |-
@@ -488,6 +497,8 @@ URLs:
 - https://www.youtube.com/watch?v=6eKtdBmk5ls
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 Commentary: |-
@@ -511,6 +522,8 @@ URLs:
 Art Tags:
 - Jhon
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - I Am the Doctor
 - Doctor
@@ -605,6 +618,8 @@ URLs:
 Art Tags:
 - Dave
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor Remix Remix
 Commentary: |-
@@ -726,6 +741,8 @@ URLs:
 Art Tags:
 - John
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 - Showtime (Original Mix)
@@ -807,6 +824,8 @@ URLs:
 - https://www.youtube.com/watch?v=P4y-FacJgwY
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 Sampled Tracks:
@@ -878,6 +897,8 @@ URLs:
 Art Tags:
 - LoWaS
 - Toby Fox
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 Sampled Tracks:
@@ -981,6 +1002,8 @@ URLs:
 - https://www.youtube.com/watch?v=yEW-Rq-HgSo
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 - CORE
@@ -1091,6 +1114,8 @@ URLs:
 - https://www.youtube.com/watch?v=w-HgPNqCq3k
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (composition)
 Referenced Tracks:
 - Savior of the Waking World
 ---
@@ -1473,6 +1498,8 @@ URLs:
 - https://www.youtube.com/watch?v=-GUi5VXeGNE
 Art Tags:
 - LoWaS
+Referenced Track Artworks:
+- Doctor (minor edit)
 Referenced Tracks:
 - Doctor
 Commentary: |-

--- a/album/cool-and-new-voulem1.yaml
+++ b/album/cool-and-new-voulem1.yaml
@@ -33,6 +33,8 @@ Art Tags:
 - Beq
 - Squiddles
 - Skaia
+Referenced Album Artworks:
+- Homestuck Vol. 5 (composition)
 Additional Files:
 - Title: Bandcamp Banner
   Files:
@@ -117,6 +119,8 @@ Art Tags:
 - Jhon
 - LoWaS
 - 'cw: blood (abstract)'
+Referenced Track Artworks:
+- Pipeorgankind (composition)
 Referenced Tracks:
 - Showtime (Piano Refrain)
 - track:its-showtime
@@ -133,6 +137,8 @@ URLs:
 - https://www.youtube.com/watch?v=mo2fTp6sfxU
 Art Tags:
 - Ruined Earth
+Referenced Track Artworks:
+- Explore (edit)
 Referenced Tracks:
 - Explore
 - Space Jam
@@ -197,6 +203,8 @@ Sampled Tracks:
 Art Tags:
 - Bowman
 - Stutzman
+Referenced Album Artworks:
+- The Felt (edit)
 Lyrics: |-
     (My name is Constable "Meat Cubes" Houston, I will eat five BIG FUCKING SHIT-FILLED ADULT hat stores in one humdrum summer day, and then my crippling addiction to pornography will be buried alive.)
 
@@ -375,6 +383,8 @@ Art Tags:
 - Germy
 - Earth
 - 'cw: decapitation (abstract)'
+Referenced Track Artworks:
+- Moonsetter (edit)
 ---
 Track: 'JHON: RICE'
 Duration: '1:28'
@@ -858,6 +868,8 @@ Cover Artists:
 - Zoey
 Art Tags:
 - Germy
+Referenced Track Artworks:
+- Sburban Countdown (edit)
 URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/suburbon-contdon
 - https://www.youtube.com/watch?v=G2e80WRHl4Y
@@ -1073,6 +1085,8 @@ Art Tags:
 - Jake
 - Consorts
 - Earth
+Referenced Album Artworks:
+- Homestuck Vol. 10 (edit)
 Commentary: |-
     <i>Niklink:</i>
     I- ok. I can explain, okay?
@@ -1150,6 +1164,8 @@ Art Tags:
 - Jhon
 - Dabe
 - Skaia
+Referenced Track Artworks:
+- Beatdown Round 2 (composition)
 ---
 Track: Tycoon
 Directory: tycoon-canmt
@@ -1438,6 +1454,8 @@ Art Tags:
 - Rose
 - Dabe
 - Jaed
+Referenced Track Artworks:
+- Fighting Spirit (composition)
 ---
 Track: go down (Fanon Cut)
 Duration: '2:28'

--- a/album/of-troles-and-chiptumes.yaml
+++ b/album/of-troles-and-chiptumes.yaml
@@ -12,6 +12,8 @@ Art Tags:
 - Kraket
 - Terexi
 - Alternia
+Referenced Album Artworks:
+- Alternia (composition)
 Cover Art File Extension: png
 Track Art File Extension: png
 Color: '#cc44ff'


### PR DESCRIPTION
Adds the track/album art references in https://github.com/hsmusic/hsmusic-data/issues/571, excluding flashes, panels, and albums that are not in the wiki.