### PR TITLE
Use timestamped Bambosh-archive links for official flashes

### DIFF
--- a/flashes.yaml
+++ b/flashes.yaml
@@ -313,7 +313,7 @@ URLs:
 Featured Tracks:
 - Pony Chorale
 ---
-Flash: '[S] John: Examine your dad''s room.'
+Flash: "[S] John: Examine your dad's room."
 Page: '948'
 Date: December 3, 2009
 URLs:
@@ -545,7 +545,7 @@ URLs:
 Featured Tracks:
 - Homestuck
 ---
-Flash: 'Vriska: What''s his deal????????'
+Flash: "Vriska: What's his deal????????"
 Page: '2672'
 Date: September 26, 2010
 Featured Tracks:
@@ -1357,8 +1357,7 @@ Date: January 26, 2013
 Featured Tracks:
 - A Very Trickster Mode Christmas (With Fancy Santas)
 ---
-Act: 'Act 6 Intermission 5 - <span style="color: #929292">I''M PUTTING YOU ON SPEAKER
-    CRAB.</span>'
+Act: "Act 6 Intermission 5 - <span style=\"color: #929292\">I'M PUTTING YOU ON SPEAKER CRAB.</span>"
 Directory: a6i5
 Color: '#77ff88'
 ---
@@ -1503,7 +1502,7 @@ URLs:
 Featured Tracks:
 - Hello Zepp
 ---
-Act: 'Act 6 Act 6 Intermission 5 - <span style="color: #1076a2">She''s 8ack</span>'
+Act: "Act 6 Act 6 Intermission 5 - <span style=\"color: #1076a2\">She's 8ack</span>"
 Directory: a6a6i5
 Color: '#00ffff'
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -501,8 +501,6 @@ Color: '#8585ff'
 Flash: '[S???] ======>'
 Page: '2070'
 Date: June 22, 2010
-URLs:
-- https://www.homestuck.com/story/2070
 Featured Tracks:
 - Showdown
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -26,7 +26,7 @@ Flash: '[S] ==>'
 Page: '82'
 Date: April 24, 2009
 URLs:
-- https://youtu.be/rrG3_mqjW04
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=59s
 Featured Tracks:
 - Windchime Foley
 ---
@@ -42,7 +42,7 @@ Flash: '[S] STRIFE!'
 Page: '90'
 Date: April 28, 2009
 URLs:
-- https://youtu.be/Ytrd_2x-8Rs
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=118s
 - https://www.bgreco.net/hsflash/001990.html
 Featured Tracks:
 - Showtime (Original Mix)
@@ -51,7 +51,7 @@ Flash: '[S] ==>'
 Page: '137'
 Date: May 9, 2009
 URLs:
-- https://youtu.be/IBqARyNMonk
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=142s
 - https://www.bgreco.net/hsflash/002037.html
 Featured Tracks:
 - Sburban Jungle (Brief Mix)
@@ -76,7 +76,7 @@ Flash: '[S] John: Take bite of apple.'
 Page: '246'
 Date: June 7, 2009
 URLs:
-- https://youtu.be/ec0sDrBI0V8
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=233s
 - https://www.bgreco.net/hsflash/002146.html
 Featured Tracks:
 - Sburban Countdown
@@ -204,7 +204,7 @@ Flash: '[S] Dave: Ascend to the highest point of the building.'
 Page: '665'
 Date: September 21, 2009
 URLs:
-- https://youtu.be/hLzo0aaSvlg
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=697s
 - https://www.bgreco.net/hsflash/002565.html
 Featured Tracks:
 - Upward Movement (Dave Owns)
@@ -213,7 +213,7 @@ Flash: '[S] WV: Lead your men to victory!'
 Page: '721'
 Date: October 2, 2009
 URLs:
-- https://youtu.be/bQ2Lw3dcilg
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=781s
 - https://www.bgreco.net/hsflash/002621.html
 Featured Tracks:
 - Vagabounce
@@ -222,7 +222,7 @@ Flash: '[S] WV: Hasten to the exit post-haste!'
 Page: '755'
 Date: October 9, 2009
 URLs:
-- https://youtu.be/_xjI4ZmvnGc
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=824s
 - https://www.bgreco.net/hsflash/002655.html
 Featured Tracks:
 - Sburban Reversal
@@ -231,7 +231,7 @@ Flash: '[S] WV: Ascend.'
 Page: '757'
 Date: October 11, 2009
 URLs:
-- https://youtu.be/a-WxdPfVddo
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=870s
 - https://www.bgreco.net/hsflash/002657.html
 Featured Tracks:
 - Explore
@@ -274,7 +274,7 @@ Flash: '[S] MIDNIGHT CREW: ACT 1031'
 Page: '833'
 Date: November 2, 2009
 URLs:
-- https://youtu.be/wAGh8RJk-TU
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1069s
 - https://www.bgreco.net/hsflash/002733.html
 Featured Tracks:
 - Dead Shuffle
@@ -337,7 +337,7 @@ Flash: '[S] Ride.'
 Page: pony
 Date: December 1, 2009
 URLs:
-- https://youtu.be/USB1pj6hAjU
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1475s
 Featured Tracks:
 - Pony Chorale
 ---
@@ -345,7 +345,7 @@ Flash: "[S] John: Examine your dad's room."
 Page: '948'
 Date: December 3, 2009
 URLs:
-- https://youtu.be/DNydoi_vFng
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1543s
 - https://www.bgreco.net/hsflash/002848.html
 Featured Tracks:
 - Revelawesome
@@ -372,7 +372,7 @@ Flash: '[S] Jade: Dream up extra arms and play advanced bass solo.'
 Page: '1026'
 Date: December 18, 2009
 URLs:
-- https://youtu.be/71UlrQFkZJc
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1751s
 - https://www.bgreco.net/hsflash/002926.html
 Featured Tracks:
 - The Beginning of Something Really Excellent
@@ -389,7 +389,7 @@ Flash: '[S] Jade: Pester John.'
 Page: '1073'
 Date: December 29, 2009
 URLs:
-- https://youtu.be/WYF1aiE0fOc
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1920s
 - https://www.bgreco.net/hsflash/002973.html
 Featured Tracks:
 - Ballad of Awakening
@@ -398,7 +398,7 @@ Flash: '[S] Enter.'
 Page: '1149'
 Date: January 14, 2010
 URLs:
-- https://youtu.be/g2CBnn3d1cY
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2113s
 - https://www.bgreco.net/hsflash/003049.html
 Featured Tracks:
 - Sburban Jungle
@@ -433,7 +433,7 @@ Flash: '[S] ==>'
 Page: '1407'
 Date: February 17, 2010
 URLs:
-- https://youtu.be/iRHWm9R59mo
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2436s
 - https://www.bgreco.net/hsflash/003307.html
 Featured Tracks:
 - Endless Climb
@@ -442,7 +442,7 @@ Flash: '[S] Dave: Accelerate.'
 Page: '1641'
 Date: April 2, 2010
 URLs:
-- https://youtu.be/kgddCGdUq9c
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2518s
 - https://www.bgreco.net/hsflash/003541.html
 Featured Tracks:
 - Atomyk Ebonpyre
@@ -460,7 +460,7 @@ Flash: '[S] Jack: Ascend.'
 Page: '1668'
 Date: April 13, 2010
 URLs:
-- https://youtu.be/DaYBhbe0dns
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2611s
 - https://www.bgreco.net/hsflash/003568.html
 Featured Tracks:
 - Black
@@ -496,7 +496,7 @@ Contributors:
 - Nic Carey (art)
 Date: May 5, 2010
 URLs:
-- https://youtu.be/ehSFreQEq2A
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2776s
 - https://www.bgreco.net/hsflash/003701.html
 Featured Tracks:
 - Skaian Skirmish
@@ -505,7 +505,7 @@ Flash: '[S] John: Reunite with your loving wife and daughter.'
 Page: '1931'
 Date: May 26, 2010
 URLs:
-- https://youtu.be/7YqiHDf-agA
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2909s
 Featured Tracks:
 - How Do I Live (Bunny Back in the Box Version)
 ---
@@ -524,7 +524,7 @@ Contributors:
 - Killian Ng (art)
 Date: May 31, 2010
 URLs:
-- https://youtu.be/paQXkYModNs
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=3066s
 - https://www.bgreco.net/hsflash/003840.html
 Featured Tracks:
 - Descend
@@ -563,7 +563,7 @@ Contributors:
 - Killian Ng (art)
 Date: September 8, 2010
 URLs:
-- https://youtu.be/raMHZCdgnnU
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=3348s
 - https://www.bgreco.net/hsflash/004478.html
 Featured Tracks:
 - Crystamanthequins
@@ -576,7 +576,7 @@ Flash: '[S] ACT 5 ACT 2 ==>'
 Page: '2626'
 Date: September 19, 2010
 URLs:
-- https://youtu.be/zZIyQuHn0Ag
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=3543s
 - https://www.bgreco.net/hsflash/004526.html
 Featured Tracks:
 - Homestuck
@@ -592,7 +592,7 @@ Flash: '[S] Vriska: Watch street tough maverick with nothing to lose'
 Page: '2787'
 Date: October 19, 2010
 URLs:
-- https://youtu.be/MfRv4W0homw
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=3696s
 - https://www.bgreco.net/hsflash/004687.html
 Featured Tracks:
 - How Do I Live (Bunny Back in the Box Version)
@@ -652,7 +652,7 @@ Contributors:
 - Killian Ng (art)
 Date: November 10, 2010
 URLs:
-- https://youtu.be/NUHzVVCnEVk
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=3793s
 Featured Tracks:
 - Let the Squiddles Sleep (End Theme)
 ---
@@ -670,7 +670,7 @@ Contributors:
 - Killian Ng (art)
 Date: November 28, 2010
 URLs:
-- https://youtu.be/BeeVidHB8-I
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=3991s
 - https://www.bgreco.net/hsflash/004827.html
 Featured Tracks:
 - Umbral Ultimatum
@@ -679,7 +679,7 @@ Flash: '[S] ==>'
 Page: '2988'
 Date: December 4, 2010
 URLs:
-- https://youtu.be/roCH-7IQjj0
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=4212s
 - https://www.bgreco.net/hsflash/004888.html
 Featured Tracks:
 - track:frost-vol6
@@ -718,7 +718,7 @@ Contributors:
 - Lexxy (art)
 Date: December 16, 2010
 URLs:
-- https://youtu.be/jYCa-ByMNsA
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=4514s
 - https://www.bgreco.net/hsflash/004987.html
 Featured Tracks:
 - Savior of the Waking World
@@ -727,7 +727,7 @@ Flash: '[S] Wake.'
 Page: '3297'
 Date: January 15, 2011
 URLs:
-- https://youtu.be/cIqYNGZokFY
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=4684s
 - https://www.bgreco.net/hsflash/005197.html
 Featured Tracks:
 - track:MeGaLoVania
@@ -790,7 +790,7 @@ Contributors:
 - Killian Ng (art)
 Date: February 16, 2011
 URLs:
-- https://youtu.be/VEA60fK1bk8
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=4894s
 - https://www.bgreco.net/hsflash/005420.html
 Featured Tracks:
 - Trollian Standoff
@@ -799,7 +799,7 @@ Flash: '[S] All: Behold glory of Zillyhoo.'
 Page: '3679'
 Date: March 23, 2011
 URLs:
-- https://youtu.be/LB2wi2EYSbw
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5040s
 - https://www.bgreco.net/hsflash/005579.html
 Featured Tracks:
 - Warhammer of Zillyhoo
@@ -869,7 +869,7 @@ Contributors:
 - Killian Ng (art)
 Date: April 30, 2011
 URLs:
-- https://youtu.be/n-hCXQPW_do
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5339s
 - https://www.bgreco.net/hsflash/005644.html
 Featured Tracks:
 - Terezi Owns
@@ -878,7 +878,7 @@ Flash: '[S] Flip.'
 Page: '3760'
 Date: May 15, 2011
 URLs:
-- https://youtu.be/8RC_02KeBrE
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5448s
 Featured Tracks:
 - 'BL1ND JUST1C3 : 1NV3ST1G4T1ON !!'
 ---
@@ -896,7 +896,7 @@ Contributors:
 - Lazylaz (art)
 Date: August 22, 2011
 URLs:
-- https://youtu.be/V-ePGeiKr_k
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5645s
 - https://www.bgreco.net/hsflash/005985.html
 Featured Tracks:
 - The Carnival
@@ -922,7 +922,7 @@ Contributors:
 - Xamag (art)
 Date: October 25, 2011
 URLs:
-- https://youtu.be/FDt-SLyEcjI
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5785s
 - https://www.bgreco.net/hsflash/006009.html
 Featured Tracks:
 - Cascade
@@ -935,7 +935,7 @@ Flash: '[S] Begin intermission 2.'
 Page: '4111'
 Date: October 31, 2011
 URLs:
-- https://youtu.be/Bc0DAfQuFNQ
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=6594s
 - https://www.bgreco.net/hsflash/006011.html
 Featured Tracks:
 - English
@@ -953,7 +953,7 @@ Flash: '[S] ACT 6'
 Page: '4113'
 Date: November 11, 2011
 URLs:
-- https://youtu.be/htBxlE2hKok
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=6774s
 - https://www.bgreco.net/hsflash/006013.html
 Featured Tracks:
 - Homestuck Anthem
@@ -990,7 +990,7 @@ Flash: '[S] END OF ACT 6 INTERMISSION 1'
 Page: '4390'
 Date: December 29, 2011
 URLs:
-- https://youtu.be/kwuo1yH5DHg
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7091s
 - https://www.bgreco.net/hsflash/006290.html
 Featured Tracks:
 - Infinity Mechanism
@@ -1003,7 +1003,7 @@ Flash: '[S] Roxy: Sleepwalk.'
 Page: '4486'
 Date: January 21, 2011
 URLs:
-- https://youtu.be/1ZYAcoEQ0dA
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7303s
 - https://www.bgreco.net/hsflash/006386.html
 Featured Tracks:
 - Even in Death
@@ -1020,7 +1020,7 @@ Flash: '[S] Prince of Heart: Rise up.'
 Page: '4572'
 Date: February 16, 2012
 URLs:
-- https://youtu.be/PVO0FXYAfKw
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7585s
 - https://www.bgreco.net/hsflash/006472.html
 Featured Tracks:
 - Time on My Side
@@ -1037,7 +1037,7 @@ Flash: '[S] Ride.'
 Page: pony2
 Date: February 26, 2012
 URLs:
-- https://youtu.be/vHSyoThUyOQ
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7827s
 Featured Tracks:
 - Pony Chorale
 ---
@@ -1045,7 +1045,7 @@ Flash: '[S] Jane: Enter.'
 Page: '4665'
 Date: March 8, 2012
 URLs:
-- https://youtu.be/cbg-wxqtgUo
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7896s
 - https://www.bgreco.net/hsflash/006565.html
 Featured Tracks:
 - Another Jungle
@@ -1106,7 +1106,7 @@ Flash: '[S] DD: Ascend more casually.'
 Page: '4944'
 Date: May 17, 2012
 URLs:
-- https://youtu.be/owe03uIkhFo
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8308s
 Featured Tracks:
 - I'm a Member of the Midnight Crew (Acapella)
 ---
@@ -1122,7 +1122,7 @@ Flash: '[S] Dirk: Synchronize.'
 Page: '5238'
 Date: July 9, 2012
 URLs:
-- https://youtu.be/GZ0PkXNtUhU
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8679s
 - https://www.bgreco.net/hsflash/007138.html
 Featured Tracks:
 - Unite Synchronization
@@ -1131,7 +1131,7 @@ Flash: '[S] Dirk: Unite.'
 Page: '5252'
 Date: July 9, 2012
 URLs:
-- https://youtu.be/U9uFkc3N4JQ
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8795s
 - https://www.bgreco.net/hsflash/007152.html
 Featured Tracks:
 - Unite Synchronization
@@ -1140,7 +1140,7 @@ Flash: '[S] Caliborn: Enter.'
 Page: '5261'
 Date: July 28, 2012
 URLs:
-- https://youtu.be/L4QUXZTKgfo
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8898s
 - https://www.bgreco.net/hsflash/007161.html
 Featured Tracks:
 - Eternity Served Cold
@@ -1293,7 +1293,7 @@ Flash: '[S] ACT 6 ACT 4'
 Page: '5438'
 Date: November 12, 2012
 URLs:
-- https://youtu.be/mF3mNn7FPwU
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9442s
 - https://www.bgreco.net/hsflash/007338.html
 Featured Tracks:
 - Even in Death (T'Morra's Belly Mix)
@@ -1366,7 +1366,7 @@ Flash: '[S] ACT 6 ACT 5'
 Page: '5512'
 Date: November 28, 2012
 URLs:
-- https://youtu.be/ShIvL8SLC7c
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9693s
 - https://www.bgreco.net/hsflash/007412.html
 Featured Tracks:
 - A Taste for Adventure
@@ -1375,7 +1375,7 @@ Flash: '[S] Ride.'
 Page: '5655'
 Date: December 26, 2012
 URLs:
-- https://youtu.be/z48Ssmhu3vg
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9808s
 - https://www.bgreco.net/hsflash/007555.html
 Featured Tracks:
 - Horschestra STRONG Version
@@ -1384,7 +1384,7 @@ Flash: '[S] Jane: Engage.'
 Page: '5711'
 Date: January 9, 2013
 URLs:
-- https://youtu.be/5O0OZQ3BuTQ
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10014s
 - https://www.bgreco.net/hsflash/008131.html
 Featured Tracks:
 - Trickster Mode (Engage)
@@ -1393,7 +1393,7 @@ Flash: '[S] Jane: Blast off.'
 Page: '5712'
 Date: January 10, 2013
 URLs:
-- https://youtu.be/tPo5q6985uE
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10051s
 Featured Tracks:
 - Trickster Mode (Blast Off)
 ---
@@ -1468,7 +1468,7 @@ Flash: '[S][A6I5] BEGIN INTERFISHIN'
 Page: '5981'
 Date: March 10, 2013
 URLs:
-- https://youtu.be/fT0SLVNdvF8
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10274s
 Featured Tracks:
 - Elevatorstuck
 ---
@@ -1490,7 +1490,7 @@ Flash: '[S][A6I5] ==>'
 Page: '6231'
 Date: April 13, 2013
 URLs:
-- https://youtu.be/oReLrD9WrA8
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10353s
 Featured Tracks:
 - A Taste for Adventure
 ---
@@ -1502,7 +1502,7 @@ Flash: '[S] ACT 6 ACT 6'
 Page: '6243'
 Date: June 12, 2013
 URLs:
-- https://youtu.be/PTYc67Cp6oE
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10491s
 Featured Tracks:
 - Homosuck Anthem
 ---
@@ -1514,7 +1514,7 @@ Flash: '[S] ACT 6 ACT 6 INTERMISSION 1'
 Page: '6278'
 Date: June 14, 2013
 URLs:
-- https://youtu.be/j-wdUF0ofts
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10601s
 - https://www.bgreco.net/hsflash/008178.html
 Featured Tracks:
 - Gold Pilot
@@ -1554,7 +1554,7 @@ Contributors:
 - J.N. Wiedle (art)
 Date: October 25, 2014
 URLs:
-- https://youtu.be/5IDKxUEiuyc
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10716s
 - https://www.bgreco.net/hsflash/GAMEOVER.html
 Featured Tracks:
 - track:carne-vale
@@ -1574,7 +1574,7 @@ Flash: '[S][A6A6I4] ====>'
 Page: '7098'
 Date: November 28, 2014
 URLs:
-- https://youtu.be/Xdn70gnBw2w
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10981s
 - https://www.bgreco.net/hsflash/008998.html
 Featured Tracks:
 - Pipeorgankind
@@ -1611,7 +1611,7 @@ Flash: '[S] MSPA Reader: Mental breakdown.'
 Page: '7448'
 Date: April 22, 2015
 URLs:
-- https://youtu.be/v3PIyyIr2pQ
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11366s
 - https://www.bgreco.net/hsflash/009348.html
 Featured Tracks:
 - Hello Zepp
@@ -1630,7 +1630,7 @@ Contributors:
 - J.N. Wiedle (art)
 Date: April 26, 2015
 URLs:
-- https://youtu.be/BzxRi-HWDLc
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11547s
 - https://www.bgreco.net/hsflash/009349.html
 Featured Tracks:
 - track:moonsetter
@@ -1650,7 +1650,7 @@ Contributors:
 - ipgd (art)
 Date: July 23, 2015
 URLs:
-- https://youtu.be/9G-2714Ht9Q
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11728s
 Featured Tracks:
 - Horsecatska
 ---
@@ -1664,7 +1664,7 @@ Contributors:
 - Rah-Bop (art)
 Date: July 27, 2015
 URLs:
-- https://youtu.be/3pLgxneqLgk
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11785s
 Featured Tracks:
 - Do You Remem8er Me
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -7,88 +7,90 @@ Act: Act 1 - The Note Desolation Plays
 Directory: a1
 Color: '#7799ff'
 ---
+Flash: 'John: Examine games on CD rack.'
+Page: '31'
 Date: April 16, 2009
 Featured Tracks:
 - Problem Sleuth Theme
-Flash: 'John: Examine games on CD rack.'
-Page: '31'
 ---
+Flash: '[S] John: Play haunting piano refrain.'
+Page: '77'
 Date: April 21, 2009
 URLs:
 - https://www.bgreco.net/hsflash/001977.html
 Featured Tracks:
 - Showtime (Piano Refrain)
-Flash: '[S] John: Play haunting piano refrain.'
-Page: '77'
 ---
+Flash: '[S] ==>'
+Page: '82'
 Date: April 24, 2009
 URLs:
 - https://youtu.be/rrG3_mqjW04
 Featured Tracks:
 - Windchime Foley
-Flash: '[S] ==>'
-Page: '82'
 ---
+Flash: '[S] John: Enter.'
+Page: '88'
 Date: April 27, 2009
 Featured Tracks:
 - Harlequin
-Flash: '[S] John: Enter.'
-Page: '88'
 ---
+Flash: '[S] STRIFE!'
+Page: '90'
 Date: April 28, 2009
 URLs:
 - https://youtu.be/Ytrd_2x-8Rs
 - https://www.bgreco.net/hsflash/001990.html
 Featured Tracks:
 - Showtime (Original Mix)
-Flash: '[S] STRIFE!'
-Page: '90'
 ---
+Flash: '[S] ==>'
+Page: '137'
 Date: May 9, 2009
 URLs:
 - https://youtu.be/IBqARyNMonk
 - https://www.bgreco.net/hsflash/002037.html
 Featured Tracks:
 - Sburban Jungle (Brief Mix)
-Flash: '[S] ==>'
-Page: '137'
 ---
+Flash: '[S] ==>'
+Page: '186'
 Date: May 21, 2009
 Featured Tracks:
 - Harlequin
-Flash: '[S] ==>'
-Page: '186'
 ---
+Flash: '[S] Rose: Play a haunting refrain on the violin.'
+Page: '222'
 Date: May 29, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002122.html
 Featured Tracks:
 - Aggrieve (Violin Refrain)
-Flash: '[S] Rose: Play a haunting refrain on the violin.'
-Page: '222'
 ---
+Flash: '[S] John: Take bite of apple.'
+Page: '246'
 Date: June 7, 2009
 URLs:
 - https://youtu.be/ec0sDrBI0V8
 - https://www.bgreco.net/hsflash/002146.html
 Featured Tracks:
 - Sburban Countdown
-Flash: '[S] John: Take bite of apple.'
-Page: '246'
 ---
 Act: Act 2 - Raise of the Conductor's Baton
 Directory: a2
 Color: '#ff5555'
 ---
