### PR TITLE
Fix call and new 2: locomotif references and links

### DIFF
--- a/album/call-and-new-2-locomotif.yaml
+++ b/album/call-and-new-2-locomotif.yaml
@@ -229,6 +229,7 @@ URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/vriska-dance
 - https://youtu.be/y5oOElI4Xo8
 Referenced Tracks:
+- Regent Erratic
 - Spider8ite!!!!!!!!
 - Spider Dance
 - Taureg
@@ -367,7 +368,7 @@ Referenced Tracks:
 - track:battle-champion-pokemon-gold-silver
 - Chorale for Jaspers
 Sampled Tracks:
-- Heartwich
+- Heartwich (With Strings)
 Lyrics: |-
     (What, you're—) (KILLING) (Pikachu?)
     (That's right!)
@@ -627,6 +628,8 @@ URLs:
 - https://youtu.be/suZN5066NNY
 Referenced Tracks:
 - Rhythm Code
+Sampled Tracks:
+- 'Dead Secretary: Zero Health'
 Lyrics: |-
     (What is going on people? My name is Dabe, and today we will be making sweet beats using GarageBand. Just follow along and do what I do.)
 
@@ -641,7 +644,7 @@ URLs:
 - https://youtu.be/NO0gyo89Wps
 Referenced Tracks:
 - 'Dead Secretary: Zero Health'
-- Chorale for Jaspers
+- G O D T R A S H
 - All Star
 ---
 Track: I slightly dislike chiptown
@@ -684,8 +687,7 @@ URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/excess-express
 - https://youtu.be/dvJi1tBAfNI
 Referenced Tracks:
-- 'Dead Secretary: Zero Health'
-- Chorale for Jaspers
+- Ich bin dead.
 ---
 Track: Ich bin not dead.
 Artists:
@@ -695,9 +697,7 @@ URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/ich-bin-not-dead
 - https://youtu.be/nkRZgNoE6RU
 Referenced Tracks:
-- 'Dead Secretary: Zero Health'
-- Chorale for Jaspers
-- All Star
+- Ich bin dead.
 ---
 Track: I absolutely loathe this Drummer.
 Artists:
@@ -757,7 +757,7 @@ URLs:
 - https://coolandnewwebcomic.bandcamp.com/track/light-at-the-end-of-the-tunnel
 - https://youtu.be/Hzn3Ev9sZAU
 Referenced Tracks:
-- I despise this BUILDUPes
+- I absolutely loathe this Drummer.
 Commentary: |-
     <i>Makin:</i> (Titular Light)
     This references Discfortune's Rise and Shine, which was never released.
@@ -1028,7 +1028,6 @@ Has Cover Art: false
 Duration: '04:36'
 URLs:
 - https://soundcloud.com/difarem/train-meldey-next-to-last-station
-- https://www.youtube.com/watch?v=z1mlC0ObCrw
 Referenced Tracks:
 - track:infection-canmt
 - Showtime (Original Mix)
@@ -1073,6 +1072,8 @@ Sampled Tracks:
 - L.A.
 - track:whales-hail-mary-mallons
 - No Credit Card
+URLs:
+- https://www.youtube.com/watch?v=z1mlC0ObCrw
 Lyrics: |-
     [original lyrics have been preserved for posterity]
 

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -38,6 +38,13 @@ Content: |-
     - added Nintendo Music listening links to [[track:big-boos-haunt]], [[track:hazy-maze-cave]], [[track:molgera-battle]], [[track:rainbow-road-super-mario-kart]], [[track:slider-super-mario-64]], and [[track:the-final-battle-super-mario-64]] (thanks, ruby!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
+    - fixed [[track:vriska-dance]] not referencing [[track:regent-erratic]] (thanks, Makin!)
+    - fixed [[track:oh-boo-hoo]] sampling "Heartwich" instead of [[track:heartwich-with-strings]] (thanks, Makin!)
+    - fixed [[track:how-2-dj-vip-excloosive-feat-dabe]] not sampling [[track:dead-secretary-zero-health]] (thanks, Makin!)
+    - fixed [[track:ich-bin-dead]] referencing [[track:chorale-for-jaspers]] and not referencing [[track:godtrash]] (thanks, Makin!)
+    - fixed [[track:excess-express]] referencing [[track:chorale-for-jaspers]], and referencing [[track:dead-secretary-zero-health]] instead of [[track:ich-bin-dead]] (thanks, Makin!)
+    - fixed [[track:ich-bin-not-dead]] referencing [[track:chorale-for-jaspers]] and [[track:all-star]], and referencing [[track:dead-secretary-zero-health]] instead of [[track:ich-bin-dead]] (thanks, Makin!)
+    - fixed [[track:light-at-the-end-of-the-tunnel]] referencing [[track:i-despise-this-buildupes]] instead of [[track:i-absolutely-loathe-this-drummer]] (thanks, Makin!)
     - fixed [[track:scarlet-wings]] not referencing [[track:kotori]] (thanks, Nevermind!)
     <!-- name fixes -->
     - fixed [[track:ground-bgm-super-mario-bros]] being named "Ground Theme (Super Mario Bros.)" (thanks, ruby!)
@@ -53,6 +60,7 @@ Content: |-
         - [[track:slider-super-mario-64]] (was 1:14, now 2:47)
         - [[track:the-final-battle-super-mario-64]] (was 2:50, now 2:49)
     <!-- link fixes -->
+    - fixed YouTube listening link for [[track:train-requiem]] being given to [[track:train-meldey-next-to-last-station]] instead (thanks, Makin!)
     - fixed Twitter link, removed dead desynced.xyz link, and added MSPFA link for [[group:desynced]] (thanks, meulanie!)
     <h3>directory changes</h3>
     <details><summary><b>Toggle Directorylog</b></summary>


### PR DESCRIPTION
Closes https://github.com/hsmusic/hsmusic-data/issues/395.

Additionally fixes a [mistake ](https://github.com/hsmusic/hsmusic-data/commit/6de32dc8c42b5acad2442d22ce034b420f339f6f) in the 5/4/2024 update, where the new listen link for Train Requiem was added to the wrong track, leaving Train Requiem still linkless.