### PR TITLE
Add closely linked artists

### DIFF
--- a/artists.yaml
+++ b/artists.yaml
@@ -2306,7 +2306,7 @@ Artist: Collector
 Artist: Cool and New Music Team
 ---
 Artist: Cool and New Web Comic
-Context Notes: >-
+Context Notes: |-
     For crediting visual elements that are lifted directly from Cool and New Web Comic. Most notably, the track art for some latter CANMT tracks are simply screenshots of the web comic.
 ---
 Artist: Coolio
@@ -2402,8 +2402,6 @@ Artist: Cowboy Bebop
 Artist: Cozmia
 Aliases:
 - Cosmia
-Context Notes: |-
-    Alias of [[group:cristata]].
 URLs:
 - https://cristata.bandcamp.com/
 ---
@@ -3319,8 +3317,6 @@ URLs:
 - https://twitter.com/DustinAjar
 ---
 Artist: Dvojka
-Context Notes: |-
-    One-man band; alias of [[artist:xszelor]].
 URLs:
 - https://dvojka.bandcamp.com
 ---
@@ -4028,8 +4024,6 @@ Dead URLs:
 - https://soundcloud.com/frostymac123
 ---
 Artist: FRUITYTEE
-Context Notes: |-
-    Alias of [[group:cristata]].
 URLs:
 - https://cristata.bandcamp.com/
 ---
@@ -4695,8 +4689,6 @@ Dead URLs:
 Artist: HermesNitram
 ---
 Artist: hexidecimal
-Context Notes: |-
-    Alias of [[group:cristata]].
 URLs:
 - https://cristata.bandcamp.com/
 ---
@@ -4717,8 +4709,6 @@ URLs:
 Artist: Hieronymous Bosch
 ---
 Artist: Highblood
-Context Notes: |-
-    One-man band; alias of [[artist:xszelor]].
 URLs:
 - https://thehighblood.bandcamp.com/
 - https://vk.com/bleedingpie
@@ -4768,7 +4758,7 @@ URLs:
 - https://open.spotify.com/artist/1cXxia1Q2VDTjWe8X2Jydm
 ---
 Artist: Homestuck
-Context Notes: >-
+Context Notes: |-
     For crediting visual elements that are lifted directly from Homestuck, MS Paint Adventures, or related official media. Most notably, the track art for many official Homestuck songs are simply screenshots of the comic.
 ---
 Artist: HONE
@@ -4814,8 +4804,6 @@ Artist: Hyadain
 Artist: Hyper Light Drifter
 ---
 Artist: hywell
-Context Notes: |-
-    Alias of [[group:cristata]].
 URLs:
 - https://cristata.bandcamp.com/
 ---
@@ -7963,11 +7951,8 @@ URLs:
 Artist: Nick Balaban
 ---
 Artist: Nick Smalley
-Context Notes: >-
-    Tracks by Nick Smalley have been retained for the sake of preserving the intended
-    structure and form of albums they appear on; however, it should be noted that
-    this artist is a known and admitted pedophile. As of this writing, he is no longer
-    creating music.
+Context Notes: |-
+    Tracks by Nick Smalley have been retained for the sake of preserving the intended structure and form of albums they appear on; however, it should be noted that this artist is a known and admitted pedophile. As of this writing, he is no longer creating music.
 ---
 Artist: Nick Tucker
 Aliases:
@@ -9094,8 +9079,6 @@ URLs:
 - https://twitter.com/theradguywoah
 ---
 Artist: Realmite
-Context Notes: |-
-    One-man band; alias of [[artist:xszelor]].
 URLs:
 - https://realmite.bandcamp.com/
 Dead URLs:
@@ -9900,10 +9883,8 @@ URLs:
 Artist: Secret of Mana
 ---
 Artist: Seijen
-Context Notes: >-
-    Tracks by Seijen have been retained for the sake of preserving the intended structure
-    and form of albums they appear on, however, it should be noted that this artist
-    has made several statements defending neo-Nazi comic Stonetoss.
+Context Notes: |-
+    Tracks by Seijen have been retained for the sake of preserving the intended structure and form of albums they appear on, however, it should be noted that this artist has made several statements defending neo-Nazi comic Stonetoss.
 ---
 Artist: Seinfeld
 ---
@@ -11541,11 +11522,11 @@ Artist: Toto
 Artist: Touhou Project
 ---
 Artist: The Track Team
-Context Notes: >-
+Context Notes: |-
     Duo behind the music of [[artist:avatar-the-last-airbender]] and The Legend of Korra, made up of [[artist:jeremy-zuckerman]] and [[artist:benjamin-wynn]].
 ---
 Artist: Traditional
