### PR TITLE
Album additions: 8reath of light!

### DIFF
--- a/album/alternate-hues-and-melodies.yaml
+++ b/album/alternate-hues-and-melodies.yaml
@@ -42,7 +42,7 @@ Commentary: |-
     [[artist:apatheticpianist]]<br>
     [[artist:pascal-van-den-bos|Pascal "PotatoBoss" van den Bos]]<br>
     [[artist:frost-carter]]<br>
-    [[artist:liquidvoid]]<br>
+    [[artist:bright0n]]<br>
     [[artist:calikid]]<br>
     [[artist:dcmd]]<br>
     [[artist:stacatto-force]]
@@ -214,7 +214,7 @@ URLs:
 ---
 Track: Glowing Space Vampire
 Artists:
-- LiquidVoid
+- bright0n
 Cover Artists:
 - SoulofWoods
 Art Tags:

--- a/album/apple-in-flight.yaml
+++ b/album/apple-in-flight.yaml
@@ -1,0 +1,28 @@
+Album: apple in flight
+Artists:
+- Ash Taylor
+Date: August 20, 2021
+URLs:
+- https://8reath-of-light.bandcamp.com/track/apple-in-flight
+Cover Artists:
+- Ash Taylor
+Color: '#ffff00'
+Groups:
+- 8reath of light
+- Fandom
+Wallpaper Artists:
+- Ash Taylor
+- Lilithtreasure (edits for wiki)
+Wallpaper File Extension: png
+Wallpaper Style: |-
+    background-repeat: no-repeat;
+    background-size: 1920x;
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight))
+
+    as featured in [[s] saturday 1](https://archiveofourown.org/works/22446544/chapters/82732354).
+---
+Track: apple in flight
+Duration: 3:37
+URLs:
+- https://8reath-of-light.bandcamp.com/track/apple-in-flight

--- a/album/apple-in-flight.yaml
+++ b/album/apple-in-flight.yaml
@@ -16,11 +16,11 @@ Wallpaper Artists:
 Wallpaper File Extension: png
 Wallpaper Style: |-
     background-repeat: no-repeat;
-    background-size: 1920x;
+    background-size: 1920px;
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight))
 
-    as featured in [[s] saturday 1](https://archiveofourown.org/works/22446544/chapters/82732354).
+    as featured in [\[s] saturday 1](https://archiveofourown.org/works/22446544/chapters/82732354).
 ---
 Track: apple in flight
 Duration: 3:37

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -4,6 +4,7 @@ Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/catch-322
 # - https://music.deconreconstruction.com/albums/catch-322
+- https://www.youtube.com/playlist?list=PLBKFsSMpX3uujvVqkcit_n7fhX5XoCP8T
 Cover Artists:
 - ragnarozzy
 Cover Art File Extension: png
@@ -27,6 +28,7 @@ Sampled Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it
 # - https://music.deconreconstruction.com/albums/catch-322?track=minute-to-win-it
+- https://www.youtube.com/watch?v=UTh0lXil8l8
 ---
 Track: Arcjec's Theme
 Duration: '3:03'
@@ -37,6 +39,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme
 # - https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme
+- https://www.youtube.com/watch?v=6q89YAbPgsk
 ---
 Track: Falling Upward
 Duration: '3:49'
@@ -47,6 +50,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/falling-upward
 # - https://music.deconreconstruction.com/albums/catch-322?track=falling-upward
+- https://www.youtube.com/watch?v=AyoMmV4C4LY
 ---
 Track: Todd Howard
 Duration: '5:32'
@@ -57,6 +61,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/todd-howard
 # - https://music.deconreconstruction.com/albums/catch-322?track=todd-howard
+- https://www.youtube.com/watch?v=1dqh4_HILUI
 ---
 Track: Taz's Theme
 Duration: '2:04'
@@ -67,6 +72,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/tazs-theme
 # - https://music.deconreconstruction.com/albums/catch-322?track=tazs-theme
+- https://www.youtube.com/watch?v=EU-ud0HBJ7c
 ---
 Track: The Eternal Siren
 Duration: '3:51'
@@ -77,6 +83,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/the-eternal-siren
 # - https://music.deconreconstruction.com/albums/catch-322?track=the-eternal-siren
+- https://www.youtube.com/watch?v=NBIf3UPrw08
 ---
 Track: Dirty Days, Spotless Nights
 Duration: '2:36'
@@ -89,6 +96,7 @@ Art Tags:
 URLs:
 - https://vasterror.bandcamp.com/track/dirty-days-spotless-nights
 # - https://music.deconreconstruction.com/albums/catch-322?track=dirty-days-spotless-nights
+- https://www.youtube.com/watch?v=kczqjEI0NeQ
 ---
 Track: Show's Over
 Duration: '2:13'
@@ -99,6 +107,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/shows-over
 # - https://music.deconreconstruction.com/albums/catch-322?track=shows-over
+- https://www.youtube.com/watch?v=nGIr6xa0XKk
 ---
 Track: Murrit's Theme
 Duration: '2:49'
@@ -129,6 +138,7 @@ Sampled Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/murrits-theme
 # - https://music.deconreconstruction.com/albums/catch-322?track=murrits-theme
+- https://www.youtube.com/watch?v=DGBBZXtaQM0
 ---
 Track: Pursuit of Happiness
 Duration: '2:00'
@@ -140,6 +150,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/pursuit-of-happiness
 # - https://music.deconreconstruction.com/albums/catch-322?track=pursuit-of-happiness
+- https://www.youtube.com/watch?v=bOQqrzz5c14
 ---
 Track: Anywhere Can Be Paradise
 Duration: '3:18'
@@ -150,6 +161,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/anywhere-can-be-paradise
 # - https://music.deconreconstruction.com/albums/catch-322?track=anywhere-can-be-paradise
+- https://www.youtube.com/watch?v=AfVEX0_lL_A
 ---
 Track: Loch And Quay
 Duration: '2:52'
@@ -160,6 +172,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/loch-and-quay
 # - https://music.deconreconstruction.com/albums/catch-322?track=loch-and-quay
+- https://www.youtube.com/watch?v=bgt2k4dsOIk
 ---
 Track: Albion's Theme
 Duration: '4:16'
@@ -172,6 +185,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/albions-theme
 # - https://music.deconreconstruction.com/albums/catch-322?track=albions-theme
+- https://www.youtube.com/watch?v=jMMeR9pDZ_o
 ---
 Track: Lite-Brite
 Duration: '1:36'
@@ -182,6 +196,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/lite-brite
 # - https://music.deconreconstruction.com/albums/catch-322?track=lite-brite
+- https://www.youtube.com/watch?v=S4h4B9TLit0
 ---
 Track: Psychymify
 Duration: '4:54'
@@ -193,6 +208,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/psychymify
 # - https://music.deconreconstruction.com/albums/catch-322?track=psychymify
+- https://www.youtube.com/watch?v=z_GaEL0DaGM
 ---
 Track: Laivan's Theme
 Duration: '2:21'
@@ -203,6 +219,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/laivans-theme
 # - https://music.deconreconstruction.com/albums/catch-322?track=laivans-theme
+- https://www.youtube.com/watch?v=hpLbxco79oc
 ---
 Track: Cathode Ray
 Duration: '4:55'
@@ -218,6 +235,7 @@ Sampled Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/cathode-ray
 # - https://music.deconreconstruction.com/albums/catch-322?track=cathode-ray
+- https://www.youtube.com/watch?v=R7l_htPvaSM
 ---
 Track: I'm Right Here
 Duration: '3:45'
@@ -228,6 +246,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/im-right-here
 # - https://music.deconreconstruction.com/albums/catch-322?track=im-right-here
+- https://www.youtube.com/watch?v=QFp8eD3fM3Y
 ---
 Track: Ellsee's Theme
 Duration: '2:20'
@@ -238,6 +257,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme
 # - https://music.deconreconstruction.com/albums/catch-322?track=ellsees-theme
+- https://www.youtube.com/watch?v=GajG_jQc048
 ---
 Track: Courage
 Duration: '4:42'
@@ -250,6 +270,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/courage
 # - https://music.deconreconstruction.com/albums/catch-322?track=courage
+- https://www.youtube.com/watch?v=FDVmlRebHJc
 ---
 Track: Another Happy Ending
 Duration: '3:22'
@@ -264,6 +285,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/another-happy-ending
 # - https://music.deconreconstruction.com/albums/catch-322?track=another-happy-ending
+- https://www.youtube.com/watch?v=_3itQffx57Q
 ---
 Section: Bonus tracks
 ---
@@ -272,7 +294,7 @@ Additional Names:
 - Name: >-
     BONUS: The Black Depths
   Annotation: >-
-    [Bandcamp](https://vasterror.bandcamp.com/track/bonus-the-black-depths)
+    [Bandcamp](https://vasterror.bandcamp.com/track/bonus-the-black-depths), [YouTube](https://www.youtube.com/watch?v=mN6V5JlP7GM)
 - Name: >-
     The Black Depths (Bonus)
   Annotation: >-
@@ -285,6 +307,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-the-black-depths
 # - https://music.deconreconstruction.com/albums/catch-322?track=bonus-the-black-depths
+- https://www.youtube.com/watch?v=mN6V5JlP7GM
 ---
 Section: Download-only tracks
 ---

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -3,7 +3,6 @@ Date: August 13, 2019
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/catch-322
-# - https://music.deconreconstruction.com/albums/catch-322
 - https://www.youtube.com/playlist?list=PLBKFsSMpX3uujvVqkcit_n7fhX5XoCP8T
 Cover Artists:
 - ragnarozzy
@@ -27,7 +26,6 @@ Sampled Tracks:
 - SFX from Rhythm Heaven
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it
-# - https://music.deconreconstruction.com/albums/catch-322?track=minute-to-win-it
 - https://www.youtube.com/watch?v=UTh0lXil8l8
 ---
 Track: Arcjec's Theme
@@ -38,7 +36,6 @@ Cover Artists:
 - Ojajy
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme
-# - https://music.deconreconstruction.com/albums/catch-322?track=arcjecs-theme
 - https://www.youtube.com/watch?v=6q89YAbPgsk
 ---
 Track: Falling Upward
@@ -49,7 +46,6 @@ Cover Artists:
 - Max O'Keefe
 URLs:
 - https://vasterror.bandcamp.com/track/falling-upward
-# - https://music.deconreconstruction.com/albums/catch-322?track=falling-upward
 - https://www.youtube.com/watch?v=AyoMmV4C4LY
 ---
 Track: Todd Howard
@@ -60,7 +56,6 @@ Cover Artists:
 - Unknown Artist
 URLs:
 - https://vasterror.bandcamp.com/track/todd-howard
-# - https://music.deconreconstruction.com/albums/catch-322?track=todd-howard
 - https://www.youtube.com/watch?v=1dqh4_HILUI
 ---
 Track: Taz's Theme
@@ -71,7 +66,6 @@ Cover Artists:
 - ghostpotion
 URLs:
 - https://vasterror.bandcamp.com/track/tazs-theme
-# - https://music.deconreconstruction.com/albums/catch-322?track=tazs-theme
 - https://www.youtube.com/watch?v=EU-ud0HBJ7c
 ---
 Track: The Eternal Siren
@@ -82,7 +76,6 @@ Cover Artists:
 - Conjunx
 URLs:
 - https://vasterror.bandcamp.com/track/the-eternal-siren
-# - https://music.deconreconstruction.com/albums/catch-322?track=the-eternal-siren
 - https://www.youtube.com/watch?v=NBIf3UPrw08
 ---
 Track: Dirty Days, Spotless Nights
@@ -95,7 +88,6 @@ Art Tags:
 - 'cw: body horror'
 URLs:
 - https://vasterror.bandcamp.com/track/dirty-days-spotless-nights
-# - https://music.deconreconstruction.com/albums/catch-322?track=dirty-days-spotless-nights
 - https://www.youtube.com/watch?v=kczqjEI0NeQ
 ---
 Track: Show's Over
@@ -106,7 +98,6 @@ Cover Artists:
 - Mikkynga
 URLs:
 - https://vasterror.bandcamp.com/track/shows-over
-# - https://music.deconreconstruction.com/albums/catch-322?track=shows-over
 - https://www.youtube.com/watch?v=nGIr6xa0XKk
 ---
 Track: Murrit's Theme
@@ -137,7 +128,6 @@ Sampled Tracks:
 - Dialogue from The Truman Show
 URLs:
 - https://vasterror.bandcamp.com/track/murrits-theme
-# - https://music.deconreconstruction.com/albums/catch-322?track=murrits-theme
 - https://www.youtube.com/watch?v=DGBBZXtaQM0
 ---
 Track: Pursuit of Happiness
@@ -149,7 +139,6 @@ Cover Artists:
 - Spruik
 URLs:
 - https://vasterror.bandcamp.com/track/pursuit-of-happiness
-# - https://music.deconreconstruction.com/albums/catch-322?track=pursuit-of-happiness
 - https://www.youtube.com/watch?v=bOQqrzz5c14
 ---
 Track: Anywhere Can Be Paradise
@@ -160,7 +149,6 @@ Cover Artists:
 - Daytura
 URLs:
 - https://vasterror.bandcamp.com/track/anywhere-can-be-paradise
-# - https://music.deconreconstruction.com/albums/catch-322?track=anywhere-can-be-paradise
 - https://www.youtube.com/watch?v=AfVEX0_lL_A
 ---
 Track: Loch And Quay
@@ -171,7 +159,6 @@ Cover Artists:
 - spicyapplejam
 URLs:
 - https://vasterror.bandcamp.com/track/loch-and-quay
-# - https://music.deconreconstruction.com/albums/catch-322?track=loch-and-quay
 - https://www.youtube.com/watch?v=bgt2k4dsOIk
 ---
 Track: Albion's Theme
@@ -184,7 +171,6 @@ Referenced Tracks:
 - Magnificat
 URLs:
 - https://vasterror.bandcamp.com/track/albions-theme
-# - https://music.deconreconstruction.com/albums/catch-322?track=albions-theme
 - https://www.youtube.com/watch?v=jMMeR9pDZ_o
 ---
 Track: Lite-Brite
@@ -195,7 +181,6 @@ Cover Artists:
 - floralmarsupial
 URLs:
 - https://vasterror.bandcamp.com/track/lite-brite
-# - https://music.deconreconstruction.com/albums/catch-322?track=lite-brite
 - https://www.youtube.com/watch?v=S4h4B9TLit0
 ---
 Track: Psychymify
@@ -207,7 +192,6 @@ Cover Artists:
 - big chalupa
 URLs:
 - https://vasterror.bandcamp.com/track/psychymify
-# - https://music.deconreconstruction.com/albums/catch-322?track=psychymify
 - https://www.youtube.com/watch?v=z_GaEL0DaGM
 ---
 Track: Laivan's Theme
@@ -218,7 +202,6 @@ Cover Artists:
 - Chumi
 URLs:
 - https://vasterror.bandcamp.com/track/laivans-theme
-# - https://music.deconreconstruction.com/albums/catch-322?track=laivans-theme
 - https://www.youtube.com/watch?v=hpLbxco79oc
 ---
 Track: Cathode Ray
@@ -234,7 +217,6 @@ Sampled Tracks:
 - DOOR STUCK! DOOR STUCK!
 URLs:
 - https://vasterror.bandcamp.com/track/cathode-ray
-# - https://music.deconreconstruction.com/albums/catch-322?track=cathode-ray
 - https://www.youtube.com/watch?v=R7l_htPvaSM
 ---
 Track: I'm Right Here
@@ -245,7 +227,6 @@ Cover Artists:
 - Sparaze
 URLs:
 - https://vasterror.bandcamp.com/track/im-right-here
-# - https://music.deconreconstruction.com/albums/catch-322?track=im-right-here
 - https://www.youtube.com/watch?v=QFp8eD3fM3Y
 ---
 Track: Ellsee's Theme
@@ -256,7 +237,6 @@ Cover Artists:
 - Crystalrina
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme
-# - https://music.deconreconstruction.com/albums/catch-322?track=ellsees-theme
 - https://www.youtube.com/watch?v=GajG_jQc048
 ---
 Track: Courage
@@ -269,7 +249,6 @@ Cover Artists:
 - Deer
 URLs:
 - https://vasterror.bandcamp.com/track/courage
-# - https://music.deconreconstruction.com/albums/catch-322?track=courage
 - https://www.youtube.com/watch?v=FDVmlRebHJc
 ---
 Track: Another Happy Ending
@@ -284,7 +263,6 @@ Referenced Tracks:
 - THE ENIGMA OF THE BARTMAN.
 URLs:
 - https://vasterror.bandcamp.com/track/another-happy-ending
-# - https://music.deconreconstruction.com/albums/catch-322?track=another-happy-ending
 - https://www.youtube.com/watch?v=_3itQffx57Q
 ---
 Section: Bonus tracks
@@ -307,7 +285,6 @@ Cover Artists:
 - Vast Error
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-the-black-depths
-# - https://music.deconreconstruction.com/albums/catch-322?track=bonus-the-black-depths
 - https://www.youtube.com/watch?v=mN6V5JlP7GM
 ---
 Section: Download-only tracks

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -294,7 +294,8 @@ Additional Names:
 - Name: >-
     BONUS: The Black Depths
   Annotation: >-
-    [Bandcamp](https://vasterror.bandcamp.com/track/bonus-the-black-depths), [YouTube](https://www.youtube.com/watch?v=mN6V5JlP7GM)
+    [Bandcamp](https://vasterror.bandcamp.com/track/bonus-the-black-depths),
+    [YouTube](https://www.youtube.com/watch?v=mN6V5JlP7GM)
 - Name: >-
     The Black Depths (Bonus)
   Annotation: >-

--- a/album/chapter-8.yaml
+++ b/album/chapter-8.yaml
@@ -52,6 +52,7 @@ Track: Unite Synchronization (Breach the Heavens Mix)
 Suffix Directory: true
 Always Reference By Directory: true
 Originally Released As: track:unite-synchronization-breach-the-heavens-mix
+Duration: 2:45
 URLs:
 - https://8reath-of-light.bandcamp.com/track/unite-synchronization-breach-the-heavens-mix-2
 ---
@@ -60,6 +61,7 @@ Suffix Directory: true
 Always Reference By Directory: true
 Artists:
 - Ash Taylor
+Duration: 1:36
 URLs:
 - https://8reath-of-light.bandcamp.com/track/headspace
 Commentary: |-
@@ -71,6 +73,7 @@ Track: apple in flight
 Suffix Directory: true
 Always Reference By Directory: true
 Originally Released As: track:apple-in-flight
+Duration: 3:37
 URLs:
 - https://8reath-of-light.bandcamp.com/track/apple-in-flight-2
 Commentary: |-
@@ -96,6 +99,7 @@ Track: foreign bodies
 Suffix Directory: true
 Always Reference By Directory: true
 Originally Released As: track:foreign-bodies
+Duration: 3:27
 URLs:
 - https://8reath-of-light.bandcamp.com/track/foreign-bodies-2
 Commentary: |-

--- a/album/chapter-8.yaml
+++ b/album/chapter-8.yaml
@@ -1,0 +1,127 @@
+Album: Chapter 8
+Date: January 12, 2022
+URLs:
+- https://8reath-of-light.bandcamp.com/album/chapter-8
+Cover Artists:
+- Ash Taylor
+Color: '#3b86fb'
+Groups:
+- 8reath of light
+- Fandom
+Art Tags:
+- Earth
+Wallpaper Artists:
+- Ash Taylor
+- Lilithtreasure (edits for wiki)
+Wallpaper File Extension: png
+Wallpaper Style: |-
+    background-repeat: no-repeat;
+    background-size: 1920x;
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/album/chapter-8))
+
+    godfeels 3.1 chapter 8's gotten a lot of music. here's most of it compiled into an album, including some new and previously unreleased tracks.
+
+    <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/album/chapter-8))
+
+    tracks 1 - 4, 6, 8 by [[artist:ash-taylor]]<br>
+    track 5 by [[artist:ash-taylor]] and [[artist:castigadora]]<br>
+    track 7 by [[artist:dana-straten]] and [[artist:ash-taylor]]
+
+    album art by [[artist:ash-taylor]]
+---
+Section: Main album
+---
+Track: '[BOOT SEQUENCE]'
+Artists:
+- Ash Taylor
+Duration: 1:46
+URLs:
+- https://8reath-of-light.bandcamp.com/track/boot-sequence
+Referenced Tracks:
+- MeGaLoVania (Reprise)
+Sampled Tracks:
+- MeGaLoVania (Reprise)
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/boot-sequence))
+
+    <big><code style="background-color: black; color: #ffff00">GHERARD'S HALO SYS.VER.0408 ONLINE.</code></big>
+---
+Track: Unite Synchronization (Breach the Heavens Mix)
+Suffix Directory: true
+Always Reference By Directory: true
+Originally Released As: track:unite-synchronization-breach-the-heavens-mix
+URLs:
+- https://8reath-of-light.bandcamp.com/track/unite-synchronization-breach-the-heavens-mix-2
+---
+Track: headspace
+Suffix Directory: true
+Always Reference By Directory: true
+Artists:
+- Ash Taylor
+URLs:
+- https://8reath-of-light.bandcamp.com/track/headspace
+---
+Track: apple in flight
+Suffix Directory: true
+Always Reference By Directory: true
+Originally Released As: track:apple-in-flight
+URLs:
+- https://8reath-of-light.bandcamp.com/track/apple-in-flight-2
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight))
+
+    Jake English does not hesitate. He flies towards his doom.
+
+    <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight-2))
+
+    as featured in [[s] saturday 1](https://archiveofourown.org/works/22446544/chapters/82732354).
+---
+Track: EPIGONE
+Suffix Directory: true
+Always Reference By Directory: true
+Artists:
+- Ash Taylor
+- CASTIGADORA
+Duration: 3:11
+URLs:
+- https://8reath-of-light.bandcamp.com/track/epigone
+---
+Track: foreign bodies
+Suffix Directory: true
+Always Reference By Directory: true
+Originally Released As: track:foreign-bodies
+URLs:
+- https://8reath-of-light.bandcamp.com/track/foreign-bodies-2
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/foreign-bodies-2))
+
+    happy birthday, dear juuuuuuuune
+    
+    <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/foreign-bodies-2))
+
+    as featured in [[s] saturday 2](https://archiveofourown.org/works/22446544/chapters/83017978).
+---
+Track: Fist of Achilles
+Artists:
+- Dana Straten
+- Ash Taylor
+Duration: 2:39
+URLs:
+- https://8reath-of-light.bandcamp.com/track/fist-of-achilles
+---
+Section: Bonus track
+---
+Track: brain ghost egbert
+Additional Names:
+- Name: >-
+    brain ghost egbert (bonus track)
+  Annotation: >-
+    [Bandcamp](https://8reath-of-light.bandcamp.com/track/brain-ghost-egbert-bonus-track)
+Artists:
+- Ash Taylor
+Duration: 2:42
+URLs:
+- https://8reath-of-light.bandcamp.com/track/brain-ghost-egbert-bonus-track
+Referenced Tracks:
+- Doctor

--- a/album/chapter-8.yaml
+++ b/album/chapter-8.yaml
@@ -16,6 +16,7 @@ Wallpaper Artists:
 - Lilithtreasure (edits for wiki)
 Wallpaper File Extension: png
 Wallpaper Style: |-
+    opacity: 1;
     background-repeat: no-repeat;
     background-size: 1920px;
 Commentary: |-

--- a/album/chapter-8.yaml
+++ b/album/chapter-8.yaml
@@ -51,7 +51,6 @@ Commentary: |-
 ---
 Track: Unite Synchronization (Breach the Heavens Mix)
 Suffix Directory: true
-Always Reference By Directory: true
 Originally Released As: track:unite-synchronization-breach-the-heavens-mix
 Duration: 2:45
 URLs:
@@ -59,7 +58,6 @@ URLs:
 ---
 Track: headspace
 Suffix Directory: true
-Always Reference By Directory: true
 Artists:
 - Ash Taylor
 Duration: 1:36
@@ -72,7 +70,6 @@ Commentary: |-
 ---
 Track: apple in flight
 Suffix Directory: true
-Always Reference By Directory: true
 Originally Released As: track:apple-in-flight
 Duration: 3:37
 URLs:
@@ -98,7 +95,6 @@ URLs:
 ---
 Track: foreign bodies
 Suffix Directory: true
-Always Reference By Directory: true
 Originally Released As: track:foreign-bodies
 Duration: 3:27
 URLs:

--- a/album/chapter-8.yaml
+++ b/album/chapter-8.yaml
@@ -4,6 +4,7 @@ URLs:
 - https://8reath-of-light.bandcamp.com/album/chapter-8
 Cover Artists:
 - Ash Taylor
+Cover Art File Extension: png
 Color: '#3b86fb'
 Groups:
 - 8reath of light
@@ -16,7 +17,7 @@ Wallpaper Artists:
 Wallpaper File Extension: png
 Wallpaper Style: |-
     background-repeat: no-repeat;
-    background-size: 1920x;
+    background-size: 1920px;
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/album/chapter-8))
 
