### PR TITLE
YouTube link change: Hometeam Adv8ntage (to composer's upload)

### DIFF
--- a/album/beyond-canon.yaml
+++ b/album/beyond-canon.yaml
@@ -538,7 +538,7 @@ Artists:
 Duration: 3:58
 URLs:
 - https://homestuck.bandcamp.com/track/hometeam-adv8ntage
-- https://youtu.be/ZrkxZz-QeVk
+- https://youtu.be/-THDS3ZI2Wg
 Cover Artists:
 - Tipsy
 Art Tags:

--- a/artists.yaml
+++ b/artists.yaml
@@ -12223,6 +12223,7 @@ URLs:
 - https://twitter.com/twirlincurtis
 - https://solarbearchiptunes.bandcamp.com/
 - https://soundcloud.com/solarbearchiptune
+- https://www.youtube.com/@twirlincurtis
 - https://www.youtube.com/user/solarbearchiptune
 ---
 Artist: Twix Stix

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -156,8 +156,8 @@ Content: |-
         - [[track:out-of-breath]]: was *gneius*, now *genius*
     - tweaked formatting of Bowmantown commentary for [[album:homestuck-vol-10]] ("Jungle Boogie" now links to [[track:jungle-boogie]]; thanks, Lilith!)
     <!-- link fixes -->
-    - fixed YouTube listening link for [[track:train-requiem]] being given to [[track:train-meldey-next-to-last-station]] instead (thanks, Makin!)
     - changed YouTube listening link for [[track:hometeam-adv8ntage]] to composer's upload (thanks, Lilith!)
+    - fixed YouTube listening link for [[track:train-requiem]] being given to [[track:train-meldey-next-to-last-station]] instead (thanks, Makin!)
     - fixed Twitter link, removed dead desynced.xyz link, and added MSPFA link for [[group:desynced]] (thanks, meulanie!)
     - removed duplicate homestuck.com link for [[flash:2070]] (thanks, Lan!)
     <h3>directory changes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -81,6 +81,7 @@ Content: |-
     <h3>data changes</h3>
     <!-- misc presentational changes -->
     - replaced most YouTube playback links for Homestuck flashes ([[flash-side:s1|side 1]], [[flash-side:s2|side 2]]) with timestamped links to Bambosh's ['[S] Homestuck - All flashes'](https://www.youtube.com/watch?v=AEIOQN3YmNc), replacing YouTube links in 60 flashes, and adding YouTube links to 46 flashes missing them altogether (thanks, Meulanie, Lan!)
+    - changed YouTube listening link for [[track:hometeam-adv8ntage]] to composer's upload (thanks, Lilith!)
     - added dates to all wiki editor commentary, showing when the entries were actually written or heavily revised, mostly based off the data repository's git commit history (thanks, Amberlina, Whisper!)
     - filled out details for [[track:velkommen-stan-lepard]], previously named "Windows XP Installation Music" with duration 5:22 and no commentary (thanks, vriska, Lan!)
     <h3>data fixes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -81,7 +81,6 @@ Content: |-
     <h3>data changes</h3>
     <!-- misc presentational changes -->
     - replaced most YouTube playback links for Homestuck flashes ([[flash-side:s1|side 1]], [[flash-side:s2|side 2]]) with timestamped links to Bambosh's ['[S] Homestuck - All flashes'](https://www.youtube.com/watch?v=AEIOQN3YmNc), replacing YouTube links in 60 flashes, and adding YouTube links to 46 flashes missing them altogether (thanks, Meulanie, Lan!)
-    - changed YouTube listening link for [[track:hometeam-adv8ntage]] to composer's upload (thanks, Lilith!)
     - added dates to all wiki editor commentary, showing when the entries were actually written or heavily revised, mostly based off the data repository's git commit history (thanks, Amberlina, Whisper!)
     - filled out details for [[track:velkommen-stan-lepard]], previously named "Windows XP Installation Music" with duration 5:22 and no commentary (thanks, vriska, Lan!)
     <h3>data fixes</h3>
@@ -158,6 +157,7 @@ Content: |-
     - tweaked formatting of Bowmantown commentary for [[album:homestuck-vol-10]] ("Jungle Boogie" now links to [[track:jungle-boogie]]; thanks, Lilith!)
     <!-- link fixes -->
     - fixed YouTube listening link for [[track:train-requiem]] being given to [[track:train-meldey-next-to-last-station]] instead (thanks, Makin!)
+    - changed YouTube listening link for [[track:hometeam-adv8ntage]] to composer's upload (thanks, Lilith!)
     - fixed Twitter link, removed dead desynced.xyz link, and added MSPFA link for [[group:desynced]] (thanks, meulanie!)
     - removed duplicate homestuck.com link for [[flash:2070]] (thanks, Lan!)
     <h3>directory changes</h3>


### PR DESCRIPTION
Changes the YouTube link of [Hometeam Adv8ntage](https://hsmusic.wiki/track/hometeam-adv8ntage/) to [Curtis's YouTube upload!](https://www.youtube.com/watch?v=-THDS3ZI2Wg)

Also adds Curtis's newer YouTube [youtube.com/@twirlincurtis](https://www.youtube.com/@twirlincurtis) newer YouTube to his artist URLs

Also, the [Beyond Canon playlist](https://www.youtube.com/playlist?list=PLnVpmehyaOFbH-1hH663k70qBQp5jc_CU) would need to be updated accordingly (removing Wheatley's upload of Hometeam Adv8ntage and replacing it with Curtis's)