-Context Notes: >-
+Context Notes: |-
     This is a catchall artist entry to list folkloric music of unknown provenance. They're almost certainly based on other contemporaneous music that has been lost to time, and were never put to paper by someone verifiably claiming to be the original creator.
 ---
 Artist: Travis Scott
@@ -11719,7 +11700,7 @@ Artist: The Undisputed Truth
 Artist: Unofficial MSPA Fans
 ---
 Artist: Unknown Artist
-Context Notes: >-
+Context Notes: |-
     Sometimes, information on who is specifically responsible for a piece of music or art is not known. This is a catchall artist entry to list them in one place. If you have any information on who any of the artists listed here may be, please get in touch with us!
 ---
 Artist: UPLIFT SPICE

--- a/groups.yaml
+++ b/groups.yaml
@@ -124,6 +124,8 @@ Category: Solo musicians
 Color: '#fc9003'
 ---
 Group: Circlejourney
+Closely Linked Artists:
+- Circlejourney
 URLs:
 - https://circlejourney.bandcamp.com/
 - https://soundcloud.com/circlejourney
@@ -135,6 +137,8 @@ Description: |-
     Solo electronic artist from Singapore, with influence from East Asian and Celtic folk music, film soundtracks, and synthpop. When they're not making music, they are also a professional artist and web developer.
 ---
 Group: Clark Powell
+Closely Linked Artists:
+- Clark Powell
 URLs:
 - https://clarkpowell.bandcamp.com/
 - https://soundcloud.com/plazmataz
@@ -142,12 +146,20 @@ Description: |-
     Composer of [[album:medium]] and [[album:symphony-impossible-to-play]] as well as dozens of tracks across the Homestuck discography, and artist behind several independent albums whose tracks were recompiled and featured as the soundtrack for [[group:psycholonials]].
 ---
 Group: Cristata