@@ -75,7 +76,7 @@ Commentary: |-
 
     <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight-2))
 
-    as featured in [[s] saturday 1](https://archiveofourown.org/works/22446544/chapters/82732354).
+    as featured in [\[s] saturday 1](https://archiveofourown.org/works/22446544/chapters/82732354).
 ---
 Track: EPIGONE
 Suffix Directory: true
@@ -100,7 +101,7 @@ Commentary: |-
     
     <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/foreign-bodies-2))
 
-    as featured in [[s] saturday 2](https://archiveofourown.org/works/22446544/chapters/83017978).
+    as featured in [\[s] saturday 2](https://archiveofourown.org/works/22446544/chapters/83017978).
 ---
 Track: Fist of Achilles
 Artists:
@@ -125,3 +126,7 @@ URLs:
 - https://8reath-of-light.bandcamp.com/track/brain-ghost-egbert-bonus-track
 Referenced Tracks:
 - Doctor
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/brain-ghost-egbert-bonus-track))
+
+    fun track i made for a hypothetical godfeels friendsim!

--- a/album/chapter-8.yaml
+++ b/album/chapter-8.yaml
@@ -46,7 +46,7 @@ Sampled Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/boot-sequence))
 
-    <big><code style="background-color: black; color: #ffff00">GHERARD'S HALO SYS.VER.0408 ONLINE.</code></big>
+    <b><big><code style="background-color: black; color: #ffff00">GHERARD'S HALO SYS.VER.0408 ONLINE.</code></big></b>
 ---
 Track: Unite Synchronization (Breach the Heavens Mix)
 Suffix Directory: true
@@ -62,6 +62,10 @@ Artists:
 - Ash Taylor
 URLs:
 - https://8reath-of-light.bandcamp.com/track/headspace
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/headspace))
+
+    "fish fear me, women fear me, i am afr8d, oh god, oh god, someone please save me from myself."
 ---
 Track: apple in flight
 Suffix Directory: true
@@ -70,7 +74,7 @@ Originally Released As: track:apple-in-flight
 URLs:
 - https://8reath-of-light.bandcamp.com/track/apple-in-flight-2
 Commentary: |-
-    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight))
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/apple-in-flight-2))
 
     Jake English does not hesitate. He flies towards his doom.
 

--- a/album/corporate-holiday-hits.yaml
+++ b/album/corporate-holiday-hits.yaml
@@ -4,7 +4,6 @@ Date: December 25, 2020
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/corporate-holiday-hits
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits
 Cover Artists:
 - Dani Calzone
 Cover Art File Extension: png
@@ -23,7 +22,6 @@ Artists:
 Duration: '02:10'
 URLs:
 - https://vasterror.bandcamp.com/track/eve
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=eve
 ---
 Track: 'Joy To This Rotten, Desolate Carcass Of A World'
 Artists:
@@ -31,7 +29,6 @@ Artists:
 Duration: '03:55'
 URLs:
 - https://vasterror.bandcamp.com/track/joy-to-this-rotten-desolate-carcass-of-a-world
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=joy-to-this-rotten-desolate-carcass-of-a-world
 ---
 Track: Holiday Shopping
 Artists:
@@ -39,7 +36,6 @@ Artists:
 Duration: '02:46'
 URLs:
 - https://vasterror.bandcamp.com/track/holiday-shopping
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=holiday-shopping
 ---
 Track: No Rest For The Wicked
 Artists:
@@ -47,7 +43,6 @@ Artists:
 Duration: '02:11'
 URLs:
 - https://vasterror.bandcamp.com/track/no-rest-for-the-wicked-2
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=holiday-shopping
 ---
 Track: Hearts In The Wrong Place
 Artists:
@@ -55,7 +50,6 @@ Artists:
 Duration: '02:02'
 URLs:
 - https://vasterror.bandcamp.com/track/hearts-in-the-wrong-place
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=hearts-in-the-wrong-place
 ---
 Track: Last Yulepassing
 Artists:
@@ -113,7 +107,6 @@ Lyrics: |-
     and we’ll be okay
 URLs:
 - https://vasterror.bandcamp.com/track/last-yulepassing-2
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=last-yulepassing
 ---
 Track: Seasonal Contentment
 Artists:
@@ -121,7 +114,6 @@ Artists:
 Duration: '02:03'
 URLs:
 - https://vasterror.bandcamp.com/track/seasonal-contentment-2
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=seasonal-contentment
 ---
 Track: Corporate Merriment Jingle 32
 Artists:
@@ -132,7 +124,6 @@ Referenced Tracks:
 - Last Christmas
 URLs:
 - https://vasterror.bandcamp.com/track/corporate-merriment-jingle-32
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=corporate-merriment-jingle-32
 ---
 Track: 'RECALL: A Winter Long Past'
 Artists:
@@ -169,7 +160,6 @@ Lyrics: |-
     Remembering how the season shone when you were still here
 URLs:
 - https://vasterror.bandcamp.com/track/recall-a-winter-long-past-2
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=recall-a-winter-long-past
 ---
 Track: Dawn
 Suffix Directory: true
@@ -179,4 +169,3 @@ Artists:
 Duration: '04:11'
 URLs:
 - https://vasterror.bandcamp.com/track/dawn
-# - https://music.deconreconstruction.com/albums/corporate-holiday-hits?track=dawn

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -171,7 +171,10 @@ URLs:
 ---
 Track: 'INTERMISSION: Mimesiswing'
 Additional Names:
-- Mimesiswing ([YouTube](https://www.youtube.com/watch?v=5wW4abjhojg))
+- Name: >-
+    Mimesiswing
+  Annotation: >-
+    [YouTube title](https://www.youtube.com/watch?v=5wW4abjhojg), minus album name
 Directory: mimesiswing
 Artists:
 - Rnd

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -4,7 +4,6 @@ Date: May 23, 2020
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/dead-shufflers-anything-goes
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes
 - https://www.youtube.com/playlist?list=PLBKFsSMpX3utRNcedTTvk9-Q-hFt5tJsj
 Cover Artists:
 - eddieDraws
@@ -27,7 +26,6 @@ Cover Artists:
 Duration: '03:16'
 URLs:
 - https://vasterror.bandcamp.com/track/overlook
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=overlook
 - https://www.youtube.com/watch?v=716i6lbXIRY
 ---
 Track: Hound Dog
@@ -73,7 +71,6 @@ Lyrics: |-
 Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/hound-dog
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=hound-dog
 - https://www.youtube.com/watch?v=3BQTcMFyC-I
 ---
 Track: Lucky Sevens
@@ -88,7 +85,6 @@ Referenced Tracks:
 - Luck Be a Lady
 URLs:
 - https://vasterror.bandcamp.com/track/lucky-sevens
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lucky-sevens
 - https://www.youtube.com/watch?v=9l7yz3GLb6E
 ---
 Track: Call It A Reraise
@@ -99,7 +95,6 @@ Cover Artists:
 Duration: '01:48'
 URLs:
 - https://vasterror.bandcamp.com/track/call-it-a-reraise
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=call-it-a-reraise
 - https://www.youtube.com/watch?v=AOV6eEFNJVo
 ---
 Track: Skullheart Duskwalk
@@ -110,7 +105,6 @@ Cover Artists:
 Duration: '02:512'
 URLs:
 - https://vasterror.bandcamp.com/track/skullheart-duskwalk
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=skullheart-duskwalk
 - https://www.youtube.com/watch?v=Sl6FYt_N23E
 ---
 Track: Path Of The Righteous Man
@@ -155,7 +149,6 @@ Lyrics: |-
 Duration: '03:22'
 URLs:
 - https://vasterror.bandcamp.com/track/path-of-the-righteous-man
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=path-of-the-righteous-man
 - https://www.youtube.com/watch?v=CL7enccHmW4
 ---
 Track: Fraudulent Quartet
@@ -166,7 +159,6 @@ Cover Artists:
 Duration: '02:08'
 URLs:
 - https://vasterror.bandcamp.com/track/fraudulent-quartet
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=fraudulent-quartet
 - https://www.youtube.com/watch?v=3fYAjLoqzL0
 ---
 Track: 'INTERMISSION: Mimesiswing'
@@ -183,7 +175,6 @@ Referenced Tracks:
 - SWING, SWING, SWING
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-mimesiswing
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=intermission-mimesiswing
 - https://www.youtube.com/watch?v=5wW4abjhojg
 ---
 Track: Dismantled
@@ -201,7 +192,6 @@ Referenced Tracks:
 Duration: '03:22'
 URLs:
 - https://vasterror.bandcamp.com/track/dismantled
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=dismantled
 - https://www.youtube.com/watch?v=yQ6ieVJAZ2M
 ---
 Track: Lovecraft
@@ -216,7 +206,6 @@ Art Tags:
 Duration: '01:32'
 URLs:
 - https://vasterror.bandcamp.com/track/lovecraft
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lovecraft
 - https://www.youtube.com/watch?v=0a_l51iUt-w
 ---
 Track: Money For Nothing
@@ -259,7 +248,6 @@ Lyrics: |-
     Oh-woah-oh, warm, soft cash
 URLs:
 - https://vasterror.bandcamp.com/track/money-for-nothing
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=money-for-nothing
 - https://www.youtube.com/watch?v=wVcJC6UHV4o
 ---
 Track: Disciplinary Action
@@ -270,7 +258,6 @@ Cover Artists:
 Duration: '02:00'
 URLs:
 - https://vasterror.bandcamp.com/track/disciplinary-action
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=disciplinary-action
 - https://www.youtube.com/watch?v=gYw2drg6g-s
 ---
 Track: Guess My Name
@@ -281,7 +268,6 @@ Cover Artists:
 Duration: '03:16'
 URLs:
 - https://vasterror.bandcamp.com/track/guess-my-name
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=guess-my-name
 - https://www.youtube.com/watch?v=h9rIAKGBNzY
 ---
 Track: Made For Spades
@@ -337,7 +323,6 @@ Lyrics: |-
 Duration: '04:18'
 URLs:
 - https://vasterror.bandcamp.com/track/made-for-spades
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=made-for-spades
 - https://www.youtube.com/watch?v=uhtW8NLCLJ4
 ---
 Track: Pale Imitation
@@ -348,7 +333,6 @@ Cover Artists:
 Duration: '05:10'
 URLs:
 - https://vasterror.bandcamp.com/track/pale-imitation
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=pale-imitation
 - https://www.youtube.com/watch?v=y56S-S9xJ0A
 ---
 Section: Bonus tracks
@@ -374,5 +358,4 @@ Referenced Tracks:
 Duration: '00:43'
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-dear-pesky-shufflers
-# - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=bonus-dear-pesky-shufflers
 - https://www.youtube.com/watch?v=TMvbL1d4gYA

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -5,6 +5,7 @@ Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/dead-shufflers-anything-goes
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes
+- https://www.youtube.com/playlist?list=PLBKFsSMpX3utRNcedTTvk9-Q-hFt5tJsj
 Cover Artists:
 - eddieDraws
 Cover Art File Extension: png
@@ -27,6 +28,7 @@ Duration: '03:16'
 URLs:
 - https://vasterror.bandcamp.com/track/overlook
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=overlook
+- https://www.youtube.com/watch?v=716i6lbXIRY
 ---
 Track: Hound Dog
 Suffix Directory: true
@@ -72,6 +74,7 @@ Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/hound-dog
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=hound-dog
+- https://www.youtube.com/watch?v=3BQTcMFyC-I
 ---
 Track: Lucky Sevens
 Artists:
@@ -86,6 +89,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/lucky-sevens
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lucky-sevens
+- https://www.youtube.com/watch?v=9l7yz3GLb6E
 ---
 Track: Call It A Reraise
 Artists:
@@ -96,6 +100,7 @@ Duration: '01:48'
 URLs:
 - https://vasterror.bandcamp.com/track/call-it-a-reraise
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=call-it-a-reraise
+- https://www.youtube.com/watch?v=AOV6eEFNJVo
 ---
 Track: Skullheart Duskwalk
 Artists:
@@ -106,6 +111,7 @@ Duration: '02:512'
 URLs:
 - https://vasterror.bandcamp.com/track/skullheart-duskwalk
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=skullheart-duskwalk
+- https://www.youtube.com/watch?v=Sl6FYt_N23E
 ---
 Track: Path Of The Righteous Man
 Artists:
@@ -150,6 +156,7 @@ Duration: '03:22'
 URLs:
 - https://vasterror.bandcamp.com/track/path-of-the-righteous-man
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=path-of-the-righteous-man
+- https://www.youtube.com/watch?v=CL7enccHmW4
 ---
 Track: Fraudulent Quartet
 Artists:
@@ -160,8 +167,11 @@ Duration: '02:08'
 URLs:
 - https://vasterror.bandcamp.com/track/fraudulent-quartet
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=fraudulent-quartet
+- https://www.youtube.com/watch?v=3fYAjLoqzL0
 ---
 Track: 'INTERMISSION: Mimesiswing'
+Additional Names:
+- Mimesiswing ([YouTube](https://www.youtube.com/watch?v=5wW4abjhojg))
 Directory: mimesiswing
 Artists:
 - Rnd
@@ -171,6 +181,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-mimesiswing
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=intermission-mimesiswing
+- https://www.youtube.com/watch?v=5wW4abjhojg
 ---
 Track: Dismantled
 Suffix Directory: true
@@ -188,6 +199,7 @@ Duration: '03:22'
 URLs:
 - https://vasterror.bandcamp.com/track/dismantled
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=dismantled
+- https://www.youtube.com/watch?v=yQ6ieVJAZ2M
 ---
 Track: Lovecraft
 Suffix Directory: true
@@ -202,6 +214,7 @@ Duration: '01:32'
 URLs:
 - https://vasterror.bandcamp.com/track/lovecraft
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=lovecraft
+- https://www.youtube.com/watch?v=0a_l51iUt-w
 ---
 Track: Money For Nothing
 Artists:
@@ -244,6 +257,7 @@ Lyrics: |-
 URLs:
 - https://vasterror.bandcamp.com/track/money-for-nothing
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=money-for-nothing
+- https://www.youtube.com/watch?v=wVcJC6UHV4o
 ---
 Track: Disciplinary Action
 Artists:
@@ -254,6 +268,7 @@ Duration: '02:00'
 URLs:
 - https://vasterror.bandcamp.com/track/disciplinary-action
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=disciplinary-action
+- https://www.youtube.com/watch?v=gYw2drg6g-s
 ---
 Track: Guess My Name
 Artists:
@@ -264,6 +279,7 @@ Duration: '03:16'
 URLs:
 - https://vasterror.bandcamp.com/track/guess-my-name
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=guess-my-name
+- https://www.youtube.com/watch?v=h9rIAKGBNzY
 ---
 Track: Made For Spades
 Artists:
@@ -319,6 +335,7 @@ Duration: '04:18'
 URLs:
 - https://vasterror.bandcamp.com/track/made-for-spades
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=made-for-spades
+- https://www.youtube.com/watch?v=uhtW8NLCLJ4
 ---
 Track: Pale Imitation
 Artists:
@@ -329,6 +346,7 @@ Duration: '05:10'
 URLs:
 - https://vasterror.bandcamp.com/track/pale-imitation
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=pale-imitation
+- https://www.youtube.com/watch?v=y56S-S9xJ0A
 ---
 Section: Bonus tracks
 ---
@@ -354,3 +372,4 @@ Duration: '00:43'
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-dear-pesky-shufflers
 # - https://music.deconreconstruction.com/albums/dead-shufflers-anything-goes?track=bonus-dear-pesky-shufflers
+- https://www.youtube.com/watch?v=TMvbL1d4gYA

--- a/album/empyreal-rhapsody.yaml
+++ b/album/empyreal-rhapsody.yaml
@@ -3,7 +3,6 @@ Date: October 12, 2021
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/empyreal-rhapsody
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody
 Artists:
 - Kal-la-kal-la
 Cover Artists:
@@ -29,7 +28,6 @@ Sampled Tracks:
 - Who Has Seen The Wind? - Written by Christina Rossetti
 URLs:
 - https://vasterror.bandcamp.com/track/phantazein
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=phantazein
 ---
 Track: Anesidora
 Duration: '04:12'
@@ -38,7 +36,6 @@ Referenced Tracks:
 - Rhapsody In Blue
 URLs:
 - https://vasterror.bandcamp.com/track/anesidora
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=anesidora
 ---
 Track: Inertia
 Suffix Directory: true
@@ -46,13 +43,11 @@ Always Reference By Directory: true
 Duration: '03:47'
 URLs:
 - https://vasterror.bandcamp.com/track/inertia
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=inertia
 ---
 Track: Cacoethes
 Duration: '04:10'
 URLs:
 - https://vasterror.bandcamp.com/track/cacoethes
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=cacoethes
 ---
 Track: Grotesquerie
 Duration: '05:27'
@@ -63,19 +58,16 @@ Sampled Tracks:
 - The Ballad of Reading Gaol - Written by Oscar Wilde
 URLs:
 - https://vasterror.bandcamp.com/track/grotesquerie
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=grotesquerie
 ---
 Track: Lacedaemonia
 Duration: '05:16'
 URLs:
 - https://vasterror.bandcamp.com/track/lacedaemonia
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=lacedaemonia
 ---
 Track: Terminal Iteration
 Duration: '04:49'
 URLs:
 - https://vasterror.bandcamp.com/track/terminal-iteration
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=terminal-iteration
 ---
 Track: Eigenstate
 Duration: '04:38'
@@ -86,7 +78,6 @@ Sampled Tracks:
 - To Be Or Not To Be - Excerpt from "Hamlet", read by Goran Visnjic in "ER"
 URLs:
 - https://vasterror.bandcamp.com/track/eigenstate
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=eigenstate
 ---
 Track: Archon
 Duration: '03:59'
@@ -107,7 +98,6 @@ Lyrics: |-
     DROWN
 URLs:
 - https://vasterror.bandcamp.com/track/archon
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=archon
 ---
 Track: Tributary
 Suffix Directory: true
@@ -127,7 +117,6 @@ Lyrics: |-
     You can't live well in your own skin
 URLs:
 - https://vasterror.bandcamp.com/track/tributary
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=tributary
 ---
 Track: Ringlorn
 Duration: '04:29'
@@ -148,16 +137,13 @@ Lyrics: |-
     Down to the mist-wrought towns where dreams go to die
 URLs:
 - https://vasterror.bandcamp.com/track/ringlorn
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=ringlorn
 ---
 Track: Pativedha
 Duration: '02:41'
 URLs:
 - https://vasterror.bandcamp.com/track/pativedha
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=pativedha
 ---
 Track: Chrysalis
 Duration: '04:15'
 URLs:
 - https://vasterror.bandcamp.com/track/chrysalis
-# - https://music.deconreconstruction.com/albums/empyreal-rhapsody?track=chrysalis

--- a/album/faux-dramatica.yaml
+++ b/album/faux-dramatica.yaml
@@ -13,7 +13,6 @@ Groups:
 - Fandom
 URLs:
 - https://vasterror.bandcamp.com/album/faux-dramatica
-# - https://music.deconreconstruction.com/albums/faux-dramatica
 Commentary: |-
     <i>Vast Error:</i>
     "We are, all of us, haunted — pursued down dim corridors by beasts who knew our names before birth. Wouldn't you like to stop running? Wouldn't you like the nightmares to end?"
@@ -29,7 +28,6 @@ Art Tags:
 - 'cw: eye horror'
 URLs:
 - https://vasterror.bandcamp.com/track/lament-for-a-dying-planet
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=lament-for-a-dying-planet
 ---
 Track: Too Slow
 Duration: 4:35
@@ -42,7 +40,6 @@ Sampled Tracks:
 - Killing In The Name
 URLs:
 - https://vasterror.bandcamp.com/track/too-slow
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=too-slow
 ---
 Track: Sillygoofysillygoofy (Ft. Andrea Libman)
 Directory: sillygoofysillygoofy
@@ -63,7 +60,6 @@ Sampled Tracks:
 - "Half-Life: Alyx but the Gnome is TOO AWARE"
 URLs:
 - https://vasterror.bandcamp.com/track/sillygoofysillygoofy-ft-andrea-libman
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=sillygoofysillygoofy-ft-andrea-libman
 Lyrics: |-
     (WOWIE ZOWIE! That whole thing was exhilarating! But oh no! It seems like this party is about to die down! We're going to have to fix that now! Heeheehahahaha!)
 ---
@@ -76,7 +72,6 @@ Sampled Tracks:
 - "audio from Super Smash Bros. For Wii U"
 URLs:
 - https://vasterror.bandcamp.com/track/carnage-carnival
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=carnage-carnival
 ---
 Track: Dustcatcher Redux (Ft. Pylon)
 Directory: dustcatcher-redux
@@ -93,7 +88,6 @@ Sampled Tracks:
 - Randy Savage Promo on Hulk Hogan (1989)
 URLs:
 - https://vasterror.bandcamp.com/track/dustcatcher-redux-ft-pylon
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=dustcatcher-redux-ft-pylon
 ---
 Track: Bite The Hand That Feeds You
 Duration: 4:21
@@ -116,7 +110,6 @@ Sampled Tracks:
 - 'The End of Evangelion - TV Spot #1'
 URLs:
 - https://vasterror.bandcamp.com/track/bite-the-hand-that-feeds-you
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=bite-the-hand-that-feeds-you
 ---
 Track: Turncoat
 Suffix Directory: true
@@ -133,7 +126,6 @@ Art Tags:
 - 'cw: blood (abstract)'
 URLs:
 - https://vasterror.bandcamp.com/track/turncoat
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=turncoat
 ---
 Track: Requiem For A Dying Planet (Ft. The Emek Hefer Choir)
 Directory: requiem-for-a-dying-planet
@@ -156,7 +148,6 @@ Sampled Tracks:
 - 'The End of Evangelion - TV Spot #1'
 URLs:
 - https://vasterror.bandcamp.com/track/requiem-for-a-dying-planet-ft-the-emek-hefer-choir
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=requiem-for-a-dying-planet-ft-the-emek-hefer-choir
 ---
 Track: Naught
 Suffix Directory: true
@@ -172,7 +163,6 @@ Art Tags:
 - 'cw: blood'
 URLs:
 - https://vasterror.bandcamp.com/track/naught
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=naught
 ---
 Section: Bonus track
 ---
@@ -215,4 +205,3 @@ Sampled Tracks:
 - Dexter's Laboratory Theme Song
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-cognito-hazard-ft-eddie-deezen
-# - https://music.deconreconstruction.com/albums/faux-dramatica?track=bonus-cognito-hazard-ft-eddie-deezen

--- a/album/fighting-further.yaml
+++ b/album/fighting-further.yaml
@@ -5,8 +5,6 @@ URLs:
 - https://vasterror.bandcamp.com/album/fighting-further
 - https://www.youtube.com/watch?v=SSEey9l2g3U
 - https://soundcloud.com/user-552040225/sets/fighting-further
-# this was accidentally linking to magnum-opus and as of March 3 2024 the DCRC website is unreachable, so can't check if it's the right URL below
-# - https://music.deconreconstruction.com/albums/fighting-further
 Artists:
 - Rainy
 Cover Artists:

--- a/album/flare-space-to-breathe-mix.yaml
+++ b/album/flare-space-to-breathe-mix.yaml
@@ -9,6 +9,7 @@ Cover Artists:
 - Hunter M
 Color: '#9d76d1'
 Groups:
+- 8reath of light
 - Fandom
 Art Tags:
 - Jade
@@ -22,7 +23,7 @@ Wallpaper Style: |-
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/flare-space-to-breathe-mix))
 
-    as featured in godfeels 3.2
+    as featured in [godfeels 3.2](https://archiveofourown.org/works/44185195/chapters/111743365)
 ---
 Track: Flare (Space to Breathe Mix)
 URLs:

--- a/album/foreign-bodies.yaml
+++ b/album/foreign-bodies.yaml
@@ -27,3 +27,5 @@ Track: foreign bodies
 Duration: 3:27
 URLs:
 - https://8reath-of-light.bandcamp.com/track/foreign-bodies
+Referenced Tracks:
+- Happy Birthday to You

--- a/album/foreign-bodies.yaml
+++ b/album/foreign-bodies.yaml
@@ -17,11 +17,11 @@ Cover Art File Extension: png
 Wallpaper File Extension: png
 Wallpaper Style: |-
     background-repeat: no-repeat;
-    background-size: 1920x;
+    background-size: 1920px;
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/foreign-bodies))
 
-    as featured in [[s] saturday 2](https://archiveofourown.org/works/22446544/chapters/83017978).
+    as featured in [\[s] saturday 2](https://archiveofourown.org/works/22446544/chapters/83017978).
 ---
 Track: foreign bodies
 Duration: 3:27

--- a/album/foreign-bodies.yaml
+++ b/album/foreign-bodies.yaml
@@ -1,0 +1,29 @@
+Album: foreign bodies
+Artists:
+- Ash Taylor
+Date: August 23, 2021
+URLs:
+- https://8reath-of-light.bandcamp.com/track/foreign-bodies
+Cover Artists:
+- Ash Taylor
+Color: '#239e00'
+Groups:
+- 8reath of light
+- Fandom
+Wallpaper Artists:
+- Ash Taylor
+- Lilithtreasure (edits for wiki)
+Cover Art File Extension: png
+Wallpaper File Extension: png
+Wallpaper Style: |-
+    background-repeat: no-repeat;
+    background-size: 1920x;
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/foreign-bodies))
+
+    as featured in [[s] saturday 2](https://archiveofourown.org/works/22446544/chapters/83017978).
+---
+Track: foreign bodies
+Duration: 3:27
+URLs:
+- https://8reath-of-light.bandcamp.com/track/foreign-bodies

--- a/album/freeroam-volume-1.yaml
+++ b/album/freeroam-volume-1.yaml
@@ -79,7 +79,7 @@ Art Tags:
 Commentary: |-
     <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/weight-of-the-world), excerpt)
 
-    Used in [S] Arron: Jump!
+    Used in [[flash:arron-jump]]!
 ---
 Track: The Realm of Reality
 Artists:
@@ -143,4 +143,4 @@ URLs:
 Commentary: |-
     <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/breaking-free)
 
-    Used in [S] Keira and Jason: Enter!
+    Used in [[flash:keira-and-jason-enter|[S] Keira and Jason: Enter!]]

--- a/album/freeroam-volume-1.yaml
+++ b/album/freeroam-volume-1.yaml
@@ -31,7 +31,7 @@ Commentary: |-
     - [[artist:robert-j-lake]]
     - [[artist:daniel-williams]]
     - [[artist:kurenai]]
-    - [[artist:amtrax]]
+    - [[artist:austin-lee-matthews]]
     - [[artist:bright0n]]
 
     The amazing cover art was drawn by [[artist:silentneptune]].

--- a/album/freeroam-volume-1.yaml
+++ b/album/freeroam-volume-1.yaml
@@ -123,7 +123,7 @@ Track: Friendly Fire
 Suffix Directory: true
 Always Reference By Directory: true
 Artists:
-- amtrax
+- Austin Lee Matthews
 Duration: 1:01
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/friendly-fire

--- a/album/freeroam-volume-1.yaml
+++ b/album/freeroam-volume-1.yaml
@@ -44,7 +44,7 @@ Commentary: |-
 
     <i>Freeroam:</i> ([Tumblr](https://www.tumblr.com/freeroam-fanadventure/163273063657/freeroam-volume-one-is-here-enjoy-a-free-nine), excerpt)
 
-    <b>[FREEROAM] - Volume One</b> is here! Enjoy a free nine piece album by a set of eight <i>extremely</i> talented musicians as a present for the One yYear Anniversary of the comic, [FREEROAM]! Thank you to all the musicians and the album artist [[artist:silentneptune]] for each of their fantastic contributions towards this album! Enjoy, and happy One Year of FREEROAM!
+    <b>[FREEROAM] - Volume One</b> is here! Enjoy a free nine piece album by a set of eight <i>extremely</i> talented musicians as a present for the One Year Anniversary of the comic, [FREEROAM]! Thank you to all the musicians and the album artist [[artist:silentneptune]] for each of their fantastic contributions towards this album! Enjoy, and happy One Year of FREEROAM!
 ---
 Track: Waiting for Adventure
 Suffix Directory: true

--- a/album/freeroam-volume-1.yaml
+++ b/album/freeroam-volume-1.yaml
@@ -14,6 +14,7 @@ Art Tags:
 - Earth
 Color: '#ff8226'
 Groups:
+- Freeroam
 - Fandom
 Commentary: |-
     <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/album/freeroam-volume-one))

--- a/album/freeroam-volume-1.yaml
+++ b/album/freeroam-volume-1.yaml
@@ -41,6 +41,10 @@ Commentary: |-
     <i>Freeroam:</i> ([Bandcamp download blurb](https://freeroamfanventure.bandcamp.com/album/freeroam-volume-one))
 
     This album is comprised of [9] full tracks!
+
+    <i>Freeroam:</i> ([Tumblr](https://www.tumblr.com/freeroam-fanadventure/163273063657/freeroam-volume-one-is-here-enjoy-a-free-nine), excerpt)
+
+    <b>[FREEROAM] - Volume One</b> is here! Enjoy a free nine piece album by a set of eight <i>extremely</i> talented musicians as a present for the One yYear Anniversary of the comic, [FREEROAM]! Thank you to all the musicians and the album artist [[artist:silentneptune]] for each of their fantastic contributions towards this album! Enjoy, and happy One Year of FREEROAM!
 ---
 Track: Waiting for Adventure
 Suffix Directory: true
@@ -115,7 +119,7 @@ Duration: 2:29
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/polaris
 Commentary: |-
-    <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/polaris)
+    <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/polaris))
 
     For later use!
 ---
@@ -128,7 +132,7 @@ Duration: 1:01
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/friendly-fire
 Commentary: |-
-    <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/friendly-fire)
+    <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/friendly-fire))
 
     For later use!
 ---
@@ -141,6 +145,6 @@ Duration: 2:23
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/breaking-free
 Commentary: |-
-    <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/breaking-free)
+    <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/breaking-free))
 
     Used in [[flash:keira-and-jason-enter|[S] Keira and Jason: Enter!]]

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -76,8 +76,8 @@ URLs:
 Commentary: |-
     <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), around 10/12/2017)
 
-    <img src="media/misc/the-man-of-action-full.png" width="600">
-    <img src="media/misc/the-man-of-action-full-alt.png" width="600">
+    <img src="media/misc/the-man-of-action-jason-ryders-theme-full.png" width="600">
+    <img src="media/misc/the-man-of-action-jason-ryders-theme-full-alt.png" width="600">
 
     Whoa boy, this is a big one!! This character is Jason Ryder from Freeroam which is made by [[artist:valantwynn]] I recommend checking it out if you're into Homestuck/Homestuck fancomics! ^u^
 

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -15,6 +15,7 @@ Art Tags:
 - Earth
 Color: '#ff924d'
 Groups:
+- Freeroam
 - Fandom
 Commentary: |-
     <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/album/freeroam-volume-one), excerpt)

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -74,7 +74,7 @@ Art Tags:
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/the-man-of-action-jason-ryders-theme
 Commentary: |-
-    <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), around 10/12/2017)
+    <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), 10/12/2017)
 
     <img src="media/misc/the-man-of-action-jason-ryders-theme-full.png" width="600">
     <img src="media/misc/the-man-of-action-jason-ryders-theme-full-alt.png" width="600">

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -76,8 +76,8 @@ URLs:
 Commentary: |-
     <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), 10/12/2017)
 
-    <img src="media/misc/the-man-of-action-jason-ryders-theme-full.png" width="600">
-    <img src="media/misc/the-man-of-action-jason-ryders-theme-full-alt.png" width="600">
+    <img src="media/misc/the-man-of-action-jason-ryders-theme-full.png" width="275">
+    <img src="media/misc/the-man-of-action-jason-ryders-theme-full-alt.png" width="275">
 
     Whoa boy, this is a big one!! This character is Jason Ryder from Freeroam which is made by [[artist:valantwynn]] I recommend checking it out if you're into Homestuck/Homestuck fancomics! ^u^
 

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -74,7 +74,7 @@ Art Tags:
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/the-man-of-action-jason-ryders-theme
 Commentary: |-
