### PR TITLE
Add Bite the Apple commentary and alt art

### DIFF
--- a/album/lofam3.yaml
+++ b/album/lofam3.yaml
@@ -139,26 +139,19 @@ Commentary: |-
     Some cool time-reversal effects in this track. Very reminiscent of the [[album:the-felt|Felt album]]. Cool art, too. Always like Ella's stuff.
 ---
 Track: Bite the Apple
-Additional Names:
-- Bite the apple (name in Bandcamp re-release)
 Artists:
 - Nice Wizard
 Duration: 4:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/bite-the-apple
-- https://nicewizard.bandcamp.com/track/bite-the-apple
-- https://soundcloud.com/nicewizard/bite-the-apple
 - https://youtu.be/ifulxtLc1_o
+- https://soundcloud.com/nicewizard/bite-the-apple
 Cover Artists:
 - inimitable-nectar
 Cover Art File Extension: jpg
 Art Tags:
 - John
 Commentary: |-
-    <i>Nice Wizard:</i> (SoundCloud description)
-
-    A track about John!
-
     <i>Nice Wizard:</i> (booklet commentary)
 
     Hey there! Bite the Apple is a song about John going from being a goofy kid playing the piano to a goofy kid being launched into SBURB! For me, this was an incredibly refreshing song to write, and I still find it refreshing to listen to! You might even call it... A Breath of fresh Heir. I'm so sorry, I'll never make puns again. Thanks for listening!
@@ -167,7 +160,11 @@ Commentary: |-
 
     In this piece, John is biting the apple. Clever!
 
-    <i>Nice Wizard:</i> (SoundCloud art)
+    <i>Nice Wizard:</i> ([SoundCloud description](https://soundcloud.com/nicewizard/bite-the-apple), 5/1/2012)
+
+    A track about John!
+
+    <i>Nice Wizard:</i> ([SoundCloud artwork](https://soundcloud.com/nicewizard/bite-the-apple), 5/1/2012)
 
     <img src="media/misc/bite-the-apple-alt.jpg" width="300">
 ---

--- a/album/lofam3.yaml
+++ b/album/lofam3.yaml
@@ -139,11 +139,15 @@ Commentary: |-
     Some cool time-reversal effects in this track. Very reminiscent of the [[album:the-felt|Felt album]]. Cool art, too. Always like Ella's stuff.
 ---
 Track: Bite the Apple
+Additional Names:
+- Bite the apple (name in Bandcamp re-release)
 Artists:
 - Nice Wizard
 Duration: 4:21
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/bite-the-apple
+- https://nicewizard.bandcamp.com/track/bite-the-apple
+- https://soundcloud.com/nicewizard/bite-the-apple
 - https://youtu.be/ifulxtLc1_o
 Cover Artists:
 - inimitable-nectar
@@ -151,13 +155,21 @@ Cover Art File Extension: jpg
 Art Tags:
 - John
 Commentary: |-
-    <i>Nice Wizard:</i> (composer, booklet commentary)
+    <i>Nice Wizard:</i> (SoundCloud description)
+
+    A track about John!
+
+    <i>Nice Wizard:</i> (booklet commentary)
 
     Hey there! Bite the Apple is a song about John going from being a goofy kid playing the piano to a goofy kid being launched into SBURB! For me, this was an incredibly refreshing song to write, and I still find it refreshing to listen to! You might even call it... A Breath of fresh Heir. I'm so sorry, I'll never make puns again. Thanks for listening!
 
     <i>Brad Griffin:</i> (booklet editor)
 
     In this piece, John is biting the apple. Clever!
+
+    <i>Nice Wizard:</i> (SoundCloud art)
+
+    <img src="media/misc/bite-the-apple-alt.jpg" width="300">
 ---
 Track: Planet Cracker
 Artists:
@@ -660,8 +672,9 @@ Commentary: |-
 
     MANDELBROT "EAT FRESH" MOON
 ---
-Track: Fool [Explicit]
-Directory: fool
+Track: Fool
+Additional Names:
+- Fool [Explicit] (name in Bandcamp release)
 Artists:
 - PhemieC
 Duration: 5:19

--- a/album/lofam3.yaml
+++ b/album/lofam3.yaml
@@ -674,7 +674,7 @@ Commentary: |-
 ---
 Track: Fool
 Additional Names:
-- Fool [Explicit] (name in Bandcamp release)
+- Fool [Explicit] ([Bandcamp](https://unofficialmspafans.bandcamp.com/track/fool-explicit))
 Artists:
 - PhemieC
 Duration: 5:19

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -50,8 +50,10 @@ Content: |-
     - added Tumblr commentary to [[album:bittersweet-hilary-troiano]] (thanks, Lilith!)
     - added Tumblr commentary to [[track:jungle-boogie]] (thanks, Lilith!)
     <!-- additional name additions -->
-    - added booklet name to [[track:ohgodboss]] (thanks, Lilith!)
-    - added YouTube and Spotify name to [[track:isle-unto-thyself]] (thanks, Lilith!)
+    - added additional names to several tracks: (thanks, Lilith, Makin!)
+        - [[track:fool]] (Bandcamp name)
+        - [[track:ohgodboss]] (booklet name)
+        - [[track:isle-unto-thyself]] (YouTube, Spotify)
     <!-- lyric additions -->
     - added lyrics to [[track:we-are-midnight-crew]] (thanks, Rosetta Leijonde, Makin!)
     - added lyrics to [[track:sunrise-9]] (thanks, Niklink, Makin!)
@@ -97,6 +99,8 @@ Content: |-
         - fixed [[track:ground-bgm-super-mario-bros]] being named "Ground Theme (Super Mario Bros.)" (thanks, ruby!)
         - fixed [[track:molgera-battle]] being named "Molgera" (thanks, ruby!)
         - fixed [[track:hazy-maze-cave]] being named "Cave Dungeon (Super Mario 64)" (thanks, ruby!)
+    <!-- name fixes (single-lines) -->
+    - fixed [[track:fool]] being named "Fool [Explicit]", preferring track art and booklet name over Bandcamp (thanks, Makin!)
     <!-- lyric fixes -->
     - fixed a bunch of incomplete or missing lyrics in various tracks (thanks, Makin!)
         - [[track:the-rose-rap]]: was *Apple pie, Cheez Whiz, [???]*, now *...Magic Castles*


### PR DESCRIPTION
Closes https://github.com/hsmusic/hsmusic-data/issues/614. Also fixes "Fool [Explicit]", whose title is just "Fool" in both the track art and the booklet.

Depends on https://github.com/hsmusic/hsmusic-media/pull/108.