+Flash: '[S] YOU THERE. BOY.'
+Page: '253'
 Date: June 14, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002153.html
 Featured Tracks:
 - Showtime (Piano Refrain)
 - Harlequin
-Flash: '[S] YOU THERE. BOY.'
-Page: '253'
 ---
+Flash: '[S] ==>'
+Page: '338'
 Date: July 4, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002238.html
@@ -113,127 +115,127 @@ Featured Tracks:
 - Captain Planet and the Planeteers End Title
 - Ghostbusters
 - track:i-dont-want-to-miss-a-thing-aerosmith
-Flash: '[S] ==>'
-Page: '338'
 ---
+Flash: '[S] Rose: Youth roll right out the front door.'
+Page: '388'
 Date: July 19, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002288.html
 Featured Tracks:
 - Aggrieve
-Flash: '[S] Rose: Youth roll right out the front door.'
-Page: '388'
 ---
+Flash: '[S] ==>==>==>!!!!!!!!!'
+Page: '393'
 Date: July 22, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002293.html
 Featured Tracks:
 - Showtime (Imp Strife Mix)
-Flash: '[S] ==>==>==>!!!!!!!!!'
-Page: '393'
 ---
+Flash: '[S] GET UP JOHN, THIS IS NO TIME FOR SLUMBER.'
+Page: '397'
 Date: July 23, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002297.html
 Featured Tracks:
 - Showtime (Imp Strife Mix)
-Flash: '[S] GET UP JOHN, THIS IS NO TIME FOR SLUMBER.'
-Page: '397'
 ---
+Flash: '[S] JOHN, SALVAGE YOUR WEAPON AND FIGHT ON!'
+Page: '400'
 Date: July 25, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002300.html
 Featured Tracks:
 - Showtime (Imp Strife Mix)
-Flash: '[S] JOHN, SALVAGE YOUR WEAPON AND FIGHT ON!'
-Page: '400'
 ---
+Flash: '[S] WHAT THIS IS SO OUTRAGEOUS'
+Page: '418'
 Date: July 30, 2009
 Featured Tracks:
 - Nannaquin
-Flash: '[S] WHAT THIS IS SO OUTRAGEOUS'
-Page: '418'
 ---
+Flash: '[S] GO ON. ==>'
+Page: '422'
 Date: August 1, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002322.html
 Featured Tracks:
 - Skies of Skaia
-Flash: '[S] GO ON. ==>'
-Page: '422'
 ---
+Flash: '[S] ==>'
+Page: '476'
 Date: August 15, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002376.html
 Featured Tracks:
 - Harlequin (Rock Version)
-Flash: '[S] ==>'
-Page: '476'
 ---
+Flash: '[S] John: Sleep.'
+Page: '644'
 Date: September 15, 2009
 Featured Tracks:
 - John Sleeps / Skaian Magicant
-Flash: '[S] John: Sleep.'
-Page: '644'
 ---
+Flash: '[S] John: Wake up.'
+Page: '651'
 Date: September 17, 2009
 Featured Tracks:
 - John Sleeps / Skaian Magicant
-Flash: '[S] John: Wake up.'
-Page: '651'
 ---
+Flash: '[S] Dave: Ascend to the highest point of the building.'
+Page: '665'
 Date: September 21, 2009
 URLs:
 - https://youtu.be/hLzo0aaSvlg
 - https://www.bgreco.net/hsflash/002565.html
 Featured Tracks:
 - Upward Movement (Dave Owns)
-Flash: '[S] Dave: Ascend to the highest point of the building.'
-Page: '665'
 ---
+Flash: '[S] WV: Lead your men to victory!'
+Page: '721'
 Date: October 2, 2009
 URLs:
 - https://youtu.be/bQ2Lw3dcilg
 - https://www.bgreco.net/hsflash/002621.html
 Featured Tracks:
 - Vagabounce
-Flash: '[S] WV: Lead your men to victory!'
-Page: '721'
 ---
+Flash: '[S] WV: Hasten to the exit post-haste!'
+Page: '755'
 Date: October 9, 2009
 URLs:
 - https://youtu.be/_xjI4ZmvnGc
 - https://www.bgreco.net/hsflash/002655.html
 Featured Tracks:
 - Sburban Reversal
-Flash: '[S] WV: Hasten to the exit post-haste!'
-Page: '755'
 ---
+Flash: '[S] WV: Ascend.'
+Page: '757'
 Date: October 11, 2009
 URLs:
 - https://youtu.be/a-WxdPfVddo
 - https://www.bgreco.net/hsflash/002657.html
 Featured Tracks:
 - Explore
-Flash: '[S] WV: Ascend.'
-Page: '757'
 ---
 Act: Act 3 - Insane Corkscrew Haymakers
 Directory: a3
 Color: '#55ff77'
 ---
+Flash: '[S] Jade: Play a silly flute refrain.'
+Page: '769'
 Date: October 15, 2009
 Featured Tracks:
 - Flute Refrain
-Flash: '[S] Jade: Play a silly flute refrain.'
-Page: '769'
 ---
+Flash: '[S] Jade: Play a hauntingly relaxing bassline.'
+Page: '822'
 Date: October 27, 2009
 Featured Tracks:
 - Gardener
-Flash: '[S] Jade: Play a hauntingly relaxing bassline.'
-Page: '822'
 ---
+Flash: '[S] Jade: Open FreshJamz!'
+Page: '830'
 Date: October 31, 2009
 Featured Tracks:
 - Showtime Remix
@@ -245,181 +247,181 @@ Featured Tracks:
 - Rediscover Fusion
 - Crystalanthemums
 - Explore Remix
-Flash: '[S] Jade: Open FreshJamz!'
-Page: '830'
 ---
+Flash: '[S] MIDNIGHT CREW: ACT 1031'
+Page: '833'
 Date: November 2, 2009
 URLs:
 - https://youtu.be/wAGh8RJk-TU
 - https://www.bgreco.net/hsflash/002733.html
 Featured Tracks:
 - Dead Shuffle
-Flash: '[S] MIDNIGHT CREW: ACT 1031'
-Page: '833'
 ---
+Flash: '[S] Dave: STRIFE.'
+Page: '836'
 Date: November 6, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002736.html
 Featured Tracks:
 - Beatdown (Strider Style)
-Flash: '[S] Dave: STRIFE.'
-Page: '836'
 ---
+Flash: '[S] Jade: Descend.'
+Page: '843'
 Date: November 8, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002743.html
 Featured Tracks:
 - Harleboss
-Flash: '[S] Jade: Descend.'
-Page: '843'
 ---
+Flash: '[S] Dave: Abscond.'
+Page: '871'
 Date: November 18, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002771.html
 Featured Tracks:
 - Beatdown Round 2
-Flash: '[S] Dave: Abscond.'
-Page: '871'
 ---
+Flash: '[S] Rose: Ascend.'
+Page: '879'
 Date: November 20, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002779.html
 Featured Tracks:
 - Harleboss
-Flash: '[S] Rose: Ascend.'
-Page: '879'
 ---
+Flash: '[S] Strife!!!'
+Page: '918'
 Date: November 27, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002818.html
 Featured Tracks:
 - Dissension (Original)
-Flash: '[S] Strife!!!'
-Page: '918'
 ---
+Flash: '[S] Rose: Fast forward to now.'
+Page: '938'
 Date: December 1, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002838.html
 Featured Tracks:
 - Chorale for Jaspers
-Flash: '[S] Rose: Fast forward to now.'
-Page: '938'
 ---
+Flash: '[S] Ride.'
+Page: pony
 Date: December 1, 2009
 URLs:
 - https://youtu.be/USB1pj6hAjU
 Featured Tracks:
 - Pony Chorale
-Flash: '[S] Ride.'
-Page: pony
 ---
+Flash: '[S] John: Examine your dad''s room.'
+Page: '948'
 Date: December 3, 2009
 URLs:
 - https://youtu.be/DNydoi_vFng
 - https://www.bgreco.net/hsflash/002848.html
 Featured Tracks:
 - Revelawesome
-Flash: '[S] John: Examine your dad''s room.'
-Page: '948'
 ---
+Flash: '[S] John: Mental breakdown.'
+Page: '979'
 Date: December 6, 2009
 Featured Tracks:
 - Hardlyquin
-Flash: '[S] John: Mental breakdown.'
-Page: '979'
 ---
+Flash: '[S] Jade: Retrieve package.'
+Page: '980'
 Date: December 8, 2009
 URLs:
 - https://www.bgreco.net/hsflash/002880.html
 Featured Tracks:
 - An Unbreakable Union
 - Carefree Victory
-Flash: '[S] Jade: Retrieve package.'
-Page: '980'
 ---
+Flash: '[S] Jade: Dream up extra arms and play advanced bass solo.'
+Page: '1026'
 Date: December 18, 2009
 URLs:
 - https://youtu.be/71UlrQFkZJc
 - https://www.bgreco.net/hsflash/002926.html
 Featured Tracks:
 - The Beginning of Something Really Excellent
-Flash: '[S] Jade: Dream up extra arms and play advanced bass solo.'
-Page: '1026'
 ---
+Flash: '[S] Dave: Strife!'
+Page: '1070'
 Date: December 24, 2009
 Featured Tracks:
 - Versus
-Flash: '[S] Dave: Strife!'
-Page: '1070'
 ---
+Flash: '[S] Jade: Pester John.'
+Page: '1073'
 Date: December 29, 2009
 URLs:
 - https://youtu.be/WYF1aiE0fOc
 - https://www.bgreco.net/hsflash/002973.html
 Featured Tracks:
 - Ballad of Awakening
-Flash: '[S] Jade: Pester John.'
-Page: '1073'
 ---
+Flash: '[S] Enter.'
+Page: '1149'
 Date: January 14, 2010
 URLs:
 - https://youtu.be/g2CBnn3d1cY
 - https://www.bgreco.net/hsflash/003049.html
 Featured Tracks:
 - Sburban Jungle
-Flash: '[S] Enter.'
-Page: '1149'
 ---
 Act: Intermission - Don't Bleed on the Suits.
 Directory: i1
 Color: '#22cc22'
 ---
+Flash: '[S][I] ==>'
+Page: '1267'
 Date: January 29, 2010
 URLs:
 - https://www.bgreco.net/hsflash/003167.html
 Featured Tracks:
 - Three in the Morning
-Flash: '[S][I] ==>'
-Page: '1267'
 ---
 Act: Act 4 - Flight of the Paradox Clones
 Directory: a4
 Color: '#b536da'
 ---
+Flash: '[S] ACT 4 ==>'
+Page: '1358'
 Date: February 10, 2010
 URLs:
 - https://www.bgreco.net/hsflash/003258.html
 Featured Tracks:
 - Doctor
-Flash: '[S] ACT 4 ==>'
-Page: '1358'
 ---
+Flash: '[S] ==>'
+Page: '1407'
 Date: February 17, 2010
 URLs:
 - https://youtu.be/iRHWm9R59mo
 - https://www.bgreco.net/hsflash/003307.html
 Featured Tracks:
 - Endless Climb
-Flash: '[S] ==>'
-Page: '1407'
 ---
+Flash: '[S] Dave: Accelerate.'
+Page: '1641'
 Date: April 2, 2010
 URLs:
 - https://youtu.be/kgddCGdUq9c
 - https://www.bgreco.net/hsflash/003541.html
 Featured Tracks:
 - Atomyk Ebonpyre
-Flash: '[S] Dave: Accelerate.'
-Page: '1641'
 ---
+Flash: '[S] ==>'
+Page: '1656'
 Date: April 3, 2010
 URLs:
 - https://www.bgreco.net/hsflash/003556.html
 Featured Tracks:
 - Bed of Rose's / Dreams of Derse
-Flash: '[S] ==>'
-Page: '1656'
 ---