-    <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), sometime 10/11/2017 - 10/12/2017)
+    <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), around 10/12/2017)
 
     <img src="media/misc/the-man-of-action-full.png" width="600">
     <img src="media/misc/the-man-of-action-full-alt.png" width="600">

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -73,6 +73,15 @@ Art Tags:
 - Jason (Freeroam)
 URLs:
 - https://freeroamfanventure.bandcamp.com/track/the-man-of-action-jason-ryders-theme
+Commentary: |-
+    <i>SilentNeptune:</i> (full-size artwork, [Tumblr](https://freeroam-fanadventure.tumblr.com/post/166314835882/pixelatedchocolatedonut-whoa-boy-this-is-a-big), sometime 10/11/2017 - 10/12/2017)
+
+    <img src="media/misc/the-man-of-action-full.png" width="600">
+    <img src="media/misc/the-man-of-action-full-alt.png" width="600">
+
+    Whoa boy, this is a big one!! This character is Jason Ryder from Freeroam which is made by [[artist:valantwynn]] I recommend checking it out if you're into Homestuck/Homestuck fancomics! ^u^
+
+    Also I never drawn guitars before, f u c k
 ---
 Track: Detective Faust, At Your Service
 Artists:

--- a/album/freeroam-volume-2.yaml
+++ b/album/freeroam-volume-2.yaml
@@ -49,7 +49,7 @@ Commentary: |-
 
     The theme of Hazel Sharp.
 
-    Used in [S] Your name is...
+    Used in [[flash:your-name-is]]
 ---
 Track: First Frenzy
 Artists:
@@ -60,7 +60,7 @@ URLs:
 Commentary: |-
     <i>Freeroam:</i> ([Bandcamp about blurb](https://freeroamfanventure.bandcamp.com/track/first-frenzy), excerpt)
 
-    Used in [S] Arron: Strife.
+    Used in [[flash:arron-strife|[S] Arron: Strife.]]
 ---
 Track: The Man of Action (Jason Ryder's Theme)
 Artists:

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -60,9 +60,13 @@ Referenced Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
 
-    <b><code style="color: #033e9d">"you said you'd always fight for me."</code></b>
+    <b><code style="color: #3c85fb">"you said you'd always fight for me."</code></b>
 
     In a quiet moment, the phenomenon called June Egbert sits down at a piano, and lets the breeze guide her hands.
+
+    <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
+
+    based in part on an original composition by sarah zedig
 ---
 Track: june
 Suffix Directory: true
@@ -75,7 +79,7 @@ URLs:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
 
-    <b><code style="color: #5c66e8">"I'm a girl now, and you can call me...</code><code style="color: #033e9d">JUNE!!</code></b>
+    <b><code style="color: #5c66e8">"I'm a girl now, and you can call me...</code><code style="color: #3c85fb">JUNE!!</code></b>
 ---
 Track: its jade, but she's a gilf now
 Artists:
@@ -158,7 +162,7 @@ Commentary: |-
 
     <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/megalovania-reprise))
 
-    [[track:MeGaLoVania|original]] by [[artist:toby-fox]]
+    [[track:MeGaLoVania|original]] by toby fox
 ---
 Track: age of monsters
 Artists:

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -24,6 +24,10 @@ Wallpaper Style: |-
     background-size: 1920px;
 Banner Dimensions: 975x180
 Banner File Extension: png
+Additional Files:
+- Title: Bandcamp banner
+  Files:
+  - banner.png
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/album/i-dreamed-of-feeling-better-vol-1), excerpt)
 

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -77,7 +77,7 @@ URLs:
 - https://8reath-of-light.bandcamp.com/track/june
 - https://www.youtube.com/watch?v=fErKEgRSG_Y&t=224s
 Commentary: |-
-    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/june))
 
     <b><code style="color: #5c66e8">"I'm a girl now, and you can call me...</code><code style="color: #3c85fb">JUNE!!</code></b>
 ---
@@ -92,7 +92,7 @@ Referenced Tracks:
 - Crystalanthemums
 - track:megalovania-undertale
 Commentary: |-
-    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/its-jade-but-shes-a-gilf-now))
 
     <b><code style="color: #4ac925">"collapsed spacetime can be so hard to navigate"</code></b>
 ---

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -22,6 +22,24 @@ Wallpaper Style: |-
     background-size: 1920x;
 Banner Dimensions: 975x180
 Banner File Extension: png
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/album/i-dreamed-of-feeling-better-vol-1), excerpt)
+
+    i dreamed of feeling better, vol. 1<br>
+    a godfeels fan album<br>
+    by [[artist:dj-terezi]] and [[artist:ash-taylor|ash taylor]]
+
+    read [godfeels](https://archiveofourown.org/series/1475819)
+
+    <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/album/i-dreamed-of-feeling-better-vol-1))
+
+    credits:<br>
+    tracks 1, 3, 5, 7 by [[artist:ash-taylor|ash taylor]]<br>
+    tracks 2, 4, 6, 8 by [[artist:dj-terezi]]
+
+    based on godfeels by sarah zedig, and Homestuck by [[artist:andrew-hussie|andrew hussie]]
+
+    cover art by [[artist:ash-taylor|ash taylor]], based on the Homestuck Aspect symbols for Light, Breath and Space
 ---
 Track: next to me
 Artists:
@@ -35,7 +53,7 @@ Referenced Tracks:
 - Doctor
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
-    
+
     <code style="color: #033e9d">"you said you'd always fight for me."</code>
 
     In a quiet moment, the phenomenon called June Egbert sits down at a piano, and lets the breeze guide her hands.
@@ -48,6 +66,10 @@ Duration: 2:30
 URLs:
 - https://8reath-of-light.bandcamp.com/track/june
 - https://www.youtube.com/watch?v=fErKEgRSG_Y&t=224s
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
+
+    <code style="color: #0715cd">"I'm a girl now, and you can call me...</code><code style="color: #033e9d">JUNE!!</code>
 ---
 Track: its jade, but she's a gilf now
 Artists:
@@ -59,6 +81,10 @@ URLs:
 Referenced Tracks:
 - Crystalanthemums
 - track:megalovania-undertale
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
+
+    <code style="color: #4ac925">"collapsed spacetime can be so hard to navigate"</code>
 ---
 Track: wherever the breeze takes this
 Artists:
@@ -69,6 +95,10 @@ URLs:
 - https://www.youtube.com/watch?v=fErKEgRSG_Y&t=604s
 Referenced Tracks:
 - Sburban Jungle
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/wherever-the-breeze-takes-this))
+
+    <code style="color: #929292">"bUt that said: woUld yoU like to get REALLY fUcked Up?"</code>
 ---
 Track: vriskafic8ion
 Additional Names:
@@ -83,6 +113,10 @@ Referenced Tracks:
 - Savior of the Waking World
 - Doctor
 - Killed by BR8K Spider!!!!!!!!
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/vriskafic8ion))
+
+    <big><big><big><code style="color: #005682">"IT'S <i>OUR</i> 8USINESS, REDGLARE!"</code></big></big></big>
 ---
 Track: dire convergence
 Artists:
@@ -93,6 +127,10 @@ URLs:
 - https://www.youtube.com/watch?v=fErKEgRSG_Y&t=1057s
 Referenced Tracks:
 - Doctor
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/dire-convergence))
+
+    Cerulean lightning screams out from the torrent, snaking out like roots into the fabric of the universe itself.
 ---
 Track: MeGaLoVania (Reprise)
 Artists:
@@ -107,6 +145,14 @@ Referenced Tracks:
 - track:MeGaLoVania
 - Doctor
 - Sburban Jungle
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/megalovania-reprise))
+
+    <code style="color: #005682">"WELL? ARE WE DOING THIS OR WHAT?"</code>
+
+    <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/megalovania-reprise))
+
+    [[MeGaLoVania|original]] by [[artist:toby-fox]]
 ---
 Track: age of monsters
 Artists:

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -7,6 +7,7 @@ URLs:
 Cover Artists:
 - Ash Taylor
 Cover Art File Extension: png
+Track Art File Extension: png
 Color: '#3c85fb'
 Groups:
 - 8reath of light
@@ -18,8 +19,9 @@ Wallpaper Artists:
 - Lilithtreasure (edits for wiki)
 Wallpaper File Extension: png
 Wallpaper Style: |-
+    opacity: 0.3;
     background-repeat: no-repeat;
-    background-size: 1920x;
+    background-size: 1920px;
 Banner Dimensions: 975x180
 Banner File Extension: png
 Commentary: |-
@@ -152,7 +154,7 @@ Commentary: |-
 
     <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/megalovania-reprise))
 
-    [[MeGaLoVania|original]] by [[artist:toby-fox]]
+    [[track:MeGaLoVania|original]] by [[artist:toby-fox]]
 ---
 Track: age of monsters
 Artists:

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -56,7 +56,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
 
-    <code style="color: #033e9d">"you said you'd always fight for me."</code>
+    <b><code style="color: #033e9d">"you said you'd always fight for me."</code></b>
 
     In a quiet moment, the phenomenon called June Egbert sits down at a piano, and lets the breeze guide her hands.
 ---
@@ -71,7 +71,7 @@ URLs:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
 
-    <code style="color: #0715cd">"I'm a girl now, and you can call me...</code><code style="color: #033e9d">JUNE!!</code>
+    <b><code style="color: #5c66e8">"I'm a girl now, and you can call me...</code><code style="color: #033e9d">JUNE!!</code></b>
 ---
 Track: its jade, but she's a gilf now
 Artists:
@@ -86,7 +86,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
 
-    <code style="color: #4ac925">"collapsed spacetime can be so hard to navigate"</code>
+    <b><code style="color: #4ac925">"collapsed spacetime can be so hard to navigate"</code></b>
 ---
 Track: wherever the breeze takes this
 Artists:
@@ -100,7 +100,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/wherever-the-breeze-takes-this))
 
-    <code style="color: #929292">"bUt that said: woUld yoU like to get REALLY fUcked Up?"</code>
+    <b><code style="color: #929292">"bUt that said: woUld yoU like to get REALLY fUcked Up?"</code></b>
 ---
 Track: vriskafic8ion
 Additional Names:
@@ -118,7 +118,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/vriskafic8ion))
 
-    <big><big><big><code style="color: #005682">"IT'S <i>OUR</i> 8USINESS, REDGLARE!"</code></big></big></big>
+    <b><big><big><big><code style="color: #005682">"IT'S <i>OUR</i> 8USINESS, REDGLARE!"</code></big></big></big></b>
 ---
 Track: dire convergence
 Artists:
@@ -150,7 +150,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/megalovania-reprise))
 
-    <code style="color: #005682">"WELL? ARE WE DOING THIS OR WHAT?"</code>
+    <b><code style="color: #005682">"WELL? ARE WE DOING THIS OR WHAT?"</code></b>
 
     <i>Ash Taylor:</i> ([Bandcamp credits blurb](https://8reath-of-light.bandcamp.com/track/megalovania-reprise))
 

--- a/album/i-dreamed-of-feeling-better-vol-1.yaml
+++ b/album/i-dreamed-of-feeling-better-vol-1.yaml
@@ -1,0 +1,127 @@
+Album: i dreamed of feeling better, vol. 1
+Directory Suffix: idofb-vol1
+Date: June 18, 2021
+URLs:
+- https://8reath-of-light.bandcamp.com/album/i-dreamed-of-feeling-better-vol-1
+- https://www.youtube.com/watch?v=fErKEgRSG_Y
+Cover Artists:
+- Ash Taylor
+Cover Art File Extension: png
+Color: '#3c85fb'
+Groups:
+- 8reath of light
+- Fandom
+Banner Artists:
+- Ash Taylor
+Wallpaper Artists:
+- Ash Taylor
+- Lilithtreasure (edits for wiki)
+Wallpaper File Extension: png
+Wallpaper Style: |-
+    background-repeat: no-repeat;
+    background-size: 1920x;
+Banner Dimensions: 975x180
+Banner File Extension: png
+---
+Track: next to me
+Artists:
+- Ash Taylor
+Duration: 3:44
+URLs:
+- https://8reath-of-light.bandcamp.com/track/next-to-me
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=0s
+Referenced Tracks:
+- Sburban Jungle
+- Doctor
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/next-to-me))
+    
+    <code style="color: #033e9d">"you said you'd always fight for me."</code>
+
+    In a quiet moment, the phenomenon called June Egbert sits down at a piano, and lets the breeze guide her hands.
+---
+Track: june
+Suffix Directory: true
+Artists:
+- dj terezi
+Duration: 2:30
+URLs:
+- https://8reath-of-light.bandcamp.com/track/june
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=224s
+---
+Track: its jade, but she's a gilf now
+Artists:
+- Ash Taylor
+Duration: 3:50
+URLs:
+- https://8reath-of-light.bandcamp.com/track/its-jade-but-shes-a-gilf-now
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=374s
+Referenced Tracks:
+- Crystalanthemums
+- track:megalovania-undertale
+---
+Track: wherever the breeze takes this
+Artists:
+- dj terezi
+Duration: 4:57
+URLs:
+- https://8reath-of-light.bandcamp.com/track/wherever-the-breeze-takes-this
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=604s
+Referenced Tracks:
+- Sburban Jungle
+---
+Track: vriskafic8ion
+Additional Names:
+- vriskafication (quirk-free)
+Artists:
+- Ash Taylor
+Duration: 2:34
+URLs:
+- https://8reath-of-light.bandcamp.com/track/vriskafic8ion
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=901s
+Referenced Tracks:
+- Savior of the Waking World
+- Doctor
+- Killed by BR8K Spider!!!!!!!!
+---
+Track: dire convergence
+Artists:
+- dj terezi
+Duration: 4:20
+URLs:
+- https://8reath-of-light.bandcamp.com/track/dire-convergence
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=1057s
+Referenced Tracks:
+- Doctor
+---
+Track: MeGaLoVania (Reprise)
+Artists:
+- Ash Taylor
+Cover Artists:
+- Ash Taylor
+Duration: 3:14
+URLs:
+- https://8reath-of-light.bandcamp.com/track/megalovania-reprise
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=1317s
+Referenced Tracks:
+- track:MeGaLoVania
+- Doctor
+- Sburban Jungle
+---
+Track: age of monsters
+Artists:
+- dj terezi
+Duration: 4:10
+URLs:
+- https://8reath-of-light.bandcamp.com/track/age-of-monsters
+- https://www.youtube.com/watch?v=fErKEgRSG_Y&t=1511s
+Referenced Tracks:
+- Doctor
+Commentary: |-
+    <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/age-of-monsters))
+
+    When he finally understands what exactly he is looking at, the first thing Jake thinks of is an apple plucked from a tree, bitten of once with voracious hunger, and then cast carelessly back into the cosmic dark.
+
+    Jake's hands cover his mouth.
+
+    The time of monsters has arrived.

--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -253,11 +253,9 @@ Commentary : |-
     Ultimate Dirk broods moodily over some epic matter of doubtlessly transcendent existential importance. The text in the background was transcribed directly from my well-thumbed physical copy of the epilogues. I kinda forgot what the interior of the Theseus looked like so I defaulted to a bunch of Galfany-esque tech.
 ---
 Track: vriskafic8ion
-Additional Names:
-- vriskafication (quirk-free)
-Artists:
-- Ash Taylor
-Duration: '2:34'
+Suffix Directory: true
+Always Reference By Directory: true
+Originally Released As: track:vriskafic8ion
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/vriskafic8ion
 - https://www.youtube.com/watch?v=xr5UUqGtjiw
@@ -267,10 +265,6 @@ Art Tags:
 - June
 - John
 - Vriska
-Referenced Tracks:
-- Savior of the Waking World
-- Doctor
-- Killed by BR8K Spider!!!!!!!!
 Commentary: |-
     <i>Fender_Jess:</i>
     So Vriskafic8ion is a track Ash wrote inspired by the fanfiction "[godfeels](https://archiveofourown.org/series/1475819)", wherein John becomes June with an assist from her own personal brain ghost Vriska. Basically, June is all of John's power and free spirit, combined with Vriska's determination, neverending drive and penchant for (over-re)action. She's a chaotic whirlwind of violence and action and willpower and volatility, all with Vriska there, in spirit, hand on her shoulder. Godfeels is one of my all-time favorite fanworks (in fact I voice June in a fandub called podfeels, check it out!), and seeing this track appear on LOFAM was an absolute delight, so I wanted to give it a visual punch to go along with the energy of the music. The piece itself is just a few vignettes of important moments plus a Cool Action Shot of June to tie it all together. As simple as the concept is, I'm really happy with how it came out; this is definitely the most ambitious thing I've ever drawn, hahah

--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -256,6 +256,7 @@ Track: vriskafic8ion
 Suffix Directory: true
 Always Reference By Directory: true
 Originally Released As: track:vriskafic8ion
+Duration: 2:34
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/vriskafic8ion
 - https://www.youtube.com/watch?v=xr5UUqGtjiw

--- a/album/lofam5a2.yaml
+++ b/album/lofam5a2.yaml
@@ -254,7 +254,6 @@ Commentary : |-
 ---
 Track: vriskafic8ion
 Suffix Directory: true
-Always Reference By Directory: true
 Originally Released As: track:vriskafic8ion
 Duration: 2:34
 URLs:

--- a/album/magnum-opus.yaml
+++ b/album/magnum-opus.yaml
@@ -3,7 +3,6 @@ Date: March 22, 2023
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/magnum-opus
-# - https://music.deconreconstruction.com/albums/magnum-opus
 Cover Artists:
 - ghastaboo
 Cover Art File Extension: png

--- a/album/penumbra-phantasm-cover-ash-taylor.yaml
+++ b/album/penumbra-phantasm-cover-ash-taylor.yaml
@@ -32,7 +32,7 @@ Commentary: |-
     [[Penumbra Phantasm|penumbra phantasm]] is my favorite homestuck song that doesn't exist outside [[artist:toby-fox|toby fox's]] hard drive
 ---
 Track: PENUMBRA PHANTASM (Cover)
-Directory: penubmra-phantasm-cover-ash-taylor
+Directory: penumbra-phantasm-cover-ash-taylor
 Additional Names:
 - Name: >-
     PENUMBRA PHANTASM (Metal Cover)

--- a/album/perils-of-probability.yaml
+++ b/album/perils-of-probability.yaml
@@ -5,7 +5,6 @@ Date: October 31, 2022
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/perils-of-probability-the-technicolor-terror-from-beyond-the-hyperthetical
-# - https://music.deconreconstruction.com/albums/perils-of-probability-the-technicolor-terror-from-beyond-the-hyperthetical
 Cover Artists:
 - rurichoo
 Cover Art File Extension: png

--- a/album/reminders-of-you-beta.yaml
+++ b/album/reminders-of-you-beta.yaml
@@ -3,7 +3,6 @@ Date: March 22, 2021
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/reminders-of-you-beta
-# - https://music.deconreconstruction.com/albums/reminders-of-you-beta
 Artists:
 - Alex Votl
 Cover Artists:
@@ -19,19 +18,16 @@ Track: 'SIDE 1: Who You Were [Beta]'
 Duration: '02:15'
 URLs:
 - https://vasterror.bandcamp.com/track/side-1-who-you-were-beta
-# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=side-1-who-you-were-beta
 ---
 Track: 'Loss Of Innocence [Beta]'
 Duration: '04:09'
 URLs:
 - https://vasterror.bandcamp.com/track/loss-of-innocence-beta
-# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=loss-of-innocence-beta
 ---
 Track: 'Still Here [Beta]'
 Duration: '03:21'
 URLs:
 - https://vasterror.bandcamp.com/track/still-here-beta
-# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=still-here-beta
 ---
 Track: 'Fixer-Upper [Beta]'
 Duration: '03:15'
@@ -39,7 +35,6 @@ Sampled Tracks:
 - SFX from Super Smash Bros
 URLs:
 - https://vasterror.bandcamp.com/track/fixer-upper-beta
-# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=fixer-upper-beta
 ---
 Track: 'Face Yourself [Beta]'
 Duration: '03:44'
@@ -48,4 +43,3 @@ Referenced Tracks:
 - track:faint-linkin-park
 URLs:
 - https://vasterror.bandcamp.com/track/side-1-who-you-were-beta
-# - https://music.deconreconstruction.com/albums/reminders-of-you-beta?track=face-yourself-beta

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -5,7 +5,6 @@ Artists:
 - pragmaticNihilist
 URLs:
 - https://vasterror.bandcamp.com/album/repiton
-# - https://music.deconreconstruction.com/albums/repiton
 - https://www.youtube.com/playlist?list=PLBKFsSMpX3ut49CRMmcCH_dq6onS8hF7q
 Cover Artists:
 - Xamag
@@ -24,7 +23,6 @@ Always Reference By Directory: true
 Duration: '3:56'
 URLs:
 - https://vasterror.bandcamp.com/track/methodology
-# - https://music.deconreconstruction.com/albums/repiton?track=methodology
 - https://www.youtube.com/watch?v=VBnhzDmAmsI
 ---
 Track: Day After Day
@@ -35,7 +33,6 @@ Art Tags:
 Duration: '4:20'
 URLs:
 - https://vasterror.bandcamp.com/track/day-after-day
-# - https://music.deconreconstruction.com/albums/repiton?track=day-after-day
 - https://www.youtube.com/watch?v=Tm4vT4PkWyI
 ---
 Track: Moment's Notice
@@ -46,7 +43,6 @@ Art Tags:
 Duration: '3:37'
 URLs:
 - https://vasterror.bandcamp.com/track/moments-notice
-# - https://music.deconreconstruction.com/albums/repiton?track=moments-notice
 - https://www.youtube.com/watch?v=yXla2i-vjvk
 ---
 Track: Suckerpunch
@@ -57,7 +53,6 @@ Art Tags:
 Duration: '4:21'
 URLs:
 - https://vasterror.bandcamp.com/track/suckerpunch
-# - https://music.deconreconstruction.com/albums/repiton?track=suckerpunch
 ---
 Track: That's Right!
 Cover Artists:
@@ -67,7 +62,6 @@ Art Tags:
 Duration: '3:22'
 URLs:
 - https://vasterror.bandcamp.com/track/thats-right
-# - https://music.deconreconstruction.com/albums/repiton?track=thats-right
 - https://www.youtube.com/watch?v=MGsaAxrdhLA
 Referenced Tracks:
 - track:september-earth-wind-fire
@@ -87,7 +81,6 @@ Referenced Tracks:
 - Radioactive Ore
 URLs:
 - https://vasterror.bandcamp.com/track/survival
-# - https://music.deconreconstruction.com/albums/repiton?track=survival
 - https://www.youtube.com/watch?v=xQLgbUvyK_Q
 ---
 Track: Home
@@ -97,7 +90,6 @@ Cover Artists:
 Duration: '2:08'
 URLs:
 - https://vasterror.bandcamp.com/track/home
-# - https://music.deconreconstruction.com/albums/repiton?track=home
 - https://www.youtube.com/watch?v=1QLicLzdZUs
 ---
 Track: 'INTERMISSION: Risk'
@@ -106,7 +98,6 @@ Suffix Directory: true
 Duration: '4:17'
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-risk
-# - https://music.deconreconstruction.com/albums/repiton?track=intermission-risk
 - https://www.youtube.com/watch?v=2wTjbu46_hE
 ---
 Track: Moonlight
@@ -117,7 +108,6 @@ Cover Artists:
 Duration: '3:01'
 URLs:
 - https://vasterror.bandcamp.com/track/moonlight
-# - https://music.deconreconstruction.com/albums/repiton?track=moonlight
 - https://www.youtube.com/watch?v=6gzdgiR1nx8
 ---
 Track: Through It All
@@ -126,7 +116,6 @@ Cover Artists:
 Duration: '4:37'
 URLs:
 - https://vasterror.bandcamp.com/track/through-it-all
-# - https://music.deconreconstruction.com/albums/repiton?track=through-it-all
 - https://www.youtube.com/watch?v=3nGf7bQTJNg
 ---
 Track: Tyrant
@@ -138,7 +127,6 @@ Referenced Tracks:
 - track:oversaturated-vast-error
 URLs:
 - https://vasterror.bandcamp.com/track/tyrant
-# - https://music.deconreconstruction.com/albums/repiton?track=tyrant
 - https://www.youtube.com/watch?v=6mLgwe5gu3g
 ---
 Track: Take The Shot
@@ -149,7 +137,6 @@ Art Tags:
 Duration: '3:38'
 URLs:
 - https://vasterror.bandcamp.com/track/take-the-shot
-# - https://music.deconreconstruction.com/albums/repiton?track=take-the-shot
 - https://www.youtube.com/watch?v=EpF7yhxA0pA
 ---
 Track: Nailed It
@@ -158,7 +145,6 @@ Cover Artists:
 Duration: '3:22'
 URLs:
 - https://vasterror.bandcamp.com/track/nailed-it
-# - https://music.deconreconstruction.com/albums/repiton?track=nailed-it
 - https://www.youtube.com/watch?v=KLw6_2wtsaI
 ---
 Track: Remember?
@@ -168,7 +154,6 @@ Cover Artists:
 Duration: '3:10'
 URLs:
 - https://vasterror.bandcamp.com/track/remember
-# - https://music.deconreconstruction.com/albums/repiton?track=remember
 - https://www.youtube.com/watch?v=R5Rj5Sh0GSo
 ---
 Track: Promise
@@ -180,7 +165,6 @@ Cover Art File Extension: jpg
 Duration: '3:03'
 URLs:
 - https://vasterror.bandcamp.com/track/promise
-# - https://music.deconreconstruction.com/albums/repiton?track=promise
 - https://www.youtube.com/watch?v=C85-5CUgkTo
 ---
 Track: Only The Beginning
@@ -191,7 +175,6 @@ Art Tags:
 Duration: '6:59'
 URLs:
 - https://vasterror.bandcamp.com/track/only-the-beginning
-# - https://music.deconreconstruction.com/albums/repiton?track=only-the-beginning
 - https://www.youtube.com/watch?v=yJZVKfDoK5s
 ---
 Section: Bonus track
@@ -209,5 +192,4 @@ Additional Names:
 Duration: '2:39'
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-where-to-now
-# - https://music.deconreconstruction.com/albums/repiton?track=bonus-where-to-now
 - https://www.youtube.com/watch?v=c_k3r4j3Iu4

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -6,6 +6,7 @@ Artists:
 URLs:
 - https://vasterror.bandcamp.com/album/repiton
 # - https://music.deconreconstruction.com/albums/repiton
+- https://www.youtube.com/playlist?list=PLBKFsSMpX3ut49CRMmcCH_dq6onS8hF7q
 Cover Artists:
 - Xamag
 Cover Art File Extension: png
@@ -24,6 +25,7 @@ Duration: '3:56'
 URLs:
 - https://vasterror.bandcamp.com/track/methodology
 # - https://music.deconreconstruction.com/albums/repiton?track=methodology
+- https://www.youtube.com/watch?v=VBnhzDmAmsI
 ---
 Track: Day After Day
 Cover Artists:
@@ -34,6 +36,7 @@ Duration: '4:20'
 URLs:
 - https://vasterror.bandcamp.com/track/day-after-day
 # - https://music.deconreconstruction.com/albums/repiton?track=day-after-day
+- https://www.youtube.com/watch?v=Tm4vT4PkWyI
 ---
 Track: Moment's Notice
 Cover Artists:
@@ -44,6 +47,7 @@ Duration: '3:37'
 URLs:
 - https://vasterror.bandcamp.com/track/moments-notice
 # - https://music.deconreconstruction.com/albums/repiton?track=moments-notice
+- https://www.youtube.com/watch?v=yXla2i-vjvk
 ---
 Track: Suckerpunch
 Cover Artists:
@@ -64,6 +68,7 @@ Duration: '3:22'
 URLs:
 - https://vasterror.bandcamp.com/track/thats-right
 # - https://music.deconreconstruction.com/albums/repiton?track=thats-right
+- https://www.youtube.com/watch?v=MGsaAxrdhLA
 Referenced Tracks:
 - track:september-earth-wind-fire
 Sampled Tracks:
@@ -83,6 +88,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/survival
 # - https://music.deconreconstruction.com/albums/repiton?track=survival
+- https://www.youtube.com/watch?v=xQLgbUvyK_Q
 ---
 Track: Home
 Suffix Directory: true
@@ -92,6 +98,7 @@ Duration: '2:08'
 URLs:
 - https://vasterror.bandcamp.com/track/home
 # - https://music.deconreconstruction.com/albums/repiton?track=home
+- https://www.youtube.com/watch?v=1QLicLzdZUs
 ---
 Track: 'INTERMISSION: Risk'
 Directory: risk
@@ -100,6 +107,7 @@ Duration: '4:17'
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-risk
 # - https://music.deconreconstruction.com/albums/repiton?track=intermission-risk
+- https://www.youtube.com/watch?v=2wTjbu46_hE
 ---
 Track: Moonlight
 Suffix Directory: true
@@ -110,6 +118,7 @@ Duration: '3:01'
 URLs:
 - https://vasterror.bandcamp.com/track/moonlight
 # - https://music.deconreconstruction.com/albums/repiton?track=moonlight
+- https://www.youtube.com/watch?v=6gzdgiR1nx8
 ---
 Track: Through It All
 Cover Artists:
@@ -118,6 +127,7 @@ Duration: '4:37'
 URLs:
 - https://vasterror.bandcamp.com/track/through-it-all
 # - https://music.deconreconstruction.com/albums/repiton?track=through-it-all
+- https://www.youtube.com/watch?v=3nGf7bQTJNg
 ---
 Track: Tyrant
 Suffix Directory: true
@@ -129,6 +139,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/tyrant
 # - https://music.deconreconstruction.com/albums/repiton?track=tyrant
+- https://www.youtube.com/watch?v=6mLgwe5gu3g
 ---
 Track: Take The Shot
 Cover Artists:
@@ -139,6 +150,7 @@ Duration: '3:38'
 URLs:
 - https://vasterror.bandcamp.com/track/take-the-shot
 # - https://music.deconreconstruction.com/albums/repiton?track=take-the-shot
+- https://www.youtube.com/watch?v=EpF7yhxA0pA
 ---
 Track: Nailed It
 Cover Artists:
@@ -147,6 +159,7 @@ Duration: '3:22'
 URLs:
 - https://vasterror.bandcamp.com/track/nailed-it
 # - https://music.deconreconstruction.com/albums/repiton?track=nailed-it
+- https://www.youtube.com/watch?v=KLw6_2wtsaI
 ---
 Track: Remember?
 Suffix Directory: true
@@ -156,6 +169,7 @@ Duration: '3:10'
 URLs:
 - https://vasterror.bandcamp.com/track/remember
 # - https://music.deconreconstruction.com/albums/repiton?track=remember
+- https://www.youtube.com/watch?v=R5Rj5Sh0GSo
 ---
 Track: Promise
 Suffix Directory: true
@@ -167,6 +181,7 @@ Duration: '3:03'
 URLs:
 - https://vasterror.bandcamp.com/track/promise
 # - https://music.deconreconstruction.com/albums/repiton?track=promise
+- https://www.youtube.com/watch?v=C85-5CUgkTo
 ---
 Track: Only The Beginning
 Cover Artists:
@@ -177,6 +192,7 @@ Duration: '6:59'
 URLs:
 - https://vasterror.bandcamp.com/track/only-the-beginning
 # - https://music.deconreconstruction.com/albums/repiton?track=only-the-beginning
+- https://www.youtube.com/watch?v=yJZVKfDoK5s
 ---
 Section: Bonus track
 ---
@@ -194,3 +210,4 @@ Duration: '2:39'
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-where-to-now
 # - https://music.deconreconstruction.com/albums/repiton?track=bonus-where-to-now
+- https://www.youtube.com/watch?v=c_k3r4j3Iu4

--- a/album/running-for-eons.yaml
+++ b/album/running-for-eons.yaml
@@ -4,6 +4,7 @@ Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/running-for-eons
 # - https://music.deconreconstruction.com/albums/running-for-eons
+- https://www.youtube.com/playlist?list=PLBKFsSMpX3uu88_aPnzw06gmx54Fzw7Df
 Cover Artists:
 - tajazzled
 Cover Art File Extension: png
@@ -44,6 +45,7 @@ Sampled Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/deep-sea-trouble
 # - https://music.deconreconstruction.com/albums/running-for-eons?track=deep-sea-trouble
+- https://www.youtube.com/watch?v=1bwR-zNtdSg
 ---
 Track: Mind In The Shutter
 Artists:
@@ -64,6 +66,7 @@ Sampled Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/mind-in-the-shutter
 # - https://music.deconreconstruction.com/albums/running-for-eons?track=mind-in-the-shutter
+- https://www.youtube.com/watch?v=AmaluhM9FoU
 ---
 Track: Royale With Cheese
 Artists:
@@ -86,3 +89,4 @@ Sampled Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/royale-with-cheese
 # - https://music.deconreconstruction.com/albums/running-for-eons?track=royale-with-cheese
+- https://www.youtube.com/watch?v=ApO_fAt1dKQ

--- a/album/running-for-eons.yaml
+++ b/album/running-for-eons.yaml
@@ -3,7 +3,6 @@ Date: February 2, 2018
 Date Added: October 25, 2023
 URLs:
 - https://vasterror.bandcamp.com/album/running-for-eons
-# - https://music.deconreconstruction.com/albums/running-for-eons
 - https://www.youtube.com/playlist?list=PLBKFsSMpX3uu88_aPnzw06gmx54Fzw7Df
 Cover Artists:
 - tajazzled
@@ -44,7 +43,6 @@ Sampled Tracks:
 - Dialogue Fear and Loathing in Las Vegas
 URLs:
 - https://vasterror.bandcamp.com/track/deep-sea-trouble
-# - https://music.deconreconstruction.com/albums/running-for-eons?track=deep-sea-trouble
 - https://www.youtube.com/watch?v=1bwR-zNtdSg
 ---
 Track: Mind In The Shutter
@@ -65,7 +63,6 @@ Sampled Tracks:
 - Hanna-Barbera SFX
 URLs:
 - https://vasterror.bandcamp.com/track/mind-in-the-shutter
-# - https://music.deconreconstruction.com/albums/running-for-eons?track=mind-in-the-shutter
 - https://www.youtube.com/watch?v=AmaluhM9FoU
 ---
 Track: Royale With Cheese
@@ -88,5 +85,4 @@ Sampled Tracks:
 - Shinji's Rant from Neon Genesis Evangelion
 URLs:
 - https://vasterror.bandcamp.com/track/royale-with-cheese
-# - https://music.deconreconstruction.com/albums/running-for-eons?track=royale-with-cheese
 - https://www.youtube.com/watch?v=ApO_fAt1dKQ

--- a/album/unite-synchronization-breach-the-heavens-mix.yaml
+++ b/album/unite-synchronization-breach-the-heavens-mix.yaml
@@ -8,6 +8,7 @@ Cover Artists:
 - Ash Taylor
 Color: '#f2a400'
 Groups:
+- 8reath of light
 - Fandom
 Wallpaper Artists:
 - Ash Taylor
