### PR TITLE
Add official artwork references

### DIFF
--- a/album/beyond-canon.yaml
+++ b/album/beyond-canon.yaml
@@ -14,6 +14,24 @@ Groups:
 - group:official
 Art Tags:
 - Dirk
+Referenced Artworks:
+- References: 'Midnight Crew: Drawing Dead'
+  Annotation: (edit)
+- Medium (edit)
+- Homestuck Vol. 5 (edit)
+- album:alternia (edit)
+- album:alterniabound (edit)
+- References: 'Homestuck Vol. 6: Heir Transparent'
+  Annotation: (edit)
+- The Felt (edit)
+- Homestuck Vol. 9 (edit)
+- References: 'Homestuck Vol. 7: At the Price of Oblivion'
+  Annotation: (edit)
+- Homestuck Vol. 8 (edit)
+- References: 'Colours and Mayhem: Universe B'
+  Annotation: (edit)
+- One Year Older (edit)
+- Symphony Impossible to Play (edit)
 Commentary: |-
     <i>Quasar Nebula:</i> (wiki editor)
 

--- a/album/beyond-canon.yaml
+++ b/album/beyond-canon.yaml
@@ -15,21 +15,17 @@ Groups:
 Art Tags:
 - Dirk
 Referenced Artworks:
-- References: 'Midnight Crew: Drawing Dead'
-  Annotation: (edit)
+- 'Midnight Crew: Drawing Dead (edit)'
 - Medium (edit)
 - Homestuck Vol. 5 (edit)
 - album:alternia (edit)
 - album:alterniabound (edit)
-- References: 'Homestuck Vol. 6: Heir Transparent'
-  Annotation: (edit)
+- 'Homestuck Vol. 6: Heir Transparent (edit)'
 - The Felt (edit)
 - Homestuck Vol. 9 (edit)
-- References: 'Homestuck Vol. 7: At the Price of Oblivion'
-  Annotation: (edit)
+- 'Homestuck Vol. 7: At the Price of Oblivion (edit)'
 - Homestuck Vol. 8 (edit)
-- References: 'Colours and Mayhem: Universe B'
-  Annotation: (edit)
+- 'Colours and Mayhem: Universe B (edit)'
 - One Year Older (edit)
 - Symphony Impossible to Play (edit)
 Commentary: |-

--- a/album/cherubim.yaml
+++ b/album/cherubim.yaml
@@ -79,6 +79,8 @@ Art Tags:
 - Calliope
 - Prospit
 - Skaia
+Referenced Artworks:
+- Power Fantasy (composition)
 MIDI Project Files:
 - Title: MIDI by Unknown (with Power Fantasy)
   Files:
@@ -102,6 +104,8 @@ Cover Artists:
 Art Tags:
 - Caliborn
 - Derse
+Referenced Artworks:
+- Reverie (composition)
 Referenced Tracks:
 - Reverie
 MIDI Project Files:
@@ -125,6 +129,8 @@ Art Tags:
 - Roxy
 - Dirk
 - Jake
+Referenced Artworks:
+- Carne Vale (composition)
 Referenced Tracks:
 - Hello Stardust
 ---
@@ -146,6 +152,8 @@ Art Tags:
 - Jake
 - 'cw: blood (abstract)'
 - 'cw: body horror (abstract)'
+Referenced Artworks:
+- Stellarum Salve (composition)
 Referenced Tracks:
 - Stellarum Salve
 - English
@@ -218,6 +226,8 @@ Cover Artists:
 Cover Art File Extension: png
 Art Tags:
 - Calliope
+Referenced Artworks:
+- Red Sucker (composition)
 Referenced Tracks:
 - The Uranian
 ---
@@ -234,6 +244,8 @@ Cover Artists:
 Cover Art File Extension: png
 Art Tags:
 - Caliborn
+Referenced Artworks:
+- Green Lolly (composition)
 Referenced Tracks:
 - Green Lolly
 - The Undying
@@ -251,6 +263,8 @@ Cover Artists:
 Cover Art File Extension: png
 Art Tags:
 - Calliope
+Referenced Artworks:
+- Constant Conquest (composition)
 Sheet Music Files:
 - Title: Sheet music by lugiaa
   Files:
@@ -273,6 +287,8 @@ Cover Artists:
 Art Tags:
 - Caliborn
 - Lil Cal
+Referenced Artworks:
+- Constant Confinement (composition)
 Referenced Tracks:
 - Constant Confinement
 - Doctor
@@ -319,6 +335,8 @@ Cover Artists:
 Cover Art File Extension: png
 Art Tags:
 - Calliope
+Referenced Artworks:
+- The Lordling (composition)
 Sheet Music Files:
 - Title: Piano scores by Thomas Ferkol (original composer)
   Files:
@@ -357,6 +375,8 @@ Cover Artists:
 Cover Art File Extension: png
 Art Tags:
 - Caliborn
+Referenced Artworks:
+- The Lyrist (composition)
 Referenced Tracks:
 - The Lyrist
 - Flowey's Laugh

--- a/album/homestuck-vol-1.yaml
+++ b/album/homestuck-vol-1.yaml
@@ -126,7 +126,7 @@ Commentary: |-
 Track: Showtime (Original Mix)
 Additional Names:
 - Name: Showtime
-  Annotation: (earlier MSPA credit)
+  Annotation: earlier MSPA credit
 Bandcamp Track ID: 2219548866
 Bandcamp Artwork ID: a3851231837
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -546,6 +546,7 @@ Content: |-
     <!-- general data fixes -->
     - fixed duration of [[track:wanderlust-redditstuck]] (was 3:52, now 3:24; thanks, Lilith, Lan, Makin!)
     - fixed duration of many Nintendo tracks to align with Nintendo Music (thanks, ruby!)
+    - fixed formatting of "original name" additional name on [[track:showtime-original-mix]] (was wrapped in parentheses; thanks, Surge!)
     - fixed citations for "[BONUS]" additional names on [[track:pondsquatter-live-chamber-version]] and [[track:frogsong]] (was "album download", now "original release"; thanks, Lilith!)
     <!-- additional file fixes -->
     - fixed [[album:homestuck-vol-4]] not listing "Homestuck_Vol4_alt9.jpg" additional file (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -151,7 +151,7 @@ Content: |-
         - added series for [[group:kalibration]] (thanks, Whisper!)
         - added series for [[group:toby-fox]] (thanks, Whisper, Cello, Lan, ruby, Jebb!)
         - added series for [[group:xszelor]] (thanks, Surge!)
-    - added artwork reference data to over 150 [[group:canmt]] tracks and albums! (thanks, Makin!)
+    - added artwork reference data to over 150 [[group:canmt]] and [[group:official]] tracks and albums! (thanks, Makin!)
     <!-- flashes -->
     - added [[flash:plink-strife]] to [[flash-act:loftlocked]] flashes (thanks, Lilith!)
     - added [[flash-act:freeroam]] flashes (thanks, Lilith!)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bca2cf4c-14b4-49b4-b7cc-2ada663e596d)

Adds refs to Cherubim's art pairs and Beyond Canon's album artworks, the only ones I could find in the official discography.