+Flash: '[S] Jack: Ascend.'
+Page: '1668'
 Date: April 13, 2010
 URLs:
 - https://youtu.be/DaYBhbe0dns
@@ -427,9 +429,9 @@ URLs:
 Featured Tracks:
 - Black
 - Descend
-Flash: '[S] Jack: Ascend.'
-Page: '1668'
 ---
+Flash: '[S] Rose and Dave: Shut up and jam.'
+Page: '1720'
 Date: April 22, 2010
 Featured Tracks:
 - Unsheath'd
@@ -437,8 +439,6 @@ Featured Tracks:
 - Octoroon Rangoon
 - Derse Dreamers
 - Phantasmagoric Waltz
-Flash: '[S] Rose and Dave: Shut up and jam.'
-Page: '1720'
 Commentary: |-
     <i>Solatrus:</i> ([[track:derse-dreamers]] composer, [Tumblr](https://web.archive.org/web/20111004070050/http://blog.solatrus.com/archive))
 
@@ -452,6 +452,8 @@ Commentary: |-
 
     HYPE TIME.
 ---
+Flash: '[S] WV?: Rise up.'
+Page: '1801'
 Contributors:
 - Michael Firman (art)
 - Nic Carey (art)
@@ -461,17 +463,17 @@ URLs:
 - https://www.bgreco.net/hsflash/003701.html
 Featured Tracks:
 - Skaian Skirmish
-Flash: '[S] WV?: Rise up.'
-Page: '1801'
 ---
+Flash: '[S] John: Reunite with your loving wife and daughter.'
+Page: '1931'
 Date: May 26, 2010
 URLs:
 - https://youtu.be/7YqiHDf-agA
 Featured Tracks:
 - How Do I Live (Bunny Back in the Box Version)
-Flash: '[S] John: Reunite with your loving wife and daughter.'
-Page: '1931'
 ---
+Flash: '[S] Descend.'
+Page: '1940'
 Contributors:
 - Brett Muller (art)
 - celestialKarakul (art)
@@ -491,21 +493,21 @@ Featured Tracks:
 - Descend
 - Squiddles!
 - Friendship Aneurysm
-Flash: '[S] Descend.'
-Page: '1940'
 ---
 Act: 'Act 5 Act 1 - <span style="color: #008b8b">MOB1US DOUBL3 R34CH4ROUND</span>'
 Directory: a5a1
 Color: '#8585ff'
 ---
+Flash: '[S???] ======>'
+Page: '2070'
 Date: June 22, 2010
 URLs:
 - https://www.homestuck.com/story/2070
 Featured Tracks:
 - Showdown
-Flash: '[S???] ======>'
-Page: '2070'
 ---
+Flash: '[S] Make her pay.'
+Page: '2578'
 Contributors:
 - Brett Muller (art)
 - celestialKarakul (art)
@@ -529,37 +531,37 @@ URLs:
 - https://www.bgreco.net/hsflash/004478.html
 Featured Tracks:
 - Crystamanthequins
-Flash: '[S] Make her pay.'
-Page: '2578'
 ---
 Act: 'Act 5 Act 2 - <span style="color: #2ed73a">He is already here.</span>'
 Directory: a5a2
 Color: '#ff0000'
 ---
+Flash: '[S] ACT 5 ACT 2 ==>'
+Page: '2626'
 Date: September 19, 2010
 URLs:
 - https://youtu.be/zZIyQuHn0Ag
 - https://www.bgreco.net/hsflash/004526.html
 Featured Tracks:
 - Homestuck
-Flash: '[S] ACT 5 ACT 2 ==>'
-Page: '2626'
 ---
+Flash: 'Vriska: What''s his deal????????'
+Page: '2672'
 Date: September 26, 2010
 Featured Tracks:
 - How Do I Live
-Flash: 'Vriska: What''s his deal????????'
-Page: '2672'
 ---
+Flash: '[S] Vriska: Watch street tough maverick with nothing to lose'
+Page: '2787'
 Date: October 19, 2010
 URLs:
 - https://youtu.be/MfRv4W0homw
 - https://www.bgreco.net/hsflash/004687.html
 Featured Tracks:
 - How Do I Live (Bunny Back in the Box Version)
-Flash: '[S] Vriska: Watch street tough maverick with nothing to lose'
-Page: '2787'
 ---
+Flash: '[S] Past Karkat: Wake up.'
+Page: '2792'
 Contributors:
 - Brett Muller (art)
 - celestialKarakul (art)
@@ -589,15 +591,15 @@ Featured Tracks:
 - Walk-Stab-Walk (R&E)
 - Horschestra
 - ERROR
-Flash: '[S] Past Karkat: Wake up.'
-Page: '2792'
 ---
+Flash: 'Dave: Answer Gamzee.'
+Page: '2818'
 Date: October 31, 2010
 Featured Tracks:
 - track:miracles-icp
-Flash: 'Dave: Answer Gamzee.'
-Page: '2818'
 ---
+Flash: '[S] Jade: Wake up.'
+Page: '2848'
 Contributors:
 - Brett Muller (art)
 - celestialKarakul (art)
@@ -614,9 +616,9 @@ URLs:
 - https://youtu.be/NUHzVVCnEVk
 Featured Tracks:
 - Let the Squiddles Sleep (End Theme)
-Flash: '[S] Jade: Wake up.'
-Page: '2848'
 ---
+Flash: '[S] Jade: Enter.'
+Page: '2927'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
@@ -633,26 +635,26 @@ URLs:
 - https://www.bgreco.net/hsflash/004827.html
 Featured Tracks:
 - Umbral Ultimatum
-Flash: '[S] Jade: Enter.'
-Page: '2927'
 ---
+Flash: '[S] ==>'
+Page: '2988'
 Date: December 4, 2010
 URLs:
 - https://youtu.be/roCH-7IQjj0
 - https://www.bgreco.net/hsflash/004888.html
 Featured Tracks:
 - track:frost-vol6
-Flash: '[S] ==>'
-Page: '2988'
 ---
+Flash: '[S] Jade: STRIFE!!!!!!!!!!!!'
+Page: '3001'
 Date: December 6, 2010
 URLs:
 - https://www.bgreco.net/hsflash/004901.html
 Featured Tracks:
 - track:sunslammer
-Flash: '[S] Jade: STRIFE!!!!!!!!!!!!'
-Page: '3001'
 ---
+Flash: '[S] John: Enter village.'
+Page: '3079'
 Contributors:
 - Eyes5 (art)
 - Lexxy (art)
@@ -668,9 +670,9 @@ URLs:
 Featured Tracks:
 - Planet Healer
 - Typheus
-Flash: '[S] John: Enter village.'
-Page: '3079'
 ---
+Flash: '[S] JOHN. RISE UP.'
+Page: '3087'
 Contributors:
 - Lexxy (art)
 Date: December 16, 2010
@@ -679,18 +681,18 @@ URLs:
 - https://www.bgreco.net/hsflash/004987.html
 Featured Tracks:
 - Savior of the Waking World
-Flash: '[S] JOHN. RISE UP.'
-Page: '3087'
 ---
+Flash: '[S] Wake.'
+Page: '3297'
 Date: January 15, 2011
 URLs:
 - https://youtu.be/cIqYNGZokFY
 - https://www.bgreco.net/hsflash/005197.html
 Featured Tracks:
 - track:MeGaLoVania
-Flash: '[S] Wake.'
-Page: '3297'
 ---
+Flash: '[S] Kanaya: Return to the core.'
+Page: '3321'
 Contributors:
 - Brett Muller (art)
 - celestialKarakul (art)
@@ -711,9 +713,9 @@ Featured Tracks:
 - Eridan's Theme
 - Nautical Nightmare
 - Heir Conditioning
-Flash: '[S] Kanaya: Return to the core.'
-Page: '3321'
 ---
+Flash: '[S] Equius: Seek the highb100d.'
+Page: '3438'
 Contributors:
 - Brett Muller (art)
 - celestialKarakul (art)
@@ -734,9 +736,9 @@ Featured Tracks:
 - Blackest Heart (With Honks)
 - Midnight Calliope
 - track:miracles-icp
-Flash: '[S] Equius: Seek the highb100d.'
-Page: '3438'
 ---
+Flash: '[S] 3x SHOWDOWN COMBO.'
+Page: '3520'
 Contributors:
 - Eyes5 (art)
 - Lexxy (art)
@@ -749,18 +751,18 @@ URLs:
 - https://www.bgreco.net/hsflash/005420.html
 Featured Tracks:
 - Trollian Standoff
-Flash: '[S] 3x SHOWDOWN COMBO.'
-Page: '3520'
 ---
+Flash: '[S] All: Behold glory of Zillyhoo.'
+Page: '3679'
 Date: March 23, 2011
 URLs:
 - https://youtu.be/LB2wi2EYSbw
 - https://www.bgreco.net/hsflash/005579.html
 Featured Tracks:
 - Warhammer of Zillyhoo
-Flash: '[S] All: Behold glory of Zillyhoo.'
-Page: '3679'
 ---
+Flash: '[S] Seer: Descend.'
+Page: '3695'
 Contributors:
 - Eyes5 (art)
 - Lexxy (art)
@@ -774,9 +776,9 @@ URLs:
 - https://www.bgreco.net/hsflash/005595.html
 Featured Tracks:
 - Black Rose / Green Sun
-Flash: '[S] Seer: Descend.'
-Page: '3695'
 ---
+Flash: '[S] ==>'
+Page: '3696'
 Contributors:
 - Lexxy (art)
 Date: April 2, 2011
@@ -784,17 +786,17 @@ URLs:
 - https://www.bgreco.net/hsflash/005596.html
 Featured Tracks:
 - At The Price of Oblivion
-Flash: '[S] ==>'
-Page: '3696'
 ---
+Flash: '[S] Terezi: Read note.'
+Page: '3718'
 Date: April 17, 2011
 URLs:
 - https://www.bgreco.net/hsflash/005618.html
 Featured Tracks:
 - Secret ROM
-Flash: '[S] Terezi: Read note.'
-Page: '3718'
 ---
+Flash: '[S] Terezi: Play records.'
+Page: '3725'
 Date: April 19, 2011
 URLs:
 - https://www.bgreco.net/hsflash/005625.html
@@ -805,9 +807,9 @@ Featured Tracks:
 - Unlabeled
 - XROM
 - track:im-a-member-of-the-midnight-crew
-Flash: '[S] Terezi: Play records.'
-Page: '3725'
 ---
+Flash: '[S] Seer: Ascend.'
+Page: '3744'
 Contributors:
 - clorinspats (art)
 - Eyes5 (art)
@@ -824,23 +826,23 @@ URLs:
 - https://www.bgreco.net/hsflash/005644.html
 Featured Tracks:
 - Terezi Owns
-Flash: '[S] Seer: Ascend.'
-Page: '3744'
 ---
+Flash: '[S] Flip.'
+Page: '3760'
 Date: May 15, 2011
 URLs:
 - https://youtu.be/8RC_02KeBrE
 Featured Tracks:
 - 'BL1ND JUST1C3 : 1NV3ST1G4T1ON !!'
-Flash: '[S] Flip.'
-Page: '3760'
 ---
+Flash: '[S][o] ==>'
+Page: '3952'
 Date: August 15, 2011
 Featured Tracks:
 - Typheus
-Flash: '[S][o] ==>'
-Page: '3952'
 ---
+Flash: '[S] Attempt rare and highly dangerous 5x SHOWDOWN COMBO.'
+Page: '4085'
 Contributors:
 - Killian Ng (art)
 - Lazylaz (art)
@@ -850,9 +852,9 @@ URLs:
 - https://www.bgreco.net/hsflash/005985.html
 Featured Tracks:
 - The Carnival
-Flash: '[S] Attempt rare and highly dangerous 5x SHOWDOWN COMBO.'
-Page: '4085'
 ---
+Flash: '[S] Cascade.'
+Page: '4109'
 Contributors:
 - Brett Muller (art)
 - Eyes5 (art)
@@ -876,21 +878,19 @@ URLs:
 - https://www.bgreco.net/hsflash/006009.html
 Featured Tracks:
 - Cascade
-Flash: '[S] Cascade.'
-Page: '4109'
 ---
 Act: Intermission 2 - The Man in the Cairo Overcoat.
 Directory: i2
 Color: '#22cc22'
 ---
+Flash: '[S] Begin intermission 2.'
+Page: '4111'
 Date: October 31, 2011
 URLs:
 - https://youtu.be/Bc0DAfQuFNQ
 - https://www.bgreco.net/hsflash/006011.html
 Featured Tracks:
 - English
-Flash: '[S] Begin intermission 2.'
-Page: '4111'
 ---
 Side: Side 2 (Acts 6-7)
 Directory: s2
@@ -901,90 +901,92 @@ Act: Act 6 Act 1 - Through Broken Glass
 Directory: a6a1
 Color: '#7799ff'
 ---
+Flash: '[S] ACT 6'
+Page: '4113'
 Date: November 11, 2011
 URLs:
 - https://youtu.be/htBxlE2hKok
 - https://www.bgreco.net/hsflash/006013.html
 Featured Tracks:
 - Homestuck Anthem
-Flash: '[S] ACT 6'
-Page: '4113'
 ---
+Flash: '[S] ==>'
+Page: '4275'
 Date: December 7, 2011
 Featured Tracks:
 - Sick Bleats
-Flash: '[S] ==>'
-Page: '4275'
 ---
+Flash: '[S] Jane: Get mail.'
+Page: '4282'
 Date: December 9, 2011
 Featured Tracks:
 - Windchime Foley
-Flash: '[S] Jane: Get mail.'
-Page: '4282'
 ---
 Act: Act 6 Intermission 1 - corpse party
 Directory: a6i1
 Color: '#eb0000'
 ---
+Flash: '[S][A6I1] Karkat: Mental breakdown.'
+Page: '4373'
 Date: December 23, 2011
 URLs:
 - https://www.bgreco.net/hsflash/006273.html
 Featured Tracks:
 - Frustracean
-Flash: '[S][A6I1] Karkat: Mental breakdown.'
-Page: '4373'
 ---
+Flash: '[S] END OF ACT 6 INTERMISSION 1'
+Page: '4390'
 Date: December 29, 2011
 URLs:
 - https://youtu.be/kwuo1yH5DHg
 - https://www.bgreco.net/hsflash/006290.html
 Featured Tracks:
 - Infinity Mechanism
-Flash: '[S] END OF ACT 6 INTERMISSION 1'
-Page: '4390'
 ---
 Act: Act 6 Act 2 - Your shit is wrecked.
 Directory: a6a2
 Color: '#f2a400'
 ---
+Flash: '[S] Roxy: Sleepwalk.'
+Page: '4486'
 Date: January 21, 2011
 URLs:
 - https://youtu.be/1ZYAcoEQ0dA
 - https://www.bgreco.net/hsflash/006386.html
 Featured Tracks:
 - Even in Death
-Flash: '[S] Roxy: Sleepwalk.'
-Page: '4486'
 ---
+Flash: '[S] RAP-OFF!!!!!!!!!!'
+Page: '4541'
 Date: February 4, 2012
 Featured Tracks:
 - Anbroids
-Flash: '[S] RAP-OFF!!!!!!!!!!'
-Page: '4541'
 ---
+Flash: '[S] Prince of Heart: Rise up.'
+Page: '4572'
 Date: February 16, 2012
 URLs:
 - https://youtu.be/PVO0FXYAfKw
 - https://www.bgreco.net/hsflash/006472.html
 Featured Tracks:
 - Time on My Side
-Flash: '[S] Prince of Heart: Rise up.'
-Page: '4572'
 ---
+Flash: '[S] Frigglish: Fast forward to Jaspersprite.'
+Page: '4617'
 Date: February 26, 2012
 Featured Tracks:
 - Chorale for Jaspers
-Flash: '[S] Frigglish: Fast forward to Jaspersprite.'
-Page: '4617'
 ---
+Flash: '[S] Ride.'
+Page: pony2
 Date: February 26, 2012
 URLs:
 - https://youtu.be/vHSyoThUyOQ
 Featured Tracks:
 - Pony Chorale
-Flash: '[S] Ride.'
-Page: pony2
 ---
+Flash: '[S] Jane: Enter.'
+Page: '4665'
 Date: March 8, 2012
 URLs:
 - https://youtu.be/cbg-wxqtgUo
@@ -992,98 +994,98 @@ URLs:
 Featured Tracks:
 - Another Jungle
 - A Taste for Adventure
-Flash: '[S] Jane: Enter.'
-Page: '4665'
 ---
 Act: Act 6 Intermission 2 - penis ouija
 Directory: a6i2
 Color: '#e00707'
 ---
+Flash: '[S][A6I2] ???'
+Page: '4815'
 Date: April 3, 2012
 Featured Tracks:
 - weird moody horse shit
-Flash: '[S][A6I2] ???'
-Page: '4815'
 ---
 Act: Act 6 Act 3 - Nobles
 Directory: a6a3
 Color: '#8899cc'
 ---
+Flash: '[S] ACT 6 ACT 3'
+Page: '4820'
 Date: April 14, 2012
 URLs:
 - https://www.bgreco.net/hsflash/006720.html
 Featured Tracks:
 - Rain
-Flash: '[S] ACT 6 ACT 3'
-Page: '4820'
 ---
+Flash: '[S] Jane: Proceed.'
+Page: '4825'
 Date: April 16, 2012
 URLs:
 - https://www.bgreco.net/hsflash/006725.html
 Featured Tracks:
 - Ruins (With Strings)
-Flash: '[S] Jane: Proceed.'
-Page: '4825'
 ---
+Flash: '[S] Jane: Cautiously approach.'
+Page: '4827'
 Date: April 17, 2012
 URLs:
 - https://www.bgreco.net/hsflash/006727.html
 Featured Tracks:
 - Elevatorstuck
-Flash: '[S] Jane: Cautiously approach.'
-Page: '4827'
 ---
+Flash: '[S] DD: Ascend.'
+Page: '4942'
 Date: May 17, 2012
 Featured Tracks:
 - Black
-Flash: '[S] DD: Ascend.'
-Page: '4942'
 ---
+Flash: '[S] DD: Ascend more casually.'
+Page: '4944'
 Date: May 17, 2012
 URLs:
 - https://youtu.be/owe03uIkhFo
 Featured Tracks:
 - I'm a Member of the Midnight Crew (Acapella)
-Flash: '[S] DD: Ascend more casually.'
-Page: '4944'
 ---
+Flash: '[S] Terry: Fast forward to Liv.'
+Page: '5027'
 Date: June 12, 2012
 Featured Tracks:
 - I Don't Want to Miss a Thing
-Flash: '[S] Terry: Fast forward to Liv.'
-Page: '5027'
 ---
+Flash: '[S] Dirk: Synchronize.'
+Page: '5238'
 Date: July 9, 2012
 URLs:
 - https://youtu.be/GZ0PkXNtUhU
 - https://www.bgreco.net/hsflash/007138.html
 Featured Tracks:
 - Unite Synchronization
-Flash: '[S] Dirk: Synchronize.'
-Page: '5238'
 ---
+Flash: '[S] Dirk: Unite.'
+Page: '5252'
 Date: July 9, 2012
 URLs:
 - https://youtu.be/U9uFkc3N4JQ
 - https://www.bgreco.net/hsflash/007152.html
 Featured Tracks:
 - Unite Synchronization
-Flash: '[S] Dirk: Unite.'
-Page: '5252'
 ---
+Flash: '[S] Caliborn: Enter.'
+Page: '5261'
 Date: July 28, 2012
 URLs:
 - https://youtu.be/L4QUXZTKgfo
 - https://www.bgreco.net/hsflash/007161.html
 Featured Tracks:
 - Eternity Served Cold
-Flash: '[S] Caliborn: Enter.'
-Page: '5261'
 ---
 Act: Act 6 Intermission 3 - Ballet of the Dancestors
 Directory: a6i3
 Color: '#b536da'
 ---
+Flash: '[S] ACT 6 INTERMISSION 3'
+Page: '5263'
 Contributors:
 - Amanda H. (art)
 - Chaz Canterbury (art)
@@ -1104,9 +1106,9 @@ Featured Tracks:
 - GameGlr
 - Iron Infidel
 - Elevatorstuck
-Flash: '[S] ACT 6 INTERMISSION 3'
-Page: '5263'
 ---
+Flash: '[S][A6I3] ==>'
+Page: '5308'
 Contributors:
 - Amanda H. (art)
 - Chaz Canterbury (art)
@@ -1129,39 +1131,39 @@ Featured Tracks:
 - Purple Bard
 - Teal Seer
 - Crab Waltz
-Flash: '[S][A6I3] ==>'
-Page: '5308'
 ---
-Date: October 9, 2012
-Featured Tracks:
-- weird moody horse shit
 Flash: '[S][A6I3] ==>'
 Page: '5373'
----
 Date: October 9, 2012
 Featured Tracks:
 - weird moody horse shit
+---
 Flash: '[S][A6I3] ==>'
 Page: '5374'
----
 Date: October 9, 2012
 Featured Tracks:
 - weird moody horse shit
+---
 Flash: '[S][A6I3] ==>'
 Page: '5375'
----
-Date: October 11, 2012
+Date: October 9, 2012
 Featured Tracks:
 - weird moody horse shit
+---
 Flash: '[S][A6I3] ==>'
 Page: '5376'
----
 Date: October 11, 2012
 Featured Tracks:
 - weird moody horse shit
+---
 Flash: '[S][A6I3] ==>'
 Page: '5377'
+Date: October 11, 2012
+Featured Tracks:
+- weird moody horse shit
 ---
+Flash: '[S][A6I3] ==>'
+Page: '5398'
 Contributors:
 - Amanda H. (art)
 - Chaz Canterbury (art)
@@ -1185,14 +1187,14 @@ Featured Tracks:
 - Orchid Horror
 - Davesprite
 - iRRRRRRRRECONCILA8LE
-Flash: '[S][A6I3] ==>'
-Page: '5398'
 ---
-Date: October 27, 2012
-Cover Art File Extension: gif
 Flash: '[S][A6I3] ==>'
 Page: '5426'
+Date: October 27, 2012
+Cover Art File Extension: gif
 ---
+Flash: '[S][A6I3] MINISTRIFE!!!'
+Page: '5427'
 Contributors:
 - 'Feastings (art: character sprites)'
 - 'Scarodactyl (art: background sprites)'
@@ -1202,241 +1204,241 @@ URLs:
 - https://www.bgreco.net/hsflash/007327.html
 Featured Tracks:
 - Killed by BR8K Spider!!!!!!!!
-Flash: '[S][A6I3] MINISTRIFE!!!'
-Page: '5427'
 ---
 Act: Act 6 Act 4 - Void
 Directory: a6a4
 Color: '#cccccc'
 ---
+Flash: '[S] ACT 6 ACT 4'
+Page: '5438'
 Date: November 12, 2012
 URLs:
 - https://youtu.be/mF3mNn7FPwU
 - https://www.bgreco.net/hsflash/007338.html
 Featured Tracks:
 - Even in Death (T'Morra's Belly Mix)
-Flash: '[S] ACT 6 ACT 4'
-Page: '5438'
 ---
+Flash: '[S] ==>'
+Page: '5440'
 Date: November 14, 2012
 Featured Tracks:
 - Eternity Served Cold
-Flash: '[S] ==>'
-Page: '5440'
 ---
 Act: Act 6 Intermission 4 - Dead
 Directory: a6i4
 Color: '#777777'
 ---
+Flash: '[S][A6I4] ==>'
+Page: '5471'
 Date: November 18, 2012
 Featured Tracks:
 - Elevatorstuck
-Flash: '[S][A6I4] ==>'
-Page: '5471'
 ---
-Date: November 19, 2012
-Featured Tracks:
-- Elevatorstuck
 Flash: '[S][A6I4] ==>'
 Page: '5472'
----
 Date: November 19, 2012
 Featured Tracks:
 - Elevatorstuck
+---
 Flash: '[S][A6I4] ==>'
 Page: '5473'
----
 Date: November 19, 2012
 Featured Tracks:
 - Elevatorstuck
+---
 Flash: '[S][A6I4] ==>'
 Page: '5474'
+Date: November 19, 2012
+Featured Tracks:
+- Elevatorstuck
 ---
+Flash: '[S][A6I4] ==>'
+Page: '5485'
 Date: November 21, 2012
 Featured Tracks:
 - Elevatorstuck
-Flash: '[S][A6I4] ==>'
-Page: '5485'
 ---
-Date: November 25, 2012
-Featured Tracks:
-- Elevatorstuck
 Flash: '[S!][A6I4] ==>'
 Page: '5494'
----
 Date: November 25, 2012
 Featured Tracks:
 - Elevatorstuck
+---
 Flash: '[!!!][A6I4] ==>'
 Page: '5495'
+Date: November 25, 2012
+Featured Tracks:
+- Elevatorstuck
 ---
 Act: Act 6 Act 5 - Of Gods and Tricksters
 Directory: a6a5
 Color: '#ffee00'
 ---
+Flash: '[S] ACT 6 ACT 5'
+Page: '5512'
 Date: November 28, 2012
 URLs:
 - https://youtu.be/ShIvL8SLC7c
 - https://www.bgreco.net/hsflash/007412.html
 Featured Tracks:
 - A Taste for Adventure
-Flash: '[S] ACT 6 ACT 5'
-Page: '5512'
 ---
+Flash: '[S] Ride.'
+Page: '5655'
 Date: December 26, 2012
 URLs:
 - https://youtu.be/z48Ssmhu3vg
 - https://www.bgreco.net/hsflash/007555.html
 Featured Tracks:
 - Horschestra STRONG Version
-Flash: '[S] Ride.'
-Page: '5655'
 ---
+Flash: '[S] Jane: Engage.'
+Page: '5711'
 Date: January 9, 2013
 URLs:
 - https://youtu.be/5O0OZQ3BuTQ
 - https://www.bgreco.net/hsflash/008131.html
 Featured Tracks:
 - Trickster Mode (Engage)
-Flash: '[S] Jane: Engage.'
-Page: '5711'
 ---
+Flash: '[S] Jane: Blast off.'
+Page: '5712'
 Date: January 10, 2013
 URLs:
 - https://youtu.be/tPo5q6985uE
 Featured Tracks:
 - Trickster Mode (Blast Off)
-Flash: '[S] Jane: Blast off.'
-Page: '5712'
 ---
+Flash: '[S] ACT 6 ACT 5 ACT 2'
+Page: '5714'
 Date: January 11, 2013
 Featured Tracks:
 - Kazoostuck
-Flash: '[S] ACT 6 ACT 5 ACT 2'
-Page: '5714'
 ---
+Flash: '[S] ==>'
+Page: '5726'
 Date: January 13, 2013
 Featured Tracks:
 - Trickster Mode (Engage)
-Flash: '[S] ==>'
-Page: '5726'
 ---
+Flash: '[S] ==>'
+Page: '5740'
 Date: January 17, 2013
 Featured Tracks:
 - Trickster Mode (Engage)
-Flash: '[S] ==>'
-Page: '5740'
 ---
+Flash: '[S] ==>'
+Page: '5759'
 Date: January 23, 2013
 Featured Tracks:
 - Trickster Mode (Engage)
-Flash: '[S] ==>'
-Page: '5759'
 ---
+Flash: '[S] Tricksters: Alchemize.'
+Page: '5763'
 Date: January 24, 2013
 Featured Tracks:
 - A Very Trickster Mode Christmas
-Flash: '[S] Tricksters: Alchemize.'
-Page: '5763'
 ---
+Flash: '[S] ==>'
+Page: '5764'
 Date: January 25, 2013
 Featured Tracks:
 - Warhammer of Zillyhoo
-Flash: '[S] ==>'
-Page: '5764'
 ---
+Flash: '[S] WHEEEEEEEEEEE!'
+Page: '5776'
 Date: January 26, 2013
 Featured Tracks:
 - A Very Trickster Mode Christmas (WHEEEEEEEEEEE!)
-Flash: '[S] WHEEEEEEEEEEE!'
-Page: '5776'
 ---
+Flash: '[S] HA HA HA! HE HE HE! HO HO HO!'
+Page: '5777'
 Date: January 26, 2013
 Featured Tracks:
 - A Very Trickster Mode Christmas (With Fancy Santas)
-Flash: '[S] HA HA HA! HE HE HE! HO HO HO!'
-Page: '5777'
 ---
 Act: 'Act 6 Intermission 5 - <span style="color: #929292">I''M PUTTING YOU ON SPEAKER
     CRAB.</span>'
 Directory: a6i5
 Color: '#77ff88'
 ---
+Flash: '[S][A6I5] BEGIN INTERFISHIN'
+Page: '5981'
 Date: March 10, 2013
 URLs:
 - https://youtu.be/fT0SLVNdvF8
 Featured Tracks:
 - Elevatorstuck
-Flash: '[S][A6I5] BEGIN INTERFISHIN'
-Page: '5981'
 ---
+Flash: '[S][A6I5] ==>'
+Page: '5997'
 Date: March 14, 2013
 Featured Tracks:
 - Yaldabaoth
-Flash: '[S][A6I5] ==>'
-Page: '5997'
 ---
+Flash: '[S][A6I5] END OF ACT 6 INTERMISSION 5 INTERMISSION 4'
+Page: '6066'
 Date: April 1, 2013
 Featured Tracks:
 - Blackest Heart (With Honks)
-Flash: '[S][A6I5] END OF ACT 6 INTERMISSION 5 INTERMISSION 4'
-Page: '6066'
 ---
+Flash: '[S][A6I5] ==>'
+Page: '6231'
 Date: April 13, 2013
 URLs:
 - https://youtu.be/oReLrD9WrA8
 Featured Tracks:
 - A Taste for Adventure
-Flash: '[S][A6I5] ==>'
-Page: '6231'
 ---
 Act: Act 6 Act 6 Act 1 - HOMOSUCK
 Directory: a6a6a1
 Color: '#2ed73a'
 ---
+Flash: '[S] ACT 6 ACT 6'
+Page: '6243'
 Date: June 12, 2013
 URLs:
 - https://youtu.be/PTYc67Cp6oE
 Featured Tracks:
 - Homosuck Anthem
-Flash: '[S] ACT 6 ACT 6'
-Page: '6243'
 ---
 Act: Act 6 Act 6 Intermission 1 - Stardust
 Directory: a6a6i1
 Color: '#dddddd'
 ---
+Flash: '[S] ACT 6 ACT 6 INTERMISSION 1'
+Page: '6278'
 Date: June 14, 2013
 URLs:
 - https://youtu.be/j-wdUF0ofts
 - https://www.bgreco.net/hsflash/008178.html
 Featured Tracks:
 - Gold Pilot
-Flash: '[S] ACT 6 ACT 6 INTERMISSION 1'
-Page: '6278'
 ---
+Flash: '[S][A6A6I1] ====>'
+Page: '6400'
 Date: August 7, 2013
 URLs:
 - https://www.bgreco.net/hsflash/008300.html
 Featured Tracks:
 - Elevatorstuck
-Flash: '[S][A6A6I1] ====>'
-Page: '6400'
 ---
 Act: Act 6 Act 6 Intermission 2 - theres problems
 Directory: a6a6i2
 Color: '#e00707'
 ---
+Flash: '[S][A6A6I2] ====>'
+Page: '6552'
 Date: September 3, 2013
 Featured Tracks:
 - track:fuchsia-ruler
-Flash: '[S][A6A6I2] ====>'
-Page: '6552'
 ---
 Act: Act 6 Act 6 Intermission 3 - GAME OVER
 Directory: a6a6i3
 Color: '#dddddd'
 ---
+Flash: '[S] GAME OVER.'
+Page: '6901'
 Contributors:
 - Hanni Brosh (art)
 - Matt Cummings (art)
@@ -1450,63 +1452,63 @@ URLs:
 - https://www.bgreco.net/hsflash/GAMEOVER.html
 Featured Tracks:
 - track:carne-vale
-Flash: '[S] GAME OVER.'
-Page: '6901'
 ---
 Act: 'Act 6 Act 6 Intermission 4 - <span style="color: #008b8b">F1X TH1S</span>'
 Directory: a6a6i4
 Color: '#4466ff'
 ---
+Flash: '[S][A6A6I4] ====>'
+Page: '7086'
 Date: November 24, 2014
 Featured Tracks:
 - Typheus (Glitched)
-Flash: '[S][A6A6I4] ====>'
-Page: '7086'
 ---
+Flash: '[S][A6A6I4] ====>'
+Page: '7098'
 Date: November 28, 2014
 URLs:
 - https://youtu.be/Xdn70gnBw2w
 - https://www.bgreco.net/hsflash/008998.html
 Featured Tracks:
 - Pipeorgankind
-Flash: '[S][A6A6I4] ====>'
-Page: '7098'
 ---
+Flash: '[S][A6A6I4] ====>'
+Page: '7101'
 Date: December 1, 2014
 Featured Tracks:
 - Elevatorstuck, with Meows
-Flash: '[S][A6A6I4] ====>'
-Page: '7101'
 ---
+Flash: '[S][A6A6I4] ====>'
+Page: '7405'
 Date: January 19, 2015
 Featured Tracks:
 - not a creature was stirring
-Flash: '[S][A6A6I4] ====>'
-Page: '7405'
 ---
 Act: Act 6 Act 6 Act 5 - MASTERPIECE
 Directory: a6a6a5
 Color: '#55ff00'
 ---
+Flash: '[S] ACT 6 ACT 6 ACT 5'
+Page: '7409'
 Date: April 13, 2015
 Featured Tracks:
 - Homosuck Swan Song
-Flash: '[S] ACT 6 ACT 6 ACT 5'
-Page: '7409'
 ---
+Flash: '[S] MSPA Reader: Mental breakdown.'
+Page: '7448'
 Date: April 22, 2015
 URLs:
 - https://youtu.be/v3PIyyIr2pQ
 - https://www.bgreco.net/hsflash/009348.html
 Featured Tracks:
 - Hello Zepp
-Flash: '[S] MSPA Reader: Mental breakdown.'
-Page: '7448'
 ---
 Act: 'Act 6 Act 6 Intermission 5 - <span style="color: #1076a2">She''s 8ack</span>'
 Directory: a6a6i5
 Color: '#00ffff'
 ---
+Flash: '[S] ACT 6 ACT 6 INTERMISSION 5'
+Page: '7449'
 Contributors:
 - Xamag (art)
 - Adrienne Garcia (art)
@@ -1519,17 +1521,17 @@ URLs:
 - https://www.bgreco.net/hsflash/009349.html
 Featured Tracks:
 - track:moonsetter
-Flash: '[S] ACT 6 ACT 6 INTERMISSION 5'
-Page: '7449'
 ---
+Flash: '[S][A6A6I5] ====>'
+Page: '7635'
 Contributors:
 - Rah-Bop (art)
 Date: June 3, 2015
 Featured Tracks:
 - Echidna
-Flash: '[S][A6A6I5] ====>'
-Page: '7635'
 ---
+Flash: '[S][A6A6I5] ====>'
+Page: '7928'
 Contributors:
 - ipgd (art)
 Date: July 23, 2015
@@ -1537,9 +1539,9 @@ URLs:
 - https://youtu.be/9G-2714Ht9Q
 Featured Tracks:
 - Horsecatska
-Flash: '[S][A6A6I5] ====>'
-Page: '7928'
 ---
+Flash: '[S] Terezi: Remem8er.'
+Page: '7959'
 Contributors:
 - Adrienne Garcia (art)
 - Ikimaru (art)
@@ -1551,13 +1553,13 @@ URLs:
 - https://youtu.be/3pLgxneqLgk
 Featured Tracks:
 - Do You Remem8er Me
-Flash: '[S] Terezi: Remem8er.'
-Page: '7959'
 ---
 Act: 'Act 6 Act 6 Act 6 - <span style="color: #ff0000">Collide.</span>'
 Directory: a6a6a6
 Color: '#ee1100'
 ---
+Flash: '[S] Collide.'
+Page: '8087'
 Contributors:
 - Adrienne Garcia (art)
 - Airin (art)
@@ -1586,13 +1588,13 @@ Featured Tracks:
 - Oppa Toby Style
 - Eternity, Served Cold (Canon Edit)
 - track:heir-of-grief-collide
-Flash: '[S] Collide.'
-Page: '8087'
 ---
 Act: 'Act 7 - <span style="color: #c7ff43">The Rapture</span><br><i>&amp; Post Canon</i>'
 Directory: a7
 Color: '#dddddd'
 ---
+Flash: '[S] ACT 7'
+Page: '8127'
 Contributors:
 - Angela Sham
 - Ani Roschier
@@ -1602,15 +1604,15 @@ URLs:
 - https://youtu.be/FevMNMwvdPw
 Featured Tracks:
 - Overture (Canon Edit)
-Flash: '[S] ACT 7'
-Page: '8127'
 ---
+Flash: '[S] ==>'
+Page: '8129'
 Date: October 25, 2016
 Featured Tracks:
 - Windchime Foley
-Flash: '[S] ==>'
-Page: '8129'
 ---
+Flash: '[S] ==>'
+Page: '8130'
 Contributors:
 - Adrienne Garcia
 Date: October 25, 2016
@@ -1618,8 +1620,6 @@ URLs:
 - https://youtu.be/rMZU89jY2j8
 Featured Tracks:
 - Ascend
-Flash: '[S] ==>'
-Page: '8130'
 ---
 Side: Additional Canon
 Color: '#f2a400'

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -17,6 +17,7 @@ Flash: '[S] John: Play haunting piano refrain.'
 Page: '77'
 Date: April 21, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11s
 - https://www.bgreco.net/hsflash/001977.html
 Featured Tracks:
 - Showtime (Piano Refrain)
@@ -32,6 +33,8 @@ Featured Tracks:
 Flash: '[S] John: Enter.'
 Page: '88'
 Date: April 27, 2009
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=100s
 Featured Tracks:
 - Harlequin
 ---
@@ -56,6 +59,7 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '186'
 Date: May 21, 2009
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Harlequin
 ---
@@ -63,6 +67,7 @@ Flash: '[S] Rose: Play a haunting refrain on the violin.'
 Page: '222'
 Date: May 29, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=194s
 - https://www.bgreco.net/hsflash/002122.html
 Featured Tracks:
 - Aggrieve (Violin Refrain)
@@ -83,6 +88,7 @@ Color: '#ff5555'
 Flash: '[S] YOU THERE. BOY.'
 Page: '253'
 Date: June 14, 2009
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/002153.html
 Featured Tracks:
@@ -92,6 +98,7 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '338'
 Date: July 4, 2009
+# Not in [S] 'Homestuck - All flashes' list
 URLs:
 - https://www.bgreco.net/hsflash/002238.html
 Featured Tracks:
@@ -120,6 +127,7 @@ Flash: '[S] Rose: Youth roll right out the front door.'
 Page: '388'
 Date: July 19, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=398s
 - https://www.bgreco.net/hsflash/002288.html
 Featured Tracks:
 - Aggrieve
@@ -128,6 +136,7 @@ Flash: '[S] ==>==>==>!!!!!!!!!'
 Page: '393'
 Date: July 22, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=449s
 - https://www.bgreco.net/hsflash/002293.html
 Featured Tracks:
 - Showtime (Imp Strife Mix)
@@ -136,6 +145,7 @@ Flash: '[S] GET UP JOHN, THIS IS NO TIME FOR SLUMBER.'
 Page: '397'
 Date: July 23, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=468s
 - https://www.bgreco.net/hsflash/002297.html
 Featured Tracks:
 - Showtime (Imp Strife Mix)
@@ -144,6 +154,7 @@ Flash: '[S] JOHN, SALVAGE YOUR WEAPON AND FIGHT ON!'
 Page: '400'
 Date: July 25, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=486s
 - https://www.bgreco.net/hsflash/002300.html
 Featured Tracks:
 - Showtime (Imp Strife Mix)
@@ -151,6 +162,7 @@ Featured Tracks:
 Flash: '[S] WHAT THIS IS SO OUTRAGEOUS'
 Page: '418'
 Date: July 30, 2009
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Nannaquin
 ---
@@ -158,6 +170,7 @@ Flash: '[S] GO ON. ==>'
 Page: '422'
 Date: August 1, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=521s
 - https://www.bgreco.net/hsflash/002322.html
 Featured Tracks:
 - Skies of Skaia
@@ -165,6 +178,7 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '476'
 Date: August 15, 2009
+# Not in [S] 'Homestuck - All flashes' list
 URLs:
 - https://www.bgreco.net/hsflash/002376.html
 Featured Tracks:
@@ -173,12 +187,16 @@ Featured Tracks:
 Flash: '[S] John: Sleep.'
 Page: '644'
 Date: September 15, 2009
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=649s
 Featured Tracks:
 - John Sleeps / Skaian Magicant
 ---
 Flash: '[S] John: Wake up.'
 Page: '651'
 Date: September 17, 2009
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=667s
 Featured Tracks:
 - John Sleeps / Skaian Magicant
 ---
@@ -225,18 +243,22 @@ Color: '#55ff77'
 Flash: '[S] Jade: Play a silly flute refrain.'
 Page: '769'
 Date: October 15, 2009
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Flute Refrain
 ---
 Flash: '[S] Jade: Play a hauntingly relaxing bassline.'
 Page: '822'
 Date: October 27, 2009
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1023s
 Featured Tracks:
 - Gardener
 ---
 Flash: '[S] Jade: Open FreshJamz!'
 Page: '830'
 Date: October 31, 2009
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Showtime Remix
 - Aggrieve Remix
@@ -261,6 +283,7 @@ Flash: '[S] Dave: STRIFE.'
 Page: '836'
 Date: November 6, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1154s
 - https://www.bgreco.net/hsflash/002736.html
 Featured Tracks:
 - Beatdown (Strider Style)
@@ -269,6 +292,7 @@ Flash: '[S] Jade: Descend.'
 Page: '843'
 Date: November 8, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1198s
 - https://www.bgreco.net/hsflash/002743.html
 Featured Tracks:
 - Harleboss
@@ -277,6 +301,7 @@ Flash: '[S] Dave: Abscond.'
 Page: '871'
 Date: November 18, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1250s
 - https://www.bgreco.net/hsflash/002771.html
 Featured Tracks:
 - Beatdown Round 2
@@ -285,6 +310,7 @@ Flash: '[S] Rose: Ascend.'
 Page: '879'
 Date: November 20, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1315s
 - https://www.bgreco.net/hsflash/002779.html
 Featured Tracks:
 - Harleboss
@@ -292,6 +318,7 @@ Featured Tracks:
 Flash: '[S] Strife!!!'
 Page: '918'
 Date: November 27, 2009
+# Not in [S] 'Homestuck - All flashes' list
 URLs:
 - https://www.bgreco.net/hsflash/002818.html
 Featured Tracks:
@@ -301,6 +328,7 @@ Flash: '[S] Rose: Fast forward to now.'
 Page: '938'
 Date: December 1, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1396s
 - https://www.bgreco.net/hsflash/002838.html
 Featured Tracks:
 - Chorale for Jaspers
@@ -325,6 +353,8 @@ Featured Tracks:
 Flash: '[S] John: Mental breakdown.'
 Page: '979'
 Date: December 6, 2009
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1587s
 Featured Tracks:
 - Hardlyquin
 ---
@@ -332,6 +362,7 @@ Flash: '[S] Jade: Retrieve package.'
 Page: '980'
 Date: December 8, 2009
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1617s
 - https://www.bgreco.net/hsflash/002880.html
 Featured Tracks:
 - An Unbreakable Union
@@ -349,6 +380,8 @@ Featured Tracks:
 Flash: '[S] Dave: Strife!'
 Page: '1070'
 Date: December 24, 2009
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=1856s
 Featured Tracks:
 - Versus
 ---
@@ -378,6 +411,7 @@ Flash: '[S][I] ==>'
 Page: '1267'
 Date: January 29, 2010
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2341s
 - https://www.bgreco.net/hsflash/003167.html
 Featured Tracks:
 - Three in the Morning
@@ -389,6 +423,7 @@ Color: '#b536da'
 Flash: '[S] ACT 4 ==>'
 Page: '1358'
 Date: February 10, 2010
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/003258.html
 Featured Tracks:
@@ -416,6 +451,7 @@ Flash: '[S] ==>'
 Page: '1656'
 Date: April 3, 2010
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=2595s
 - https://www.bgreco.net/hsflash/003556.html
 Featured Tracks:
 - Bed of Rose's / Dreams of Derse
@@ -433,6 +469,7 @@ Featured Tracks:
 Flash: '[S] Rose and Dave: Shut up and jam.'
 Page: '1720'
 Date: April 22, 2010
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Unsheath'd
 - Welcome to the New Extreme
@@ -501,6 +538,7 @@ Color: '#8585ff'
 Flash: '[S???] ======>'
 Page: '2070'
 Date: June 22, 2010
+# Not in [S] 'Homestuck - All flashes' list (ofc)
 Featured Tracks:
 - Showdown
 ---
@@ -546,6 +584,7 @@ Featured Tracks:
 Flash: "Vriska: What's his deal????????"
 Page: '2672'
 Date: September 26, 2010
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - How Do I Live
 ---
@@ -570,6 +609,7 @@ Contributors:
 - Hanni Brosh (art)
 - Killian Ng (art)
 Date: October 25, 2010
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/004692.html
 Featured Tracks:
@@ -593,6 +633,7 @@ Featured Tracks:
 Flash: 'Dave: Answer Gamzee.'
 Page: '2818'
 Date: October 31, 2010
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - track:miracles-icp
 ---
@@ -647,6 +688,7 @@ Flash: '[S] Jade: STRIFE!!!!!!!!!!!!'
 Page: '3001'
 Date: December 6, 2010
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=4336s
 - https://www.bgreco.net/hsflash/004901.html
 Featured Tracks:
 - track:sunslammer
@@ -663,6 +705,7 @@ Contributors:
 - Lauren Ross (art)
 - Killian Ng (art)
 Date: December 15, 2010
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/004979.html
 Featured Tracks:
@@ -703,6 +746,7 @@ Contributors:
 - Lauren Ross (art)
 - Killian Ng (art)
 Date: January 22, 2011
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/005221.html
 Featured Tracks:
@@ -726,6 +770,7 @@ Contributors:
 - Lauren Ross (art)
 - Killian Ng (art)
 Date: February 6, 2011
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/005338.html
 Featured Tracks:
@@ -770,6 +815,7 @@ Contributors:
 - Lauren Ross (art)
 - Killian Ng (art)
 Date: March 30, 2011
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/005595.html
 Featured Tracks:
@@ -781,6 +827,7 @@ Contributors:
 - Lexxy (art)
 Date: April 2, 2011
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5168s
 - https://www.bgreco.net/hsflash/005596.html
 Featured Tracks:
 - At The Price of Oblivion
@@ -789,6 +836,7 @@ Flash: '[S] Terezi: Read note.'
 Page: '3718'
 Date: April 17, 2011
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=5322s
 - https://www.bgreco.net/hsflash/005618.html
 Featured Tracks:
 - Secret ROM
@@ -796,6 +844,7 @@ Featured Tracks:
 Flash: '[S] Terezi: Play records.'
 Page: '3725'
 Date: April 19, 2011
+# Not in [S] 'Homestuck - All flashes' list
 URLs:
 - https://www.bgreco.net/hsflash/005625.html
 Featured Tracks:
@@ -836,6 +885,7 @@ Featured Tracks:
 Flash: '[S][o] ==>'
 Page: '3952'
 Date: August 15, 2011
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Typheus
 ---
@@ -911,12 +961,15 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '4275'
 Date: December 7, 2011
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Sick Bleats
 ---
 Flash: '[S] Jane: Get mail.'
 Page: '4282'
 Date: December 9, 2011
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=6978s
 Featured Tracks:
 - Windchime Foley
 ---
@@ -928,6 +981,7 @@ Flash: '[S][A6I1] Karkat: Mental breakdown.'
 Page: '4373'
 Date: December 23, 2011
 URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7032s
 - https://www.bgreco.net/hsflash/006273.html
 Featured Tracks:
 - Frustracean
@@ -957,6 +1011,8 @@ Featured Tracks:
 Flash: '[S] RAP-OFF!!!!!!!!!!'
 Page: '4541'
 Date: February 4, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7489s
 Featured Tracks:
 - Anbroids
 ---
@@ -972,6 +1028,8 @@ Featured Tracks:
 Flash: '[S] Frigglish: Fast forward to Jaspersprite.'
 Page: '4617'
 Date: February 26, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7795s
 Featured Tracks:
 - Chorale for Jaspers
 ---
@@ -1000,6 +1058,8 @@ Color: '#e00707'
 Flash: '[S][A6I2] ???'
 Page: '4815'
 Date: April 3, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8071s
 Featured Tracks:
 - weird moody horse shit
 ---
@@ -1010,6 +1070,7 @@ Color: '#8899cc'
 Flash: '[S] ACT 6 ACT 3'
 Page: '4820'
 Date: April 14, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/006720.html
 Featured Tracks:
@@ -1018,6 +1079,7 @@ Featured Tracks:
 Flash: '[S] Jane: Proceed.'
 Page: '4825'
 Date: April 16, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/006725.html
 Featured Tracks:
@@ -1026,6 +1088,7 @@ Featured Tracks:
 Flash: '[S] Jane: Cautiously approach.'
 Page: '4827'
 Date: April 17, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/006727.html
 Featured Tracks:
@@ -1034,6 +1097,8 @@ Featured Tracks:
 Flash: '[S] DD: Ascend.'
 Page: '4942'
 Date: May 17, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8280s
 Featured Tracks:
 - Black
 ---
@@ -1048,6 +1113,8 @@ Featured Tracks:
 Flash: '[S] Terry: Fast forward to Liv.'
 Page: '5027'
 Date: June 12, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8488s
 Featured Tracks:
 - I Don't Want to Miss a Thing
 ---
@@ -1096,6 +1163,7 @@ Contributors:
 - Xamag (art)
 - Tanney Liu (art)
 Date: August 31, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/007163.html
 Featured Tracks:
@@ -1119,6 +1187,7 @@ Contributors:
 - Xamag (art)
 - Tanney Liu (art)
 Date: September 24, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/007208.html
 Featured Tracks:
@@ -1133,30 +1202,40 @@ Featured Tracks:
 Flash: '[S][A6I3] ==>'
 Page: '5373'
 Date: October 9, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9327s
 Featured Tracks:
 - weird moody horse shit
 ---
 Flash: '[S][A6I3] ==>'
 Page: '5374'
 Date: October 9, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9347s
 Featured Tracks:
 - weird moody horse shit
 ---
 Flash: '[S][A6I3] ==>'
 Page: '5375'
 Date: October 9, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9372s
 Featured Tracks:
 - weird moody horse shit
 ---
 Flash: '[S][A6I3] ==>'
 Page: '5376'
 Date: October 11, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9398s
 Featured Tracks:
 - weird moody horse shit
 ---
 Flash: '[S][A6I3] ==>'
 Page: '5377'
 Date: October 11, 2012
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=9422s
 Featured Tracks:
 - weird moody horse shit
 ---
@@ -1174,6 +1253,7 @@ Contributors:
 - Xamag (art)
 - Tanney Liu (art)
 Date: October 22, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/007298.html
 Featured Tracks:
@@ -1190,6 +1270,7 @@ Flash: '[S][A6I3] ==>'
 Page: '5426'
 Date: October 27, 2012
 Cover Art File Extension: gif
+# Yes
 ---
 Flash: '[S][A6I3] MINISTRIFE!!!'
 Page: '5427'
@@ -1198,6 +1279,7 @@ Contributors:
 - 'Scarodactyl (art: background sprites)'
 - 'Shelby Cragg (art: last panel)'
 Date: November 3, 2012
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/007327.html
 Featured Tracks:
@@ -1219,6 +1301,7 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '5440'
 Date: November 14, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Eternity Served Cold
 ---
@@ -1229,42 +1312,49 @@ Color: '#777777'
 Flash: '[S][A6I4] ==>'
 Page: '5471'
 Date: November 18, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
 Flash: '[S][A6I4] ==>'
 Page: '5472'
 Date: November 19, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
 Flash: '[S][A6I4] ==>'
 Page: '5473'
 Date: November 19, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
 Flash: '[S][A6I4] ==>'
 Page: '5474'
 Date: November 19, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
 Flash: '[S][A6I4] ==>'
 Page: '5485'
 Date: November 21, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
 Flash: '[S!][A6I4] ==>'
 Page: '5494'
 Date: November 25, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
 Flash: '[!!!][A6I4] ==>'
 Page: '5495'
 Date: November 25, 2012
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Elevatorstuck
 ---
@@ -1310,48 +1400,63 @@ Featured Tracks:
 Flash: '[S] ACT 6 ACT 5 ACT 2'
 Page: '5714'
 Date: January 11, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10076s
 Featured Tracks:
 - Kazoostuck
 ---
 Flash: '[S] ==>'
 Page: '5726'
 Date: January 13, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10117s
 Featured Tracks:
 - Trickster Mode (Engage)
 ---
 Flash: '[S] ==>'
 Page: '5740'
 Date: January 17, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10132s
 Featured Tracks:
 - Trickster Mode (Engage)
 ---
 Flash: '[S] ==>'
 Page: '5759'
 Date: January 23, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10162s
 Featured Tracks:
 - Trickster Mode (Engage)
 ---
 Flash: '[S] Tricksters: Alchemize.'
 Page: '5763'
 Date: January 24, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10214s
 Featured Tracks:
 - A Very Trickster Mode Christmas
 ---
 Flash: '[S] ==>'
 Page: '5764'
 Date: January 25, 2013
+# Not in [S] 'Homestuck - All flashes'
 Featured Tracks:
 - Warhammer of Zillyhoo
 ---
 Flash: '[S] WHEEEEEEEEEEE!'
 Page: '5776'
 Date: January 26, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10231s
 Featured Tracks:
 - A Very Trickster Mode Christmas (WHEEEEEEEEEEE!)
 ---
 Flash: '[S] HA HA HA! HE HE HE! HO HO HO!'
 Page: '5777'
 Date: January 26, 2013
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=10239s
 Featured Tracks:
 - A Very Trickster Mode Christmas (With Fancy Santas)
 ---
@@ -1370,12 +1475,14 @@ Featured Tracks:
 Flash: '[S][A6I5] ==>'
 Page: '5997'
 Date: March 14, 2013
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Yaldabaoth
 ---
 Flash: '[S][A6I5] END OF ACT 6 INTERMISSION 5 INTERMISSION 4'
 Page: '6066'
 Date: April 1, 2013
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Blackest Heart (With Honks)
 ---
@@ -1415,6 +1522,7 @@ Featured Tracks:
 Flash: '[S][A6A6I1] ====>'
 Page: '6400'
 Date: August 7, 2013
+# Not captured in [S] 'Homestuck - All flashes'
 URLs:
 - https://www.bgreco.net/hsflash/008300.html
 Featured Tracks:
@@ -1427,6 +1535,7 @@ Color: '#e00707'
 Flash: '[S][A6A6I2] ====>'
 Page: '6552'
 Date: September 3, 2013
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - track:fuchsia-ruler
 ---
@@ -1457,6 +1566,7 @@ Color: '#4466ff'
 Flash: '[S][A6A6I4] ====>'
 Page: '7086'
 Date: November 24, 2014
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Typheus (Glitched)
 ---
@@ -1472,12 +1582,16 @@ Featured Tracks:
 Flash: '[S][A6A6I4] ====>'
 Page: '7101'
 Date: December 1, 2014
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11175s
 Featured Tracks:
 - Elevatorstuck, with Meows
 ---
 Flash: '[S][A6A6I4] ====>'
 Page: '7405'
 Date: January 19, 2015
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11215s
 Featured Tracks:
 - not a creature was stirring
 ---
@@ -1488,6 +1602,8 @@ Color: '#55ff00'
 Flash: '[S] ACT 6 ACT 6 ACT 5'
 Page: '7409'
 Date: April 13, 2015
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=11215s
 Featured Tracks:
 - Homosuck Swan Song
 ---
@@ -1524,6 +1640,7 @@ Page: '7635'
 Contributors:
 - Rah-Bop (art)
 Date: June 3, 2015
+# Not in [S] 'Homestuck - All flashes' list
 Featured Tracks:
 - Echidna
 ---
@@ -1605,6 +1722,7 @@ Featured Tracks:
 Flash: '[S] ==>'
 Page: '8129'
 Date: October 25, 2016
+# '[S] Homestuck - All flashes' precedes the credits
 Featured Tracks:
 - Windchime Foley
 ---
@@ -1613,6 +1731,7 @@ Page: '8130'
 Contributors:
 - Adrienne Garcia
 Date: October 25, 2016
+# '[S] Homestuck - All flashes' precedes the credits
 URLs:
 - https://youtu.be/rMZU89jY2j8
 Featured Tracks:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -47,6 +47,9 @@ Content: |-
     - added lyrics to [[track:dave-striders-cool-mixtape]] (thanks, Niklink, Makin!)
     <!-- link additions -->
     - added Nintendo Music listening links to [[track:big-boos-haunt]], [[track:hazy-maze-cave]], [[track:molgera-battle]], [[track:rainbow-road-super-mario-kart]], [[track:slider-super-mario-64]], and [[track:the-final-battle-super-mario-64]] (thanks, ruby!)
+    <h3>data changes</h3>
+    <!-- misc presentational changes -->
+    - replaced most YouTube playback links for Homestuck flashes ([[flash-side:s1|side 1]], [[flash-side:s2|side 2]]) with timestamped links to Bambosh's ['[S] Homestuck - All flashes'](https://www.youtube.com/watch?v=AEIOQN3YmNc), replacing YouTube links in 60 flashes, and adding YouTube links to 46 flashes missing them altogether (thanks, Meulanie, Lan!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:teal-seer]] not referencing [[track:somethings-different]], and added various commentary related to this (thanks, Makin!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -88,6 +88,7 @@ Content: |-
     <!-- link fixes -->
     - fixed YouTube listening link for [[track:train-requiem]] being given to [[track:train-meldey-next-to-last-station]] instead (thanks, Makin!)
     - fixed Twitter link, removed dead desynced.xyz link, and added MSPFA link for [[group:desynced]] (thanks, meulanie!)
+    - removed duplicate homestuck.com link for [[flash:2070]] (thanks, Lan!)
     <h3>directory changes</h3>
     <details><summary><b>Toggle Directorylog</b></summary>
     - changed directory of [[track:ground-bgm-super-mario-bros]] from <code>ground-theme-super-mario-bros</code> to <code>ground-bgm-super-mario-bros</code>


### PR DESCRIPTION
Resolves #683. Also tidies `Flash` and `Page` fields being placed generally at the bottom of flash entries (they belong at the top, like any name and directory field).