@@ -21,13 +22,13 @@ Wallpaper Style: |-
 Commentary: |-
     <i>Ash Taylor:</i> ([Bandcamp about blurb](https://8reath-of-light.bandcamp.com/track/unite-synchronization-breach-the-heavens-mix))
 
-    <code style="color: #f2a400">"I did not go through Hell just to die like  this."<br>
+    <p style="color: #f2a400">"I did not go through Hell just to die like this."<br>
     "I don't have to be perfect.<br>
-    I just have to be better than I was."</code>
+    I just have to be better than I was."</p>
 
     --------
 
-    made this in an afternoon after gf3.1 chapter 8 pt 2 came out. sarah how dare you make me root for dirk strider
+    made this in an afternoon after [gf3.1 chapter 8 pt 2](https://archiveofourown.org/works/22446544/chapters/79329385) came out. sarah how dare you make me root for dirk strider
 ---
 Track: Unite Synchronization (Breach the Heavens Mix)
 Duration: 2:45

--- a/album/vast-error-vol-1-3.yaml
+++ b/album/vast-error-vol-1-3.yaml
@@ -10,7 +10,6 @@ Wallpaper Artists:
 - artist:kobacat
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-1-3
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3
 Cover Artists:
 - Sparaze
 - Joyfulldreams
@@ -30,7 +29,6 @@ Cover Artists:
 Duration: '01:12'
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=the-static
 ---
 Track: Curtain Call
 Originally Released As: Curtain Call
@@ -39,7 +37,6 @@ Cover Artists:
 Duration: '01:37'
 URLs:
 - https://vasterror.bandcamp.com/track/curtain-call-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=curtain-call
 ---
 Track: Blood Right
 Originally Released As: Blood Right
@@ -48,7 +45,6 @@ Cover Artists:
 Duration: '03:35'
 URLs:
 - https://vasterror.bandcamp.com/track/blood-right-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=blood-right
 ---
 Track: Cosmic Significance
 Originally Released As: Cosmic Significance
@@ -57,7 +53,6 @@ Cover Artists:
 Duration: '03:53'
 URLs:
 - https://vasterror.bandcamp.com/track/cosmic-significance-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=cosmic-significance
 ---
 Track: Star Children
 Originally Released As: Star Children
@@ -66,7 +61,6 @@ Cover Artists:
 Duration: '03:37'
 URLs:
 - https://vasterror.bandcamp.com/track/star-children-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=star-children
 ---
 Track: A New World
 Originally Released As: A New World
@@ -75,7 +69,6 @@ Cover Artists:
 Duration: '01:42'
 URLs:
 - https://vasterror.bandcamp.com/track/a-new-world-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=a-new-world
 ---
 Track: Razzmatazz
 Originally Released As: Razzmatazz
@@ -84,7 +77,6 @@ Cover Artists:
 Duration: '02:16'
 URLs:
 - https://vasterror.bandcamp.com/track/razzmatazz-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=razzmatazz
 ---
 Track: Mammory Master
 Originally Released As: Mammory Master
@@ -93,7 +85,6 @@ Cover Artists:
 Duration: '01:45'
 URLs:
 - https://vasterror.bandcamp.com/track/mammory-master-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mammory-master
 ---
 Track: Striving For A Future
 Originally Released As: Striving For A Future
@@ -104,7 +95,6 @@ Art Tags:
 Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/striving-for-a-future-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=striving-for-a-future
 ---
 Track: A Very Active Imagination
 Originally Released As: A Very Active Imagination
@@ -113,7 +103,6 @@ Cover Artists:
 Duration: '03:38'
 URLs:
 - https://vasterror.bandcamp.com/track/a-very-active-imagination-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=a-very-active-imagination
 ---
 Track: Bias
 Originally Released As: track:bias-vast-error
@@ -122,7 +111,6 @@ Cover Artists:
 Duration: '03:00'
 URLs:
 - https://vasterror.bandcamp.com/track/bias-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=bias
 ---
 Track: Six By Six
 Originally Released As: Six By Six
@@ -131,7 +119,6 @@ Cover Artists:
 Duration: '02:48'
 URLs:
 - https://vasterror.bandcamp.com/track/six-by-six-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=six-by-six
 ---
 Track: Ferocity Weaving
 Originally Released As: Ferocity Weaving
@@ -140,7 +127,6 @@ Cover Artists:
 Duration: '05:02'
 URLs:
 - https://vasterror.bandcamp.com/track/ferocity-weaving-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=ferocity-weaving
 ---
 Track: Radioactive Ore
 Originally Released As: Radioactive Ore
@@ -151,7 +137,6 @@ Art Tags:
 Duration: '02:36'
 URLs:
 - https://vasterror.bandcamp.com/track/radioactive-ore-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=radioactive-ore
 ---
 Track: Starry Night
 Originally Released As: Starry Night
@@ -160,7 +145,6 @@ Cover Artists:
 Duration: '01:37'
 URLs:
 - https://vasterror.bandcamp.com/track/starry-night-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=starry-night
 ---
 Track: Clamor
 Directory: clamor-vast-error
@@ -173,7 +157,6 @@ Cover Artists:
 Duration: '01:53'
 URLs:
 - https://vasterror.bandcamp.com/track/clamor-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=clamor
 Referenced Tracks:
 - Sortir
 ---
@@ -184,7 +167,6 @@ Cover Artists:
 Duration: '01:40'
 URLs:
 - https://vasterror.bandcamp.com/track/song-for-the-lost-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=song-for-the-lost
 ---
 Track: Woof-
 Originally Released As: Woof-
@@ -193,7 +175,6 @@ Cover Artists:
 Duration: '03:17'
 URLs:
 - https://vasterror.bandcamp.com/track/woof-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=woof-
 ---
 Track: Sunrise
 Originally Released As: track:sunrise-vast-error
@@ -202,7 +183,6 @@ Cover Artists:
 Duration: '03:18'
 URLs:
 - https://vasterror.bandcamp.com/track/sunrise-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sunrise
 ---
 Track: J-Jitterbug
 Originally Released As: J-Jitterbug
@@ -211,7 +191,6 @@ Cover Artists:
 Duration: '02:00'
 URLs:
 - https://vasterror.bandcamp.com/track/j-jitterbug-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=j-jitterbug
 ---
 Track: Extra Worse
 Originally Released As: Extra Worse
@@ -220,7 +199,6 @@ Cover Artists:
 Duration: '01:44'
 URLs:
 - https://vasterror.bandcamp.com/track/extra-worse-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=extra-worse
 ---
 Track: On Repeat
 Originally Released As: On Repeat (Intermission)
@@ -229,7 +207,6 @@ Cover Artists:
 Duration: '02:14'
 URLs:
 - https://vasterror.bandcamp.com/track/on-repeat
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=on-repeat
 ---
 Track: Commercial Break
 Originally Released As: Commercial Break
@@ -238,14 +215,12 @@ Cover Artists:
 Duration: '03:20'
 URLs:
 - https://vasterror.bandcamp.com/track/commercial-break-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=commercial-break
 ---
 Track: 'INTERMISSION: Beyond The Wall'
 Originally Released As: Beyond the Wall (Intermission)
 Duration: '03:13'
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-beyond-the-wall-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=intermission-beyond-the-wall
 ---
 Track: Third Eye
 Originally Released As: Third Eye
@@ -256,7 +231,6 @@ Art Tags:
 Duration: '02:25'
 URLs:
 - https://vasterror.bandcamp.com/track/third-eye-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=third-eye
 ---
 Track: Oversaturated
 Originally Released As: track:oversaturated-vast-error
@@ -265,7 +239,6 @@ Cover Artists:
 Duration: '04:27'
 URLs:
 - https://vasterror.bandcamp.com/track/oversaturated-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=oversaturated
 ---
 Track: Paint The Town Black
 Originally Released As: Paint The Town Black
@@ -274,7 +247,6 @@ Cover Artists:
 Duration: '02:59'
 URLs:
 - https://vasterror.bandcamp.com/track/paint-the-town-black-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=paint-the-town-black
 ---
 Track: Final Bow
 Originally Released As: Final Bow
@@ -283,7 +255,6 @@ Cover Artists:
 Duration: '02:10'
 URLs:
 - https://vasterror.bandcamp.com/track/final-bow-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=final-bow
 ---
 Track: You'd Do It For Randolph Scott
 Originally Released As: You'd Do It For Randolph Scott
@@ -292,7 +263,6 @@ Cover Artists:
 Duration: '01:36'
 URLs:
 - https://vasterror.bandcamp.com/track/youd-do-it-for-randolph-scott-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=youd-do-it-for-randolph-scott
 ---
 Track: Alone In The Rain
 Originally Released As: Alone In The Rain
@@ -301,7 +271,6 @@ Cover Artists:
 Duration: '03:53'
 URLs:
 - https://vasterror.bandcamp.com/track/alone-in-the-rain-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=alone-in-the-rain
 ---
 Track: Poetic
 Originally Released As: track:poetic-vast-error
@@ -310,7 +279,6 @@ Cover Artists:
 Duration: '02:07'
 URLs:
 - https://vasterror.bandcamp.com/track/poetic-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=poetic
 ---
 Track: Zehanpuryu
 Originally Released As: Zehanpuryu
@@ -319,7 +287,6 @@ Cover Artists:
 Duration: '02:25'
 URLs:
 - https://vasterror.bandcamp.com/track/zehanpuryu-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=zehanpuryu
 ---
 Track: Revelations
 Originally Released As: track:revelations-vast-error
@@ -328,7 +295,6 @@ Cover Artists:
 Duration: '02:21'
 URLs:
 - https://vasterror.bandcamp.com/track/revelations
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=revelations
 ---
 Track: The Day After Spring Began
 Originally Released As: The Day After Spring Began
@@ -337,7 +303,6 @@ Cover Artists:
 Duration: '03:00'
 URLs:
 - https://vasterror.bandcamp.com/track/the-day-after-spring-began-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=the-day-after-spring-began
 ---
 Track: Terran Wanderer
 Originally Released As: Terran Wanderer
@@ -346,7 +311,6 @@ Cover Artists:
 Duration: '02:13'
 URLs:
 - https://vasterror.bandcamp.com/track/terran-wanderer-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=terran-wanderer
 ---
 Track: Invigorated Wasteland
 Originally Released As: Invigorated Wasteland
@@ -355,7 +319,6 @@ Cover Artists:
 Duration: '02:24'
 URLs:
 - https://vasterror.bandcamp.com/track/invigorated-wasteland-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=invigorated-wasteland
 ---
 Track: Scarred For Life
 Originally Released As: Scarred For Life
@@ -364,7 +327,6 @@ Cover Artists:
 Duration: '02:30'
 URLs:
 - https://vasterror.bandcamp.com/track/scarred-for-life-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=scarred-for-life
 ---
 Track: Curtain Call (psithurist's "the game isn't sgrub" remix)
 Directory: curtain-call-remix # suffixed
@@ -374,7 +336,6 @@ Cover Artists:
 Duration: '02:26'
 URLs:
 - https://vasterror.bandcamp.com/track/curtain-call-psithurists-the-game-isnt-sgrub-remix-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=curtain-call-psithurists-the-game-isnt-sgrub-remix
 ---
 Track: Polkafighter!
 Originally Released As: Polkafighter!
@@ -383,7 +344,6 @@ Cover Artists:
 Duration: '01:22'
 URLs:
 - https://vasterror.bandcamp.com/track/polkafighter-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=polkafighter
 ---
 Track: Mantle Piece
 Originally Released As: Mantle Piece
@@ -392,7 +352,6 @@ Cover Artists:
 Duration: '04:28'
 URLs:
 - https://vasterror.bandcamp.com/track/mantle-piece-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mantle-piece
 ---
 Track: Mother Of The Stars
 Originally Released As: Mother Of The Stars
@@ -401,7 +360,6 @@ Cover Artists:
 Duration: '02:26'
 URLs:
 - https://vasterror.bandcamp.com/track/mother-of-the-stars-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=mother-of-the-stars
 ---
 Track: Sickly Green Glow
 Originally Released As: Sickly Green Glow
@@ -410,7 +368,6 @@ Cover Artists:
 Duration: '02:42'
 URLs:
 - https://vasterror.bandcamp.com/track/sickly-green-glow-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sickly-green-glow
 ---
 Track: Waltz In The Static Void
 Originally Released As: Waltz In The Static Void
@@ -419,7 +376,6 @@ Cover Artists:
 Duration: '01:54'
 URLs:
 - https://vasterror.bandcamp.com/track/waltz-in-the-static-void-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=waltz-in-the-static-void
 ---
 Track: Code Red And Existential Dread
 Originally Released As: Code Red And Existential Dread
@@ -428,7 +384,6 @@ Cover Artists:
 Duration: '04:06'
 URLs:
 - https://vasterror.bandcamp.com/track/code-red-and-existential-dread-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=code-red-and-existential-dread
 ---
 Track: Sortir
 Originally Released As: Sortir
@@ -437,7 +392,6 @@ Cover Artists:
 Duration: '03:46'
 URLs:
 - https://vasterror.bandcamp.com/track/sortir-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=sortir
 ---
 Track: Vast Error
 Originally Released As: Vast Error
@@ -446,7 +400,6 @@ Cover Artists:
 Duration: '04:08'
 URLs:
 - https://vasterror.bandcamp.com/track/vast-error-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=vast-error
 ---
 Track: Ultima Hoc Fatum
 Originally Released As: Ultima Hoc Fatum
@@ -455,7 +408,6 @@ Cover Artists:
 Duration: '06:09'
 URLs:
 - https://vasterror.bandcamp.com/track/ultima-hoc-fatum-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=ultima-hoc-fatum
 ---
 Track: Gone
 Originally Released As: track:gone-vast-error
@@ -464,7 +416,6 @@ Cover Artists:
 Duration: '02:34'
 URLs:
 - https://vasterror.bandcamp.com/track/gone
-# - https://music.deconreconstruction.com/albums/vast-error-vol-1-3?track=gone
 ---
 Section: Download-only tracks
 ---

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -11,6 +11,7 @@ Banner File Extension: jpg
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-4
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4
+- https://www.youtube.com/playlist?list=PLnVpmehyaOFYxlJDVeVL0O5pq_vplBITl
 Cover Artists:
 - TetraTheRipper
 Cover Art File Extension: png

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -33,6 +33,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/nostalgia
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nostalgia
+- https://www.youtube.com/watch?v=F9cXP0627N8
 ---
 Track: Road To Recovery
 Duration: '3:27'
@@ -43,6 +44,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/road-to-recovery
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=road-to-recovery
+- https://www.youtube.com/watch?v=uTdkuRwZgCg
 Commentary: |-
     <i>Xamag:</i> (track artist, alternate artwork)
 
@@ -59,6 +61,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/immortal
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=immortal
+- https://www.youtube.com/watch?v=z4-2S9RrGHw
 ---
 Track: Air Exchange
 Duration: '3:34'
@@ -72,6 +75,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/air-exchange
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=air-exchange
+- https://www.youtube.com/watch?v=pJd46EME9ik
 ---
 Track: Radical Statical
 Duration: '2:37'
@@ -84,6 +88,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/radical-statical
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=radical-statical
+- https://www.youtube.com/watch?v=R3sTjHC0iQM
 ---
 Track: Predestination
 Directory: predestination-vast-error
@@ -99,6 +104,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/predestination
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=predestination
+- https://www.youtube.com/watch?v=aAdtCr4auCo
 ---
 Track: Corporate
 Directory: corporate-vast-error
@@ -111,6 +117,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/corporate
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=corporate
+- https://www.youtube.com/watch?v=DJoN7Y8CIQk
 ---
 Track: The Crucible
 Duration: '2:19'
@@ -121,6 +128,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/the-crucible
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=the-crucible
+- https://www.youtube.com/watch?v=eKTQrv6jWfc
 ---
 Track: LC Rains
 Duration: '2:13'
@@ -131,6 +139,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/lc-rains
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=lc-rains
+- https://www.youtube.com/watch?v=GX-HZBIPQx0
 ---
 Track: Secure
 Directory: secure-vast-error
@@ -142,6 +151,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/secure
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=secure
+- https://www.youtube.com/watch?v=i_pyy9eM8CQ
 ---
 Track: Gravitational Pull
 Duration: '2:36'
@@ -152,6 +162,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/gravitational-pull
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=gravitational-pull
+- https://www.youtube.com/watch?v=_nUME3dZvx8
 ---
 Track: Solana
 Duration: '2:30'
@@ -162,6 +173,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/solana
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solana
+- https://www.youtube.com/watch?v=MGeXMFROMUs
 ---
 Track: 'INTERMISSION: Ever Closer'
 Directory: ever-closer
@@ -173,6 +185,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-ever-closer
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=intermission-ever-closer
+- https://www.youtube.com/watch?v=he76OBSMJo4
 ---
 Track: Trial By Fire
 Duration: '4:20'
@@ -183,6 +196,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/trial-by-fire
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=trial-by-fire
+- https://www.youtube.com/watch?v=951fcKeUh34
 ---
 Track: My Protective Light
 Duration: '2:51'
@@ -193,6 +207,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/my-protective-light
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=my-protective-light
+- https://www.youtube.com/watch?v=ghi4SJS9JdI
 ---
 Track: It's Alive
 Duration: '2:05'
@@ -205,6 +220,7 @@ Art Tags:
 URLs:
 - https://vasterror.bandcamp.com/track/its-alive
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=its-alive
+- https://www.youtube.com/watch?v=pr2TIC7_T3A
 ---
 Track: Disenchanted
 Duration: '3:26'
@@ -222,6 +238,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/disenchanted
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=disenchanted
+- https://www.youtube.com/watch?v=z0EvWgGdhc4
 ---
 Track: Nebula
 Directory: nebula-vast-error
@@ -233,6 +250,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/nebula
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nebula
+- https://www.youtube.com/watch?v=i8zzfd423h4
 ---
 Track: Cheap (Boxed Wine)
 Duration: '3:17'
@@ -247,6 +265,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/cheap-boxed-wine
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=cheap-boxed-wine
+- https://www.youtube.com/watch?v=RMeMCe68MLs
 ---
 Track: Expanse Of All
 Duration: '3:00'
@@ -257,6 +276,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/expanse-of-all
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=expanse-of-all
+- https://www.youtube.com/watch?v=9QiJ2ugdWmc
 ---
 Track: Indefinite Progress
 Duration: '2:38'
@@ -267,6 +287,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/indefinite-progress
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=indefinite-progress
+- https://www.youtube.com/watch?v=NwINque1-EA
 ---
 Track: Refutation
 Directory: refutation-vast-error
@@ -280,6 +301,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/refutation
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=refutation
+- https://www.youtube.com/watch?v=y8JVZ5YCH2o
 ---
 Track: Furbish
 Duration: '2:43'
@@ -290,6 +312,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/furbish
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=furbish
+- https://www.youtube.com/watch?v=rzd58vqDIvI
 ---
 Track: Be All End All
 Duration: '2:06'
@@ -300,6 +323,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/be-all-end-all
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=be-all-end-all
+- https://www.youtube.com/watch?v=E0yg37MiCvs
 Commentary: |-
     <i>Deer:</i> (track artist, alternate artwork)
 
@@ -315,6 +339,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/solidarity
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solidarity
+- https://www.youtube.com/watch?v=CaKEqOMlNCw
 ---
 Track: Aortian Embrace
 Duration: '3:56'
@@ -325,6 +350,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/aortian-embrace
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=aortian-embrace
+- https://www.youtube.com/watch?v=ABbSvChHBDg
 ---
 Track: Fine With You
 Duration: '3:10'
@@ -334,6 +360,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/fine-with-you
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=fine-with-you
+- https://www.youtube.com/watch?v=Ba0s69GmNtA
 ---
 Track: One Step Forward
 Duration: '4:17'
@@ -344,6 +371,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/one-step-forward
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=one-step-forward
+- https://www.youtube.com/watch?v=uOg72SiUDbw
 ---
 Track: Soul Shaded
 Duration: '2:18'
@@ -354,6 +382,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/soul-shaded
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=soul-shaded
+- https://www.youtube.com/watch?v=gdZOm85AfDI
 ---
 Track: A Flesh Cage Of Emotion
 Duration: '3:00'
@@ -366,6 +395,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/a-flesh-cage-of-emotion
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=a-flesh-cage-of-emotion
+- https://www.youtube.com/watch?v=eJm31GI-c9g
 ---
 Track: Oversaturated (Elevator Mix)
 Duration: '0:49'
@@ -378,6 +408,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/oversaturated-elevator-mix
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=oversaturated-elevator-mix
+- https://www.youtube.com/watch?v=7wqx7-LnaDU
 ---
 Track: Good Old Hornless Jerryatric
 Duration: '2:29'
@@ -388,6 +419,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/good-old-hornless-jerryatric
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=good-old-hornless-jerryatric
+- https://www.youtube.com/watch?v=XyT1XzSFWQY
 ---
 Track: Chamber Cultist
 Duration: '2:32'
@@ -400,6 +432,7 @@ Art Tags:
 URLs:
 - https://vasterror.bandcamp.com/track/chamber-cultist
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=chamber-cultist
+- https://www.youtube.com/watch?v=CWnPOxICW3o
 ---
 Track: Transmuted
 Directory: transmuted-vast-error
@@ -416,6 +449,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/transmuted
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=transmuted
+- https://www.youtube.com/watch?v=3ktSsd_zje8
 ---
 Track: Farewell But Not Goodbye
 Duration: '4:24'
@@ -426,6 +460,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/farewell-but-not-goodbye
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=farewell-but-not-goodbye
+- https://www.youtube.com/watch?v=pe8A-B1gr4c
 ---
 Track: Pandora
 Directory: pandora-vast-error
@@ -447,6 +482,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/pandora
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=pandora
+- https://www.youtube.com/watch?v=XbNNBagSqPo
 ---
 Track: Bittersweet
 Directory: bittersweet-vast-error
@@ -458,6 +494,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bittersweet
+- https://www.youtube.com/watch?v=wPW65crQce0
 ---
 Section: Bonus tracks
 ---
@@ -480,6 +517,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-nothing-special
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-nothing-special
+- https://www.youtube.com/watch?v=qrBP_OQDLM4
 ---
 Track: Twelve By Twelve
 Additional Names:
@@ -501,6 +539,7 @@ Referenced Tracks:
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-twelve-by-twelve
 # - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-twelve-by-twelve
+- https://www.youtube.com/watch?v=OuTBY3_GdRc
 ---
 Section: Download-only tracks
 ---

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -10,7 +10,6 @@ Banner Dimensions: 1100x216
 Banner File Extension: jpg
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-4
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFYxlJDVeVL0O5pq_vplBITl
 Cover Artists:
 - TetraTheRipper
@@ -33,7 +32,6 @@ Cover Artists:
 - big chalupa
 URLs:
 - https://vasterror.bandcamp.com/track/nostalgia
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nostalgia
 - https://www.youtube.com/watch?v=F9cXP0627N8
 ---
 Track: Road To Recovery
@@ -44,7 +42,6 @@ Cover Artists:
 - Xamag
 URLs:
 - https://vasterror.bandcamp.com/track/road-to-recovery
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=road-to-recovery
 - https://www.youtube.com/watch?v=uTdkuRwZgCg
 Commentary: |-
     <i>Xamag:</i> (track artist, alternate artwork)
@@ -61,7 +58,6 @@ Cover Artists:
 - SilentNeptune
 URLs:
 - https://vasterror.bandcamp.com/track/immortal
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=immortal
 - https://www.youtube.com/watch?v=z4-2S9RrGHw
 ---
 Track: Air Exchange
@@ -75,7 +71,6 @@ Referenced Tracks:
 - Zehanpuryu
 URLs:
 - https://vasterror.bandcamp.com/track/air-exchange
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=air-exchange
 - https://www.youtube.com/watch?v=pJd46EME9ik
 ---
 Track: Radical Statical
@@ -88,7 +83,6 @@ Referenced Tracks:
 - Mammory Master
 URLs:
 - https://vasterror.bandcamp.com/track/radical-statical
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=radical-statical
 - https://www.youtube.com/watch?v=R3sTjHC0iQM
 ---
 Track: Predestination
@@ -104,7 +98,6 @@ Referenced Tracks:
 - A New Day
 URLs:
 - https://vasterror.bandcamp.com/track/predestination
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=predestination
 - https://www.youtube.com/watch?v=aAdtCr4auCo
 ---
 Track: Corporate
@@ -117,7 +110,6 @@ Cover Artists:
 - Spruik
 URLs:
 - https://vasterror.bandcamp.com/track/corporate
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=corporate
 - https://www.youtube.com/watch?v=DJoN7Y8CIQk
 ---
 Track: The Crucible
@@ -128,7 +120,6 @@ Cover Artists:
 - groeuf
 URLs:
 - https://vasterror.bandcamp.com/track/the-crucible
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=the-crucible
 - https://www.youtube.com/watch?v=eKTQrv6jWfc
 ---
 Track: LC Rains
@@ -139,7 +130,6 @@ Cover Artists:
 - Xamag
 URLs:
 - https://vasterror.bandcamp.com/track/lc-rains
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=lc-rains
 - https://www.youtube.com/watch?v=GX-HZBIPQx0
 ---
 Track: Secure
@@ -151,7 +141,6 @@ Cover Artists:
 - groeuf
 URLs:
 - https://vasterror.bandcamp.com/track/secure
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=secure
 - https://www.youtube.com/watch?v=i_pyy9eM8CQ
 ---
 Track: Gravitational Pull
@@ -162,7 +151,6 @@ Cover Artists:
 - falthiere
 URLs:
 - https://vasterror.bandcamp.com/track/gravitational-pull
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=gravitational-pull
 - https://www.youtube.com/watch?v=_nUME3dZvx8
 ---
 Track: Solana
@@ -173,7 +161,6 @@ Cover Artists:
 - Circlejourney
 URLs:
 - https://vasterror.bandcamp.com/track/solana
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solana
 - https://www.youtube.com/watch?v=MGeXMFROMUs
 ---
 Track: 'INTERMISSION: Ever Closer'
@@ -185,7 +172,6 @@ Cover Artists:
 - Vast Error
 URLs:
 - https://vasterror.bandcamp.com/track/intermission-ever-closer
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=intermission-ever-closer
 - https://www.youtube.com/watch?v=he76OBSMJo4
 ---
 Track: Trial By Fire
@@ -196,7 +182,6 @@ Cover Artists:
 - banavalope
 URLs:
 - https://vasterror.bandcamp.com/track/trial-by-fire
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=trial-by-fire
 - https://www.youtube.com/watch?v=951fcKeUh34
 ---
 Track: My Protective Light
@@ -207,7 +192,6 @@ Cover Artists:
 - Captainquestion
 URLs:
 - https://vasterror.bandcamp.com/track/my-protective-light
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=my-protective-light
 - https://www.youtube.com/watch?v=ghi4SJS9JdI
 ---
 Track: It's Alive
@@ -220,7 +204,6 @@ Art Tags:
 - 'cw: blood (abstract)'
 URLs:
 - https://vasterror.bandcamp.com/track/its-alive
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=its-alive
 - https://www.youtube.com/watch?v=pr2TIC7_T3A
 ---
 Track: Disenchanted
@@ -238,7 +221,6 @@ Referenced Tracks:
 - Seal It Over
 URLs:
 - https://vasterror.bandcamp.com/track/disenchanted
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=disenchanted
 - https://www.youtube.com/watch?v=z0EvWgGdhc4
 ---
 Track: Nebula
@@ -250,7 +232,6 @@ Cover Artists:
 - Chumi
 URLs:
 - https://vasterror.bandcamp.com/track/nebula
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=nebula
 - https://www.youtube.com/watch?v=i8zzfd423h4
 ---
 Track: Cheap (Boxed Wine)
@@ -265,7 +246,6 @@ Referenced Tracks:
 - track:oversaturated-vast-error
 URLs:
 - https://vasterror.bandcamp.com/track/cheap-boxed-wine
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=cheap-boxed-wine
 - https://www.youtube.com/watch?v=RMeMCe68MLs
 ---
 Track: Expanse Of All
@@ -276,7 +256,6 @@ Cover Artists:
 - Cristata
 URLs:
 - https://vasterror.bandcamp.com/track/expanse-of-all
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=expanse-of-all
 - https://www.youtube.com/watch?v=9QiJ2ugdWmc
 ---
 Track: Indefinite Progress
@@ -287,7 +266,6 @@ Cover Artists:
 - Aeritus
 URLs:
 - https://vasterror.bandcamp.com/track/indefinite-progress
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=indefinite-progress
 - https://www.youtube.com/watch?v=NwINque1-EA
 ---
 Track: Refutation
@@ -301,7 +279,6 @@ Referenced Tracks:
 - Scarred For Life
 URLs:
 - https://vasterror.bandcamp.com/track/refutation
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=refutation
 - https://www.youtube.com/watch?v=y8JVZ5YCH2o
 ---
 Track: Furbish
@@ -312,7 +289,6 @@ Cover Artists:
 - anemonta
 URLs:
 - https://vasterror.bandcamp.com/track/furbish
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=furbish
 - https://www.youtube.com/watch?v=rzd58vqDIvI
 ---
 Track: Be All End All
@@ -323,7 +299,6 @@ Cover Artists:
 - Deer
 URLs:
 - https://vasterror.bandcamp.com/track/be-all-end-all
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=be-all-end-all
 - https://www.youtube.com/watch?v=E0yg37MiCvs
 Commentary: |-
     <i>Deer:</i> (track artist, alternate artwork)
@@ -339,7 +314,6 @@ Cover Artists:
 - yorozuya
 URLs:
 - https://vasterror.bandcamp.com/track/solidarity
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=solidarity
 - https://www.youtube.com/watch?v=CaKEqOMlNCw
 ---
 Track: Aortian Embrace
@@ -350,7 +324,6 @@ Cover Artists:
 - Cristata
 URLs:
 - https://vasterror.bandcamp.com/track/aortian-embrace
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=aortian-embrace
 - https://www.youtube.com/watch?v=ABbSvChHBDg
 ---
 Track: Fine With You
@@ -360,7 +333,6 @@ Cover Artists:
 - falthiere
 URLs:
 - https://vasterror.bandcamp.com/track/fine-with-you
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=fine-with-you
 - https://www.youtube.com/watch?v=Ba0s69GmNtA
 ---
 Track: One Step Forward
@@ -371,7 +343,6 @@ Cover Artists:
 - Greaserparty
 URLs:
 - https://vasterror.bandcamp.com/track/one-step-forward
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=one-step-forward
 - https://www.youtube.com/watch?v=uOg72SiUDbw
 ---
 Track: Soul Shaded
@@ -382,7 +353,6 @@ Cover Artists:
 - Deer
 URLs:
 - https://vasterror.bandcamp.com/track/soul-shaded
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=soul-shaded
 - https://www.youtube.com/watch?v=gdZOm85AfDI
 ---
 Track: A Flesh Cage Of Emotion
@@ -395,7 +365,6 @@ Referenced Tracks:
 - Solana
 URLs:
 - https://vasterror.bandcamp.com/track/a-flesh-cage-of-emotion
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=a-flesh-cage-of-emotion
 - https://www.youtube.com/watch?v=eJm31GI-c9g
 ---
 Track: Oversaturated (Elevator Mix)
@@ -408,7 +377,6 @@ Referenced Tracks:
 - track:oversaturated-vast-error
 URLs:
 - https://vasterror.bandcamp.com/track/oversaturated-elevator-mix
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=oversaturated-elevator-mix
 - https://www.youtube.com/watch?v=7wqx7-LnaDU
 ---
 Track: Good Old Hornless Jerryatric
@@ -419,7 +387,6 @@ Cover Artists:
 - Cereovo
 URLs:
 - https://vasterror.bandcamp.com/track/good-old-hornless-jerryatric
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=good-old-hornless-jerryatric
 - https://www.youtube.com/watch?v=XyT1XzSFWQY
 ---
 Track: Chamber Cultist
@@ -432,7 +399,6 @@ Art Tags:
 - 'cw: blood'
 URLs:
 - https://vasterror.bandcamp.com/track/chamber-cultist
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=chamber-cultist
 - https://www.youtube.com/watch?v=CWnPOxICW3o
 ---
 Track: Transmuted
@@ -449,7 +415,6 @@ Referenced Tracks:
 - Risingson
 URLs:
 - https://vasterror.bandcamp.com/track/transmuted
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=transmuted
 - https://www.youtube.com/watch?v=3ktSsd_zje8
 ---
 Track: Farewell But Not Goodbye
@@ -460,7 +425,6 @@ Cover Artists:
 - SilentNeptune
 URLs:
 - https://vasterror.bandcamp.com/track/farewell-but-not-goodbye
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=farewell-but-not-goodbye
 - https://www.youtube.com/watch?v=pe8A-B1gr4c
 ---
 Track: Pandora
@@ -482,7 +446,6 @@ Referenced Tracks:
 - Solana
 URLs:
 - https://vasterror.bandcamp.com/track/pandora
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=pandora
 - https://www.youtube.com/watch?v=XbNNBagSqPo
 ---
 Track: Bittersweet
@@ -494,7 +457,6 @@ Cover Artists:
 - big chalupa
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bittersweet
 - https://www.youtube.com/watch?v=wPW65crQce0
 ---
 Section: Bonus tracks
@@ -517,7 +479,6 @@ Cover Artists:
 - Vast Error
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-nothing-special
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-nothing-special
 - https://www.youtube.com/watch?v=qrBP_OQDLM4
 ---
 Track: Twelve By Twelve
@@ -539,7 +500,6 @@ Referenced Tracks:
 - Six By Six
 URLs:
 - https://vasterror.bandcamp.com/track/bonus-twelve-by-twelve
-# - https://music.deconreconstruction.com/albums/vast-error-vol-4?track=bonus-twelve-by-twelve
 - https://www.youtube.com/watch?v=OuTBY3_GdRc
 ---
 Section: Download-only tracks

--- a/album/vast-error-vol-5-side-1.yaml
+++ b/album/vast-error-vol-5-side-1.yaml
@@ -3,7 +3,6 @@ Date: September 05, 2022
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-5-side-1
-# - https://music.deconreconstruction.com/albums/vast-error-vol-5-side-1
 Cover Artists:
 - Tyson Northcutt
 Cover Art File Extension: png

--- a/album/vast-error-vol-5-side-2.yaml
+++ b/album/vast-error-vol-5-side-2.yaml
@@ -3,7 +3,6 @@ Date: September 12, 2022
 Date Added: April 13, 2024
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-5-side-2
-# - https://music.deconreconstruction.com/albums/vast-error-vol-5-side-2
 Cover Artists:
 - Tyson Northcutt
 Cover Art File Extension: png

--- a/artists.yaml
+++ b/artists.yaml
@@ -2703,6 +2703,8 @@ Artist: Dan Tyminski
 ---
 Artist: Dana Smart
 ---
+Artist: Dana Straten
+---
 Artist: Danganronpa
 ---
 Artist: Danger Mouse

--- a/artists.yaml
+++ b/artists.yaml
@@ -13040,6 +13040,7 @@ URLs:
 - https://twitter.com/djterezizone
 Dead URLs:
 - https://twitter.com/AUTlSMSHAWTY #migrated to djterezizone
+---
 Artist: doctoroftime
 ---
 Artist: dodostad

--- a/artists.yaml
+++ b/artists.yaml
@@ -1552,12 +1552,21 @@ Dead URLs:
 - https://www.patreon.com/thatsnarkydragon
 ---
 Artist: bright0n
+Aliases:
+- LiquidVoid
+- Liquid Void
+- DJLiquidVoid
+- M△LLYN
 URLs:
 - https://bright0nsounds.bandcamp.com/
 - https://open.spotify.com/artist/5l7yzVBPFLfLxmWDrJBJHL
 - https://soundcloud.com/bright0nsounds
+- https://mvllyn.bandcamp.com/
+- https://djliquidvoid.newgrounds.com
 Dead URLs:
 - https://twitter.com/blazebrxghton_
+- https://liquidvoidmusic.bandcamp.com/ #old Bandcamp URL of M△LLYN bandcamp, says "LV (RENAMED TO M△LLYN)" in the tab name upon access
+- https://liquidvoidmusic.tumblr.com
 ---
 Artist: Bring Me The Horizon
 ---
@@ -6568,8 +6577,6 @@ URLs:
 - https://liqxid.carrd.co/
 Dead URLs:
 - https://vrissprites.tumblr.com/
----
-Artist: LiquidVoid
 ---
 Artist: Lira Yin
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -950,6 +950,17 @@ Aliases:
 - Dingaling
 - Widdly 2 Diddly
 ---
+Artist: Austin Lee Matthews
+Aliases:
+- amtrax
+URLs:
+- https://amtrax91.bandcamp.com/
+- https://www.youtube.com/@AMTRAX
+- https://bsky.app/profile/amtrax.bsky.social
+- https://amtrax.tumblr.com
+- https://www.austinleematthews.com
+- https://amtrax.carrd.co
+---
 Artist: Austinado
 URLs:
 - https://twitter.com/avstinado
@@ -12722,8 +12733,6 @@ URLs:
 Artist: All Time Low
 ---
 Artist: Alf Clausen
----
-Artist: amtrax
 ---
 Artist: angryoct
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -1700,6 +1700,7 @@ Aliases:
 - deathmetaljock
 - agonist
 - Julia
+- Julia Norza
 Dead URLs:
 - https://twitter.com/deathmetaljock
 ---
@@ -13031,6 +13032,8 @@ Dead URLs:
 - https://diolis.tumblr.com/
 ---
 Artist: dj terezi
+Aliases:
+- Ellie Tara
 URLs:
 - https://djterezi.bandcamp.com/
 - https://soundcloud.com/djt3r3z1

--- a/artists.yaml
+++ b/artists.yaml
@@ -13023,6 +13023,13 @@ Artist: diolis
 Dead URLs:
 - https://diolis.tumblr.com/
 ---
+Artist: dj terezi
+URLs:
+- https://djterezi.bandcamp.com/
+- https://soundcloud.com/djt3r3z1
+- https://twitter.com/djterezizone
+Dead URLs:
+- https://twitter.com/AUTlSMSHAWTY #migrated to djterezizone
 Artist: doctoroftime
 ---
 Artist: dodostad

--- a/artists.yaml
+++ b/artists.yaml
@@ -11924,6 +11924,11 @@ Artist: V
 Artist: V-6
 ---
 Artist: ValantWynn
+URLs:
+- https://valantwynn.tumblr.com
+- https://www.youtube.com/@valantwynn
+Dead URLs:
+- https://twitter.com/ValantWynn #locked
 ---
 Artist: valdotpng
 Aliases:

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -3303,6 +3303,15 @@ URLs:
 - https://www.deviantart.com/patmandx/art/S-Odi-Observe-408171946
 - https://mspfa.com/?s=988&p=806
 ---
+Flash: '[S] Plink: Strife!'
+Directory: plink-strife
+Date: April 26, 2014
+Featured Tracks:
+- track:resolve-loftlocked
+URLs:
+- https://www.deviantart.com/patmandx/art/S-Plink-Strife-450115910
+- https://mspfa.com/?s=988&p=945
+---
 Flash: '[S] Lisa: Enter.'
 Directory: lisa-enter
 Date: July 1, 2014
@@ -3321,6 +3330,54 @@ Featured Tracks:
 URLs:
 - https://www.deviantart.com/patmandx/art/Erica-Play-475730393
 - https://mspfa.com/?s=988&p=1130
+---
+Act: Freeroam
+Directory: freeroam
+Color: '#ff6305'
+---
+Flash: '[S] [FREEROAM]'
+Directory: freeroam
+Date: July 21, 2016
+Featured Tracks:
+- track:waiting-for-adventure-freeroam
+URLs:
+- https://mspfa.com/?s=14778&p=1
+---
+Flash: '[S] Arron: Jump.'
+Directory: arron-jump
+Date: December 6, 2016
+Featured Tracks:
+- Weight of the World
+URLs:
+- https://mspfa.com/?s=14778&p=192
+- https://www.youtube.com/watch?v=Q1p38biT7B8
+---
+Flash: '[S] Keira and Jason: Enter.'
+Directory: keira-and-jason-enter
+Date: July 21, 2017
+Featured Tracks:
+- track:breaking-FREE
+URLs:
+- https://mspfa.com/?s=14778&p=294
+- https://www.youtube.com/watch?v=G7CGgrOxf64
+---
+Flash: '[S] Your name is...'
+Directory: your-name-is
+Date: July 21, 2018
+Featured Tracks:
+- Iridescence on the Rise
+URLs:
+- https://mspfa.com/?s=14778&p=376
+- https://www.youtube.com/watch?v=rHCEAGKRMxA
+---
+Flash: '[S] Arron: Strife!'
+Directory: arron-strife
+Date: July 21, 2020
+Featured Tracks:
+- First Frenzy
+URLs:
+- https://mspfa.com/?s=14778&p=395
+- https://www.youtube.com/watch?v=zKZ2uofVh3E
 ---
 Act: Alternate Session
 Directory: alternate-session

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -3306,6 +3306,7 @@ URLs:
 Flash: '[S] Plink: Strife!'
 Directory: plink-strife
 Date: April 26, 2014
+Cover Art File Extension: png
 Featured Tracks:
 - track:resolve-loftlocked
 URLs:
@@ -3338,6 +3339,7 @@ Color: '#ff6305'
 Flash: '[S] [FREEROAM]'
 Directory: freeroam
 Date: July 21, 2016
+Cover Art File Extension: png
 Featured Tracks:
 - track:waiting-for-adventure-freeroam
 URLs:

--- a/groups.yaml
+++ b/groups.yaml
@@ -604,7 +604,6 @@ URLs:
 - https://vasterror.bandcamp.com/
 - https://twitter.com/Deconrecon_
 - https://www.deconreconstruction.com/
-# - https://music.deconreconstruction.com/
 Series:
 - Name: Numbered volumes
   Albums:

--- a/groups.yaml
+++ b/groups.yaml
@@ -647,7 +647,9 @@ URLs:
 - https://mspfa.com/?s=14778
 - https://freeroamfanventure.bandcamp.com/
 Description: |-
-    To-do description! Wow, this is tough.
+    For a group of nine friends, a familiar game puts all that they love in jeopardy and together they must forge a path to success while pulling away at the curtains of a grander mystery that threatens their chances for victory.
+    <hr class="split">
+    Fanventure by [[artist:valentwynn]], updating from 2016 through 2020; [[flash:arron-strife|the latest update]] released alongside [[album:freeroam-volume-2|the second volume]]. This discography features several familiar faces from the wider fanmusic sphere.
 ---
 Group: Redditstuck
 URLs:

--- a/groups.yaml
+++ b/groups.yaml
@@ -646,6 +646,7 @@ Group: Freeroam
 URLs:
 - https://mspfa.com/?s=14778
 - https://freeroamfanventure.bandcamp.com/
+- https://freeroam-fanadventure.tumblr.com/
 Description: |-
     For a group of nine friends, a familiar game puts all that they love in jeopardy and together they must forge a path to success while pulling away at the curtains of a grander mystery that threatens their chances for victory.
     <hr class="split">

--- a/groups.yaml
+++ b/groups.yaml
@@ -576,6 +576,26 @@ Description: |-
 Category: Fandom projects
 Color: '#c466ff'
 ---
+Group: 8reath of light
+URLs:
+- https://8reath-of-light.bandcamp.com/
+Series:
+- Name: Albums
+  Albums:
+  - i dreamed of feeling better, vol. 1
+  - Chapter 8
+- Name: Solo singles
+  Albums:
+  - Unite Synchronization (Breach the Heavens Mix)
+  - apple in flight
+  - foreign bodies
+  - Flare (Space to Breathe Mix)
+Description: |-
+    fan music 8ased on [godfeels](https://archiveofourown.org/series/1475819), the canon-divergent homestuck fanfic by sarah zedig.
+    <hr class="split">
+    [Description via Bandcamp.](https://8reath-of-light.bandcamp.com/)<br>
+    Ran by and contributed to by [[artist:ash-taylor]].
+---
 Group: Deconreconstruction
 Directory: deconrecon
 URLs:
@@ -621,6 +641,13 @@ URLs:
 - https://desynced.xyz/
 Description: |-
     A fanventure by a talented team of authors, artists and musicians, in the works since 2017 and updating since early 2020!
+---
+Group: Freeroam
+URLs:
+- https://mspfa.com/?s=14778
+- https://freeroamfanventure.bandcamp.com/
+Description: |-
+    To-do description! Wow, this is tough.
 ---
 Group: Redditstuck
 URLs:

--- a/groups.yaml
+++ b/groups.yaml
@@ -592,9 +592,11 @@ Series:
   - Flare (Space to Breathe Mix)
 Description: |-
     fan music 8ased on [godfeels](https://archiveofourown.org/series/1475819), the canon-divergent homestuck fanfic by sarah zedig.
+
     <hr class="split">
+
     [Description via Bandcamp.](https://8reath-of-light.bandcamp.com/)<br>
-    Ran by and contributed to by [[artist:ash-taylor]].
+    Ran and contributed to by [[artist:ash-taylor]].
 ---
 Group: Deconreconstruction
 Directory: deconrecon
@@ -649,8 +651,12 @@ URLs:
 - https://freeroam-fanadventure.tumblr.com/
 Description: |-
     For a group of nine friends, a familiar game puts all that they love in jeopardy and together they must forge a path to success while pulling away at the curtains of a grander mystery that threatens their chances for victory.
+
     <hr class="split">
-    Fanventure by [[artist:valentwynn]], updating from 2016 through 2020; [[flash:arron-strife|the latest update]] released alongside [[album:freeroam-volume-2|the second volume]]. This discography features several familiar faces from the wider fanmusic sphere.
+
+    [Description via MSPFA.](https://mspfa.com/?s=14778&p=1)
+
+    Fanventure by [[artist:valantwynn]], updating from 2016 through 2020; [[flash:arron-strife|the latest update]] released alongside [[album:freeroam-volume-2|the second volume]]. This discography features several familiar faces from the wider fanmusic sphere.
 ---
 Group: Redditstuck
 URLs:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -91,7 +91,7 @@ Content: |-
         - added [[album:foreign-bodies]]!
         - added [[album:chapter-8]]!
         - added [[album:flare-space-to-breathe-mix]]!
-    - added [[group:freeroam]] discography! (thanks, Lilith!)
+    - added [[group:freeroam]] discography! (thanks, Lilith, Lan!)
         - added [[album:freeroam-volume-1]]!
         - added [[album:freeroam-volume-2]]!
     - added [[group:stalemate]] discography! (thanks, Jebb, Whisper, WarxTron!)
@@ -147,6 +147,9 @@ Content: |-
         - added series for [[group:toby-fox]] (thanks, Whisper, Cello!)
         - added series for [[group:xszelor]] (thanks, Surge!)
     - added artwork reference data to over 150 [[group:canmt]] tracks and albums! (thanks, Makin!)
+    <!-- flashes -->
+    - added [[flash:plink-strife]] to [[flash-act:loftlocked]] flashes (thanks, Lilith!)
+    - added [[flash-act:freeroam]] flashes (thanks, Lilith!)
     <!-- tracks -->
     - added bonus track [[track:a-sour-brote-of-gamgitation-plays]] to [[album:brostuck]] (thanks, Lilith, Whisper!)
     <!-- commentary -->
@@ -196,6 +199,7 @@ Content: |-
     - added Tumblr commentary and alternate artwork to [[track:hunting-the-most-dangerous-game]] (thanks, Lilith!)
     - added SoundCloud commentary, additional name, and listening link to [[track:chronic-infection]] (thanks, Lilith!)
     - added YouTube commentary and listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
+    - added Tumblr commentary and full size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith!)
     - added Bandcamp commentary blurb (2022) and related notes to [[album:perfectly-generic-album]] (thanks, Tangle, Lilith!)
     - added Newgrounds commentary to [[track:clockstopper-new-game-plus-all-clocks-percent]] and [[track:deadkidsgodhood]] (thanks, Whisper!)
     - added Tumblr commentary to [[track:dawn-of-man]] (thanks, Lilith!)
@@ -240,6 +244,7 @@ Content: |-
         - [[track:s-disc-1]], [[track:s-disc-2]], and [[track:s-disc-3]] (YouTube)
         - [[track:deadkidsgodhood]] (Newgrounds)
         - [[track:brobots]] (Newgrounds)
+        - [[track:mimesiswing]] (YouTube)
         - [[track:midnight-squared]] (Spotify)
         - [[track:horsecatska]] (Tumblr)
         - most tracks from [[album:perfectly-generic-album]] (YouTube)
@@ -267,6 +272,7 @@ Content: |-
         - [[album:the-vriska-mixt8pe]] (quirk-free)
     <!-- listening links -->
     - added YouTube listening link to [[track:versus-hardmode-remix]] (thanks, Lilith!)
+    - added YouTube listening links to [[album:running-for-eons]], [[album:repiton]], [[album:vast-error-vol-4]], [[album:catch-322]], and [[album:dead-shufflers-anything-goes]] (thanks, Lilith!)
     - added YouTube listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
     - added Spotify listening links across [[album:noirscape]] (thanks, Lilith!)
     <!-- commentary citations -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -200,7 +200,7 @@ Content: |-
     - added SoundCloud commentary, additional name, and listening link to [[track:chronic-infection]] (thanks, Lilith!)
     - added YouTube commentary and listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
     - added Tumblr commentary blurb excerpt to [[album:freeroam-volume-1]] (thanks, Lilith!
-    - added Tumblr commentary and full size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith, Lan!)
+    - added Tumblr commentary and full-size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith, Lan!)
     - added Bandcamp commentary blurb (2022) and related notes to [[album:perfectly-generic-album]] (thanks, Tangle, Lilith!)
     - added Newgrounds commentary to [[track:clockstopper-new-game-plus-all-clocks-percent]] and [[track:deadkidsgodhood]] (thanks, Whisper!)
     - added Tumblr commentary to [[track:dawn-of-man]] (thanks, Lilith!)
@@ -273,7 +273,7 @@ Content: |-
         - [[album:the-vriska-mixt8pe]] (quirk-free)
     <!-- listening links -->
     - added YouTube listening link to [[track:versus-hardmode-remix]] (thanks, Lilith!)
-    - added YouTube listening links to [[album:running-for-eons]], [[album:repiton]], [[album:vast-error-vol-4]], [[album:catch-322]], and [[album:dead-shufflers-anything-goes]] (thanks, Lilith!)
+    - added YouTube listening links to [[album:running-for-eons]], [[album:repiton]], [[album:vast-error-vol-4]], [[album:catch-322]], and [[album:dead-shufflers-anything-goes]] (thanks, Lilith, Lan!)
     - added YouTube listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
     - added Spotify listening links across [[album:noirscape]] (thanks, Lilith!)
     <!-- commentary citations -->
@@ -316,12 +316,12 @@ Content: |-
     <!-- rereleases -->
     - marked [[track:let-me-dance-let-me-glisten]] ([[album:beforus]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:the-sock-ruse]] ([[album:lofam4]]) newly as a rerelease (thanks, Lilith!)
-    - marked [[track:vriskafic8ion-lofam5a2]] ([[album:lofam5a2]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:fine-with-you]] ([[album:vast-error-vol-4]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:through-the-haze-the-green-box-set-1]] ([[album:the-green-box-set-1]]) newly as a rerelease (thanks, Jebb!)
     - marked [[track:in-the-deep-the-green-box-set-1]] ([[album:the-green-box-set-1]]) newly as a rerelease (thanks, Jebb!)
     - marked [[track:off-the-path-the-green-box-set-1]] ([[album:the-green-box-set-1]]) newly as a rerelease (thanks, Jebb!)
     - marked [[track:final-movement-the-green-box-set-1]] ([[album:the-green-box-set-1]]) newly as a rerelease (thanks, Jebb!)
+    - marked [[track:vriskafic8ion-lofam5a2]] ([[album:lofam5a2]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:moonslayer-lofam5a2]] ([[album:lofam5a2]]) newly as a rerelease (thanks, Lilith!)
     <!-- moved tracks, track section changes -->
     - added descriptions to track sections in [[album:homestuck-vol-1-4]], [[album:homestuck-vol-8]], [[album:alternia]], and [[album:one-year-older]] (thanks, Surge, Whisper!)
@@ -368,11 +368,11 @@ Content: |-
     - fixed [[track:roundabout]] crediting Eddie Offord (as artist) in addition to [[artist:yes]] (thanks, Cello, Lan, Whisper!)
     - fixed [[track:in-the-end]] crediting [[artist:limp-bizkit]] instead of [[artist:linkin-park]] (thanks, Cello, Jebb!)
     <!-- merged artists -->
+    - fixed [[artist:bright0n]] having some credits under another name (thanks, Lilith!)
     - fixed [[artist:corbin-pangilinan]] having some credits under another name (thanks, Lilith!)
     - fixed [[artist:rachel-lake]] having some credits under another name (thanks, Rainy, Lilith!)
     - fixed [[artist:twirlin-curtis]] having some credits under another name (thanks, Makin, Lilith!)
     - fixed [[artist:waif]] having some credits under another name (thanks, Makin, Whisper, Lilith!)
-    - fixed [[artist:bright0n]] having some credits under another name (thanks, Lilith!)
     <!-- track section fixes -->
     - fixed [[track:a-new-world-reprise]] ([[album:reprise]]) not being listed as a bonus track (thanks, Tangle!)
     - fixed [[track:the-song-of-all-time]] not being listed as a bonus track (thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -199,6 +199,7 @@ Content: |-
     - added Tumblr commentary and alternate artwork to [[track:hunting-the-most-dangerous-game]] (thanks, Lilith!)
     - added SoundCloud commentary, additional name, and listening link to [[track:chronic-infection]] (thanks, Lilith!)
     - added YouTube commentary and listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
+    - added Tumblr commentary blurb excerpt to [[album:freeroam-volume-1]] (thanks, Lilith!
     - added Tumblr commentary and full size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith!)
     - added Bandcamp commentary blurb (2022) and related notes to [[album:perfectly-generic-album]] (thanks, Tangle, Lilith!)
     - added Newgrounds commentary to [[track:clockstopper-new-game-plus-all-clocks-percent]] and [[track:deadkidsgodhood]] (thanks, Whisper!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -90,7 +90,7 @@ Content: |-
         - added [[album:apple-in-flight]]!
         - added [[album:foreign-bodies]]!
         - added [[album:chapter-8]]!
-        - added [[album:flare-space-to-breathe-mix]]! 
+        - added [[album:flare-space-to-breathe-mix]]!
     - added [[group:freeroam]] discography! (thanks, Lilith!)
         - added [[album:freeroam-volume-1]]!
         - added [[album:freeroam-volume-2]]!

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -200,7 +200,7 @@ Content: |-
     - added SoundCloud commentary, additional name, and listening link to [[track:chronic-infection]] (thanks, Lilith!)
     - added YouTube commentary and listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
     - added Tumblr commentary blurb excerpt to [[album:freeroam-volume-1]] (thanks, Lilith!
-    - added Tumblr commentary and full size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith!)
+    - added Tumblr commentary and full size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith, Lan!)
     - added Bandcamp commentary blurb (2022) and related notes to [[album:perfectly-generic-album]] (thanks, Tangle, Lilith!)
     - added Newgrounds commentary to [[track:clockstopper-new-game-plus-all-clocks-percent]] and [[track:deadkidsgodhood]] (thanks, Whisper!)
     - added Tumblr commentary to [[track:dawn-of-man]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -69,7 +69,6 @@ Content: |-
     - added [[album:loftlocked-vol-1]]! (thanks, Lilith, Jebb, Pat, Audrey!)
     - added [[album:let-me-dance-let-me-glisten-single]]! (thanks, Lilith!)
     - added [[album:sbahj-the-album]]! (thanks, Lilith, Lan, votl!)
-    - added [[album:freeroam-volume-1]] and [[album:freeroam-volume-2]]! (thanks, Lilith!)
     - added [[album:413-sp3c14l]] by [[artist:afterdevth]]! (thanks, Jebb!)
     - added [[album:rooftop-paladin]] by [[artist:hazama-yuutou]]! (thanks, Lilith!)
     - added [[album:2ollux2-fiinal-frontiier]] by [[artist:maukustus]]! (thanks, Jebb!)
@@ -85,6 +84,16 @@ Content: |-
         - added [[album:gba-pokemon-unbound-super-music-collection]]!
         - added [[album:unbound-day-selection-original-soundtrack]]!
         - added [[album:unbound-battle-selection-original-soundtrack]]!
+    - added [[group:8reath-of-light]] discography! (thanks, Lilith!)
+        - added [[album:i-dreamed-of-feeling-better-vol-1]]!
+        - added [[album:unite-synchronization-breach-the-heavens-mix]]!
+        - added [[album:apple-in-flight]]!
+        - added [[album:foreign-bodies]]!
+        - added [[album:chapter-8]]!
+        - added [[album:flare-space-to-breathe-mix]]! 
+    - added [[group:freeroam]] discography! (thanks, Lilith!)
+        - added [[album:freeroam-volume-1]]!
+        - added [[album:freeroam-volume-2]]!
     - added [[group:stalemate]] discography! (thanks, Jebb, Whisper, WarxTron!)
         - added [[album:stalemate-vol-1]]!
         - added [[album:stalemate-vol-2]]!
@@ -111,9 +120,7 @@ Content: |-
         - added [[album:intermission]]!
         - added [[album:paradise]]!
     - added singles by [[artist:ash-taylor]]! (thanks, Lilith!)
-        - added [[album:unite-synchronization-breach-the-heavens-mix]]!
         - added [[album:english-metal-cover]]!
-        - added [[album:flare-space-to-breathe-mix]]!
         - added [[album:penumbra-phantasm-cover-ash-taylor]]!
     - added singles and more by [[artist:raid]]! (thanks, Lilith, Tangle!)
         - added [[album:doctor-raid-remix]]!
@@ -302,6 +309,7 @@ Content: |-
     <!-- rereleases -->
     - marked [[track:let-me-dance-let-me-glisten]] ([[album:beforus]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:the-sock-ruse]] ([[album:lofam4]]) newly as a rerelease (thanks, Lilith!)
+    - marked [[track:vriskafic8ion-lofam5a2]] ([[album:lofam5a2]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:fine-with-you]] ([[album:vast-error-vol-4]]) newly as a rerelease (thanks, Lilith!)
     - marked [[track:through-the-haze-the-green-box-set-1]] ([[album:the-green-box-set-1]]) newly as a rerelease (thanks, Jebb!)
     - marked [[track:in-the-deep-the-green-box-set-1]] ([[album:the-green-box-set-1]]) newly as a rerelease (thanks, Jebb!)
@@ -357,6 +365,7 @@ Content: |-
     - fixed [[artist:rachel-lake]] having some credits under another name (thanks, Rainy, Lilith!)
     - fixed [[artist:twirlin-curtis]] having some credits under another name (thanks, Makin, Lilith!)
     - fixed [[artist:waif]] having some credits under another name (thanks, Makin, Whisper, Lilith!)
+    - fixed [[artist:bright0n]] having some credits under another name (thanks, Lilith!)
     <!-- track section fixes -->
     - fixed [[track:a-new-world-reprise]] ([[album:reprise]]) not being listed as a bonus track (thanks, Tangle!)
     - fixed [[track:the-song-of-all-time]] not being listed as a bonus track (thanks, Lan!)


### PR DESCRIPTION
Adds the remainder of the 8reath of light catalogue that I didn't include in the Ash Taylor singles pull request previously: [hsmusic/hsmusic-data#639](https://github.com/hsmusic/hsmusic-data/pull/639)

- i dreamed of feeling better, vol. 1
- apple in flight
- foreign bodies
- Chapter 8

Additionally, there is now a 8reath of light group, which Unite Synchronization (Breach the Heavens Mix), and Flare (Space to Breathe Mix) have been moved to.

Also does the following additional changes/fixes:
adds Freeroam flashes
added Freeroam Volume 1 commentary blurb excerpt from Tumblr
added The Man of Action (Jason Ryder's Theme) full artwork and commentary blurb from Tumblr

added [S] Plink: Strife! to Loftlocked flashes
added YouTube listening links to Vast Error Vol. 4, Repiton, Catch 322, Dead Shufflers: Anything Goes, and Running for Eons

added Freeroam group (description by Lan)

added dj terezi and Dana Straten to artists

marked vriskafic8ion (lofam5a2) newly as a rerelease

merges bright0n artist entries (LiquidVoid was formerly separate, but she's one and the same)
renames Austin Lee Matthews (amtrax moved to aliases)

Merge with media request: 
https://github.com/hsmusic/hsmusic-media/pull/101