### PR TITLE
Fix Ultralovania artist credit

### DIFF
--- a/album/cool-and-new-greatest-hits.yaml
+++ b/album/cool-and-new-greatest-hits.yaml
@@ -55,7 +55,7 @@ Track: Ultralovania
 Artists:
 - Noisemaker
 Cover Artists:
-- CreatorOfJanespeak
+- Cloudaria
 Art Tags:
 - Vriska
 - Aradia

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -58,6 +58,8 @@ Content: |-
     - fixed [[track:light-at-the-end-of-the-tunnel]] referencing [[track:i-despise-this-buildupes]] instead of [[track:i-absolutely-loathe-this-drummer]] (thanks, Makin!)
     - fixed [[track:scarlet-wings]] not referencing [[track:kotori]] (thanks, Nevermind!)
     - fixed [[track:dave-striders-cool-mixtape]] not sampling [[track:sweet-bro-and-hella-jeff-show]] and [[track:sports-lofam2]] (thanks, Makin!)
+    <!-- crediting fixes -->
+    - fixed [[track:ultralovania]] artwork being credited to [[artist:creatorofjanespeak]] rather than [[artist:cloudaria]] (thanks, Lilith, Tangle, Makin!)
     <!-- name fixes -->
     - fixed [[track:ground-bgm-super-mario-bros]] being named "Ground Theme (Super Mario Bros.)" (thanks, ruby!)
     - fixed [[track:molgera-battle]] being named "Molgera" (thanks, ruby!)


### PR DESCRIPTION
No, Cloudaria and Anervaria are not the same person, this was just a typo. Closes https://github.com/hsmusic/hsmusic-data/issues/588.