+Closely Linked Artists:
+- Cristata
+- Cozmia
+- FRUITYTEE
+- hexidecimal
+- hywell
 URLs:
 - https://cristata.bandcamp.com
 Description: |-
     Artist behind [[album:perfectly-generic-album]] and beyond, and creator of crossover fanventure [Deltastuck](https://mspfa.com/?s=33534&p=1). Releases music under [[artist:cristata|a variety of names]].
 ---
 Group: Devieus
+Closely Linked Artists:
+- Devieus
 URLs:
 - https://devieus.bandcamp.com
 - https://weeklybeats.com/devieus
@@ -155,6 +167,8 @@ Description: |-
     Plural 'jack of all trades' from the Netherlands; they wrote a suite of twelve EPs based on each of the trolls' lands, and they've composed a track each week of every second year since 2012.
 ---
 Group: Funk McLovin
+Closely Linked Artists:
+- Funk McLovin
 URLs:
 - https://funkmclovin.bandcamp.com/
 - https://www.youtube.com/channel/UCIyu12_DBaAkDfFq-UQuHNw
@@ -164,6 +178,8 @@ Description: |-
     [Description via Bandcamp.](https://funkmclovin.bandcamp.com/)
 ---
 Group: horizon
+Closely Linked Artists:
+- horizon
 URLs:
 - https://ohanadyomene.bandcamp.com/
 - https://www.youtube.com/c/horizonandyomene
@@ -173,6 +189,8 @@ Description: |-
     Singer-composer and storyteller, also writing as OPHELIA ANADYOMENE; soloist behind dozens of many renowned covers including [[track:flare-with-vocals]] and [[track:derse-dreamers-ii]], plus works in other fandoms and emotionally moving, genre-diverse original music.
 ---
 Group: James Dever
+Closely Linked Artists:
+- James Dever
 URLs:
 - https://jamesdever.bandcamp.com
 - https://soundcloud.com/jamesdevermusic
@@ -183,6 +201,8 @@ Description: |-
     [Description via Bandcamp.](https://jamesdever.bandcamp.com/)
 ---
 Group: James Roach
+Closely Linked Artists:
+- James Roach
 URLs:
 - https://hames.bandcamp.com/
 - https://www.jamesroach.net/
@@ -190,30 +210,40 @@ Description: |-
     LA-based composer and audio engineer behind [[album:hiveswap-act-1-ost|Hiveswap]], [[album:pesterquest-soundtrack|Pesterquest]], and much more. They've been doing music for over twenty years; today, they're the creative director behind the HICU.
 ---
 Group: Jamie Paige
+Closely Linked Artists:
+- Jamie Paige
 URLs:
 - https://jamiepaige.bandcamp.com/
 Description: |-
     Saw wave elemental talking in pictures. Contributor to several LOFAMs and other fan albums, as well as [[album:homestuck-vol-10]], Jamie Paige's solo work is a rainbow of breakbeats, vocal synths, and gay shit.
 ---
 Group: Michael Guy Bowman
+Closely Linked Artists:
+- Michael Guy Bowman
 URLs:
 - https://bowman.bandcamp.com/
 Description: |-
     Renowned for [[Sburban Jungle]], his official solo album [[album:mobius-trip-and-hadron-kaleido]] and many other hit Homestuck releases, Bowman has gone on to create his own expansive personal discography since.
 ---
 Group: Nasqueron
+Closely Linked Artists:
+- Kal-la-kal-la
 URLs:
 - https://nasqueron.bandcamp.com/
 Description: |-
     Artist behind tracks across a wide variety of fan albums (where she's credited as [[artist:kal-la-kal-la]]), with two experimental noise-poetry albums by her own solo release.
 ---
 Group: Parsec Productions
+Closely Linked Artists:
+- Mark J. Hadley
 URLs:
 - https://parsecproductions.bandcamp.com/
 Description: |-
     Best known to Homestuck fans for creating some of its [[Skies of Skaia|foundational]] [[Aggrieve|themes]], and to the internet at large for Slender: The Eight Pages and [[album:slender-the-arrival-soundtrack|its sequel]], Mark J. Hadley is a multitalented composer and independent developer.
 ---
 Group: Solatrus
+Closely Linked Artists:
+- Solatrus
 URLs:
 - https://solatrus.bandcamp.com
 - https://soundcloud.com/solatrus
@@ -221,24 +251,32 @@ Description: |-
     Known primarily for [[track:frost-vol6]] and his solo album [[album:prospit-and-derse]], this artist has been making electronic and orchestral music for many years.
 ---
 Group: tempest2k
+Closely Linked Artists:
+- tempest2k
 URLs:
 - https://nuclear333.bandcamp.com/
 Description: |-
     Co-creator of the webcomic [INHOSPITABLE](https://inhospitable.net/), and musician with a history spanning half a decade. Plural internet artist.
 ---
 Group: Tensei
+Closely Linked Artists:
+- Tensei
 URLs:
 - https://tenseimusic.bandcamp.com/
 Description: |-
     Metal composer behind hit 2011 release [[album:strife]] and overall guitarist and musician behind a whole host of memorable tracks. He's gone on to release the 2017 sequel [[album:strife-2]] and a variety of other collaborative tracks since Homestuck!
 ---
 Group: Toby Fox
+Closely Linked Artists:
+- Toby Fox
 URLs:
 - https://tobyfox.bandcamp.com/
 Description: |-
     Artist of well over 100 tracks in Homestuck's musical canon (including the elusive [[Penumbra Phantasm]]), Toby Fox went on to compose the much-renowned soundtracks to his games [[group:undertale-and-deltarune]], firmly planting his place in modern game and internet history.
 ---
 Group: what is lost in the mines?
+Closely Linked Artists:
+- WHATISLOSTINTHEMINES
 URLs:
 - https://what.bandcamp.com/
 Description: |-
@@ -247,6 +285,11 @@ Description: |-
     [Description via Bandcamp.](https://web.archive.org/web/20201222140725/https://what.bandcamp.com/album/bashful-hearts-out)
 ---
 Group: Xszelor
+Closely Linked Artists:
+- Xszelor
+- Dvojka
+- Highblood
+- Realmite
 URLs:
 - https://thehighblood.bandcamp.com/
 - https://scorpan.bandcamp.com/music

--- a/groups.yaml
+++ b/groups.yaml
@@ -148,10 +148,10 @@ Description: |-
 Group: Cristata
 Closely Linked Artists:
 - Cristata
-- Cozmia
-- FRUITYTEE
-- hexidecimal
-- hywell
+- Cozmia (alias)
+- FRUITYTEE (alias)
+- hexidecimal (alias)
+- hywell (alias)
 URLs:
 - https://cristata.bandcamp.com
 Description: |-
@@ -287,9 +287,9 @@ Description: |-
 Group: Xszelor
 Closely Linked Artists:
 - Xszelor
-- Dvojka
-- Highblood
-- Realmite
+- Dvojka (alias)
+- Highblood (alias)
+- Realmite (alias)
 URLs:
 - https://thehighblood.bandcamp.com/
 - https://scorpan.bandcamp.com/music


### PR DESCRIPTION
I.e. manual links between related groups and artists, including specially-presented "alias" annotations. Depends on hsmusic/hsmusic-wiki#580.