### PR TITLE
Album additions: Svix's Audacity to Waiting for the Night (Svix mix) (also I'm Here for the Future from 2010) + group (Svix)

### DIFF
--- a/album/audacity.yaml
+++ b/album/audacity.yaml
@@ -19,6 +19,8 @@ Duration: 5:11
 URLs:
 - https://svix.bandcamp.com/track/audacity
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/audacity))
+
     The stage is set, your nervous gaze tells a tale of apprehension
     so maybe I should lead you through the lime
 
@@ -31,6 +33,8 @@ Lyrics: |-
     four in the morning and you know that you only have to mention
     and maybe we could keep this going
 
+    ~
+
     I feel the eyes upon my back, I'm an object of obsession
     but maybe I don't see it how the rest
 
@@ -42,6 +46,8 @@ Lyrics: |-
 
     then all my problems hit the floor when you're wearing that expression
     and simply nothing else besides it :o
+
+    ~
 
     Take my hand and we shall make a stand
     Tell me you love me

--- a/album/audacity.yaml
+++ b/album/audacity.yaml
@@ -41,7 +41,7 @@ Lyrics: |-
     but maybe I'm the one to overthink
 
     then all my problems hit the floor when you're wearing that expression
-    and simply nothing else besides it :\o
+    and simply nothing else besides it :o
 
     Take my hand and we shall make a stand
     Tell me you love me

--- a/album/audacity.yaml
+++ b/album/audacity.yaml
@@ -60,3 +60,47 @@ Lyrics: |-
 
     Whisper things and tell me all your sins
     There's nothing worth hiding
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
+    *(0:44-1:13)*
+
+    The stage is set, your nervous gaze tells a tale of apprehension
+    So maybe I should lead you through the time
+
+    Light to the touch, my hand in yours is a matter of convention
+    But maybe we could move things forwards
+
+    The night begins and faces turn to the centre of attention
+    So maybe we should give them what they're here
+
+    Four in the morning and you know that you only have to mention
+    And maybe we could keep this going
+
+    *(1:28-1:57)*
+
+    I feel the eyes upon my back, I'm an object of obsession
+    But maybe I don't see how the rest
+
+    Do what you will, I get a kick out of power and suppression
+    And I maybe I pretend to struggle
+
+    When we're alone I sometimes fail to get the right impression
+    But maybe I'm the one to overthink
+
+    Then all my problems hit the floor when you're wearing that expression
+    And simply nothing else besides it
+
+    *(2:27-2:56)*
+
+    Tell my hand and we shall make a stand
+    Tell me you love me
+
+    Hold me tight until you're feeling right
+    Tell me you now see
+
+    Spill your heart and we can make a start
+    My arm in yours guiding
+
+    Whisper things and tell me all your sins
+    There's nothing worth hiding

--- a/album/audacity.yaml
+++ b/album/audacity.yaml
@@ -1,4 +1,5 @@
 Album: Audacity
+Style: single
 Artists:
 - Svix
 Date: June 10, 2012
@@ -13,8 +14,6 @@ Groups:
 Cover Art File Extension: png
 ---
 Track: Audacity
-Directory: audacity-svix
-Always Reference By Directory: true
 Duration: 5:11
 URLs:
 - https://svix.bandcamp.com/track/audacity

--- a/album/audacity.yaml
+++ b/album/audacity.yaml
@@ -1,0 +1,56 @@
+Album: Audacity
+Artists:
+- Svix
+Date: June 10, 2012
+URLs:
+- https://svix.bandcamp.com/track/audacity
+Cover Artists:
+- Svix
+Color: '#e752d2'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+---
+Track: Audacity
+Directory: audacity-svix
+Always Reference By Directory: true
+Duration: 5:11
+URLs:
+- https://svix.bandcamp.com/track/audacity
+Lyrics: |-
+    The stage is set, your nervous gaze tells a tale of apprehension
+    so maybe I should lead you through the lime
+
+    light to the touch, my hand in yours is a matter of convention
+    but maybe we could move things forward
+
+    The night begins and faces turn to the centre of attention
+    so maybe we should give them what they're here
+
+    four in the morning and you know that you only have to mention
+    and maybe we could keep this going
+
+    I feel the eyes upon my back, I'm an object of obsession
+    but maybe I don't see it how the rest
+
+    do what you will, I get a kick out of power and supression
+    and maybe I pretend to struggle
+
+    When we're alone I sometimes fail to get the right impression
+    but maybe I'm the one to overthink
+
+    then all my problems hit the floor when you're wearing that expression
+    and simply nothing else besides it :\o
+
+    Take my hand and we shall make a stand
+    Tell me you love me
+
+    Hold me tight until you're feeling right
+    Tell me you now see
+
+    Spill your heart and we can make a start
+    My arm in yours guiding
+
+    Whisper things and tell me all your sins
+    There's nothing worth hiding

--- a/album/coastline-in-december.yaml
+++ b/album/coastline-in-december.yaml
@@ -1,4 +1,5 @@
 Album: Coastline in December
+Style: single
 Artists:
 - Svix
 Date: July 10, 2014

--- a/album/coastline-in-december.yaml
+++ b/album/coastline-in-december.yaml
@@ -1,0 +1,66 @@
+Album: Coastline in December
+Artists:
+- Svix
+Date: July 10, 2014
+URLs:
+- https://svix.bandcamp.com/track/coastline-in-december
+- https://open.spotify.com/album/2G19RRbtcsZhE7ACKlEK2V
+Cover Artists:
+- Svix
+Color: '#06fcfb'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+Commentary: |-
+    <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/track/coastline-in-december))
+
+    For all the things I've left behind
+---
+Track: Coastline in December
+Duration: 5:40
+URLs:
+- https://svix.bandcamp.com/track/coastline-in-december
+- https://open.spotify.com/track/3IDqE4BF9DedKdtke2vWZo
+Lyrics: |-
+    All the oceans in the sky
+    The birds, atop the ceiling, fly
+    Above the other passers by
+    Until they're left behind
+
+    Now I'm thinking out to sea
+    Of all the things you said to me
+    We'll make the most of what's to be
+    Forever kept in mind
+
+    Yesterday a chance encounter led my way
+    A single year
+    How it made things appear
+    The days were bright the love in the air was fuller
+
+    Today it's a coastline in December
+    The snowy dunes
+    Lead to the granite ruins
+    They reach and join the clouds with no other colour
+
+    In, out, all throughout the tide comes rolling, to take me out
+    Feel the rotors flying
+    Hear the long grass sighing
+
+    I'll keep my heart safe on the inside, for you
+
+    Yesterday my only want lay yards away
+    A simple call
+    For me to have it all
+    The thought such days were scarce not one I would utter
+
+    Today it's a place I can't remember
+    A solemn light
+    My waiting phone at night
+    I'd turn back time and write life another cover
+
+    Lie awake I think I hear my name
+    close my eyes it's probably just the rain
+
+    Lie awake I think I hear my name
+    close my eyes it's probably just the rain

--- a/album/coastline-in-december.yaml
+++ b/album/coastline-in-december.yaml
@@ -23,6 +23,8 @@ URLs:
 - https://svix.bandcamp.com/track/coastline-in-december
 - https://open.spotify.com/track/3IDqE4BF9DedKdtke2vWZo
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/coastline-in-december))
+
     All the oceans in the sky
     The birds, atop the ceiling, fly
     Above the other passers by
@@ -32,6 +34,8 @@ Lyrics: |-
     Of all the things you said to me
     We'll make the most of what's to be
     Forever kept in mind
+
+    ///
 
     Yesterday a chance encounter led my way
     A single year
@@ -43,11 +47,15 @@ Lyrics: |-
     Lead to the granite ruins
     They reach and join the clouds with no other colour
 
+    ///
+
     In, out, all throughout the tide comes rolling, to take me out
     Feel the rotors flying
     Hear the long grass sighing
 
     I'll keep my heart safe on the inside, for you
+
+    ///
 
     Yesterday my only want lay yards away
     A simple call
@@ -58,6 +66,8 @@ Lyrics: |-
     A solemn light
     My waiting phone at night
     I'd turn back time and write life another cover
+
+    ///
 
     Lie awake I think I hear my name
     close my eyes it's probably just the rain

--- a/album/cyberdemon.yaml
+++ b/album/cyberdemon.yaml
@@ -95,6 +95,84 @@ Lyrics: |-
     you'll never be the same
     Cyberdemon
     start believing
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
+    *(0:21-1:02)*
+
+    You should have known with what you're dealing
+
+    Now you're alone searching for meaning
+
+    You're hesitating
+    'Cos there's something in the dark
+    You see the marks
+    Feel my heartbeat
+    Growing stronger
+
+    You walk the long forgotten hallways
+    Open the wrong ill-gotten doorways
+
+    Keep coming forward
+    'Cos you think you're something tough
+    I've had enough
+    Take my penance here
+    No longer
+
+    *(1:04-1:24)*
+
+    Strong men fall whilst others run
+    'Cos now you let me in
+    Cyberdemon
+    What a feelin'
+
+    You can't stop what has begun
+    I'm clawing at your skin
+    Cyberdemon
+    Start believing
+
+    *(1:25-1:45)*
+
+    A thousand voices make you wonder
+    Illicit powers make you hunger
+
+    What's there to lose if you're already deep in sin
+    So let's begin
+    Take my hand, I'll take you under
+
+    *(1:46-2:07)*
+
+    One last breath you're almost there
+    Just gotta say my name
+    Cyberdemon
+    What a feelin'
+
+    Blood and smoke hang in the air
+    You'll never be the same
+    Cyberdemon
+    Start believing
+
+    *(2:32-3:14)*
+
+    Strong men fall whilst others run
+    'Cos now you let me in
+    Cyberdemon
+    What a feelin'
+
+    You can't stop what has begun
+    I'm clawing at your skin
+    Cyberdemon
+    Start believing
+
+    One last breath you're almost there
+    Just gotta say my name
+    Cyberdemon
+    What a feelin'
+
+    Blood and smoke hang in the air
+    You'll never be the same
+    Cyberdemon
+    Start believing
 ---
 Track: Feel the same
 Duration: 3:23
@@ -129,6 +207,58 @@ Lyrics: |-
 
     but soon like me you won't remember
     come a little bit closer
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
+    *(0:31-1:00)*
+
+    Am I awake or am I dreaming
+    'Cos you don't quite look the same
+
+    What is this fire I am feeling
+    Come a little bit closer
+
+    Am I alive am I still breathing
+    'Cos you don't quite feel the same
+
+    What is this colour I am bleeding
+    Come a little bit closer
+
+    *(1:17-1:46)*
+
+    When I lay broken you were stronger
+    'Cos you don't quite look the same
+
+    But now I fear your flame no longer
+    Come a little bit closer
+
+    I never thought you would surrender
+    'Cos you don't quite feel the same
+
+    But soon like me you won't remember
+    Come a little bit closer
+
+    *(1:52-1:54)*
+
+    'Cos you don't quite look the same
+
+    *(1:59-2:02)*
+
+    'Cos you don't quite feel the s-
+
+    *(2:34-3:03)*
+
+    Am I awake or am I dreaming
+    'Cos you don't quite look the same
+
+    What is this fire I am feeling
+    Come a little bit closer
+
+    Am I alive am I still breathing
+    'Cos you don't quite feel the same
+
+    What is this colour I am bleeding
+    Come a little bit closer
 ---
 Track: Pretend to sleep
 Duration: 3:33

--- a/album/cyberdemon.yaml
+++ b/album/cyberdemon.yaml
@@ -20,6 +20,8 @@ URLs:
 - https://www.youtube.com/watch?v=T6V5p4fqDIk
 - https://open.spotify.com/track/6NMRxfHQ2mi9azYxNJLUva
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/cyberdemon))
+
     You should have known with what you're dealing
 
     Now you're alone searching for meaning
@@ -39,6 +41,8 @@ Lyrics: |-
     take my penance here
     no longer
 
+    ///
+
     Strong men fall whilst others run
     'cos now you let me in
     Cyberdemon
@@ -49,12 +53,16 @@ Lyrics: |-
     Cyberdemon
     start believing
 
+    ///
+
     a thousand voices make you wonder
     illicit powers make you hunger
 
     what's there to loose if you're already deep in sin
     so let's begin
     take my hand, I'll take you under
+
+    ///
 
     one last breath you're almost there
     just gotta say my name
@@ -65,6 +73,8 @@ Lyrics: |-
     you'll never be the same
     Cyberdemon
     start believing
+
+    ///
 
     strong men fall whilst others run
     'cos now you let me in
@@ -92,6 +102,8 @@ URLs:
 - https://svix.bandcamp.com/track/feel-the-same
 - https://open.spotify.com/track/6DSCYng9qgrQtFmuWHynfP
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/feel-the-same))
+
     am I awake or am I dreaming
     cos you don't quite look the same
 
@@ -103,6 +115,8 @@ Lyrics: |-
 
     what is this colour I am bleeding
     come a little bit closer
+
+    //////
 
     when I lay broken you were stronger
     cos you don't quite look the same

--- a/album/cyberdemon.yaml
+++ b/album/cyberdemon.yaml
@@ -1,0 +1,135 @@
+Album: Cyberdemon
+Artists:
+- Svix
+Date: September 3, 2021
+URLs:
+- https://svix.bandcamp.com/album/cyberdemon
+- https://open.spotify.com/album/0Y3rQmZH42vLR4bqSFue78
+Cover Artists:
+- Svix
+Color: '#f44d2c'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+---
+Track: Cyberdemon
+Duration: 3:50
+URLs:
+- https://svix.bandcamp.com/track/cyberdemon
+- https://www.youtube.com/watch?v=T6V5p4fqDIk
+- https://open.spotify.com/track/6NMRxfHQ2mi9azYxNJLUva
+Lyrics: |-
+    You should have known with what you're dealing
+
+    Now you're alone searching for meaning
+
+    You're hesitating
+    'cos there's something in the dark
+    you see the marks
+    feel my heartbeat
+    growing stronger
+
+    You walk the long forgotten hallways
+    open the wrong ill-gotten doorways
+
+    Keep coming forward
+    'cos you think you're something tough
+    I've had enough
+    take my penance here
+    no longer
+
+    Strong men fall whilst others run
+    'cos now you let me in
+    Cyberdemon
+    what a feelin'
+
+    you can't stop what has begun
+    I'm clawing at your skin
+    Cyberdemon
+    start believing
+
+    a thousand voices make you wonder
+    illicit powers make you hunger
+
+    what's there to loose if you're already deep in sin
+    so let's begin
+    take my hand, I'll take you under
+
+    one last breath you're almost there
+    just gotta say my name
+    Cyberdemon
+    what a feelin'
+
+    blood and smoke hang in the air
+    you'll never be the same
+    Cyberdemon
+    start believing
+
+    strong men fall whilst others run
+    'cos now you let me in
+    Cyberdemon
+    what a feelin'
+
+    you can't stop what has begun
+    I'm clawing at your skin
+    Cyberdemon
+    start believing
+
+    one last breath you're almost there
+    just gotta say my name
+    Cyberdemon
+    what a feelin'
+
+    blood and smoke hang in the air
+    you'll never be the same
+    Cyberdemon
+    start believing
+---
+Track: Feel the same
+Duration: 3:23
+URLs:
+- https://svix.bandcamp.com/track/feel-the-same
+- https://open.spotify.com/track/6DSCYng9qgrQtFmuWHynfP
+Lyrics: |-
+    am I awake or am I dreaming
+    cos you don't quite look the same
+
+    what is this fire I am feeling
+    come a little bit closer
+
+    am I alive am I still breathing
+    cos you don't quite feel the same
+
+    what is this colour I am bleeding
+    come a little bit closer
+
+    when I lay broken you were stronger
+    cos you don't quite look the same
+
+    but now I fear your flame no longer
+    come a little bit closer
+
+    I never thought you would surrender
+    cos you don't quite feel the same
+
+    but soon like me you won't remember
+    come a little bit closer
+---
+Track: Pretend to sleep
+Duration: 3:33
+URLs:
+- https://svix.bandcamp.com/track/pretend-to-sleep
+- https://open.spotify.com/track/25wcYf8N8E8Xeu0i1UYRaC
+---
+Track: Veri
+Directory: veri-cyberdemon
+Always Reference By Directory: true
+Duration: 4:24
+URLs:
+- https://svix.bandcamp.com/track/veri
+- https://open.spotify.com/track/6fl9Lm5yHCgkp8GM5yzNdo
+Referenced Tracks:
+- track:verisimilitude-induction
+Sampled Tracks:
+- Verisimilitude (Glaze Remix)

--- a/album/fire-forget.yaml
+++ b/album/fire-forget.yaml
@@ -1,5 +1,6 @@
 Album: Fire + Forget
 Directory: fire-forget
+Style: single
 Artists:
 - Svix
 Date: September 16, 2009

--- a/album/fire-forget.yaml
+++ b/album/fire-forget.yaml
@@ -22,7 +22,7 @@ URLs:
 Commentary: |-
     <i>Svix:</i> ([Bandcamp about blurb](https://web.archive.org/web/20100106142505/http://svix.bandcamp.com/))
 
-    Taking a break from music due to my physics degree, I shall return later! Thank you for listening :\]
+    Taking a break from music due to my physics degree, I shall return later! Thank you for listening :]
 
     ~\Svix
 

--- a/album/fire-forget.yaml
+++ b/album/fire-forget.yaml
@@ -1,0 +1,35 @@
+Album: Fire + Forget
+Directory: fire-forget
+Artists:
+- Svix
+Date: September 16, 2009
+URLs:
+- https://www.youtube.com/watch?v=4bo66SdSP1E
+Cover Artists:
+- Svix
+Color: '#fc4134'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+---
+Track: Fire + Forget
+Directory: fire-forget-original
+Always Reference By Directory: true
+Duration: 3:40
+URLs:
+- https://www.youtube.com/watch?v=4bo66SdSP1E
+Commentary: |-
+    <i>Svix:</i> ([Bandcamp about blurb](https://web.archive.org/web/20100106142505/http://svix.bandcamp.com/))
+
+    Taking a break from music due to my physics degree, I shall return later! Thank you for listening :\]
+
+    ~\Svix
+
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/2799350/))
+
+    Thought I'd try my hand at some Drum and Bass! I had fun with this one; it's not overly complicated, has quite a bit of low-end bass going on which I quite like and I think it's nice and lively - I purposefully didn't really let up the pace with it.
+
+    Certainly a genre I will return to.
+
+    Oh and FA's music player wouldn't load the song with '+' in it's filename so I had to change it to 'and' *rolls eyes*.

--- a/album/im-here-for-the-future.yaml
+++ b/album/im-here-for-the-future.yaml
@@ -41,7 +41,7 @@ Lyrics: |-
     Here and now's the place to be
     after all you've been through it's just you and me
     you'll be hard to beat my guarantee
-    'Cos I'm going nowhere I'm here for the future  
+    'Cos I'm going nowhere I'm here for the future
 Commentary: |-
     <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3453787/))
 

--- a/album/im-here-for-the-future.yaml
+++ b/album/im-here-for-the-future.yaml
@@ -17,6 +17,8 @@ Duration: 2:43
 URLs:
 - https://www.youtube.com/watch?v=1DZ3u2eGQL0
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://www.furaffinity.net/view/3453787/))
+
     Take my hand I'll help you stand
     and then we'll journey through all the things we've planned
     I'll be sure to help you understand
@@ -33,14 +35,32 @@ Lyrics: |-
     Here and now's the place to be
     'cos after all it's just you and me
 
+    <i>[[artist:lilithtreasure|Lilith]], [[artist:quasar-nebula|Lan]]:</i> (wiki lyrics)
+
     Take my hand I'll help you stand
-    and then we'll journey through the things we've planned
+    And then we'll journey through all the things we've planned
     I'll be sure to help you understand
     That I'm going nowhere I'm here for the future
 
     Here and now's the place to be
-    after all you've been through it's just you and me
-    you'll be hard to beat my guarantee
+    After all you've been through it's just you and me
+    You'll be hard to beat my guarantee
+    'Cos I'm going nowhere I'm here for the future
+
+    Take my hand I'll help you stand
+    We'll journey through the things we've planned
+
+    Here and now's the place to be
+    'Cos after all it's just you and me
+
+    Take my hand I'll help you stand
+    And then we'll journey through the things we've planned
+    I'll be sure to help you understand
+    That I'm going nowhere I'm here for the future
+
+    Here and now's the place to be
+    After all you've been through it's just you and me
+    You'll be hard to beat my guarantee
     'Cos I'm going nowhere I'm here for the future
 Commentary: |-
     <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3453787/))

--- a/album/im-here-for-the-future.yaml
+++ b/album/im-here-for-the-future.yaml
@@ -1,0 +1,50 @@
+Album: I'm Here for the Future
+Artists:
+- Svix
+Date: February 21, 2010
+URLs:
+- https://www.youtube.com/watch?v=1DZ3u2eGQL0
+Cover Artists:
+- Svix
+Color: '#babbca'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+---
+Track: I'm Here for the Future
+Duration: 2:43
+URLs:
+- https://www.youtube.com/watch?v=1DZ3u2eGQL0
+Lyrics: |-
+    Take my hand I'll help you stand
+    and then we'll journey through all the things we've planned
+    I'll be sure to help you understand
+    That I'm going nowhere I'm here for the future
+
+    Here and now's the place to be
+    after all you've been through it's just you and me
+    you'll be hard to beat my guarantee
+    'Cos I'm going nowhere I'm here for the future
+
+    Take my hand I'll help you stand
+    we'll journey through the things we've planned
+
+    Here and now's the place to be
+    'cos after all it's just you and me
+
+    Take my hand I'll help you stand
+    and then we'll journey through the things we've planned
+    I'll be sure to help you understand
+    That I'm going nowhere I'm here for the future
+
+    Here and now's the place to be
+    after all you've been through it's just you and me
+    you'll be hard to beat my guarantee
+    'Cos I'm going nowhere I'm here for the future  
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3453787/))
+
+    A little piano ditty for red_fox_gt
+
+    I thought it would be nice to leave the vocals fairly natural for a change. Anyway I've always wanted to make a love song, I'm a bit of a soppy git really.

--- a/album/im-here-for-the-future.yaml
+++ b/album/im-here-for-the-future.yaml
@@ -1,4 +1,5 @@
 Album: I'm Here for the Future
+Style: single
 Artists:
 - Svix
 Date: February 21, 2010

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -11,6 +11,7 @@ Cover Artists:
 Cover Art File Extension: png
 Color: '#009a85'
 Groups:
+- Svix
 - Beyond
 Additional Files:
 - Title: Keytar Fox SWF

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -304,6 +304,8 @@ Directory: fire-forget
 Duration: 4:16
 URLs:
 - https://svix.bandcamp.com/track/fire-forget-2
+Referenced Tracks:
+- track:fire-forget-original
 ---
 Track: The Fox Cub
 Duration: 2:56
@@ -323,8 +325,8 @@ Referenced Tracks:
 - track:my-hibernation-original
 - track:verisimilitude-original
 - track:flying-battery-zone-act-2
-- track:fire-forget
-- track:wistful-induction
+- track:fire-forget-original
+- track:wistful-original
 - You Fade Away
 - track:shake-your-tail-original
 - The Fox Cub

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -75,6 +75,8 @@ Duration: 5:18
 URLs:
 - https://svix.bandcamp.com/track/verisimilitude-2
 - https://www.youtube.com/watch?v=6-CllxbnGU8
+Referenced Tracks:
+- track:verisimilitude-original
 Lyrics: |-
     Colour
     The kind I wish I saw before my feelings were like no
@@ -283,6 +285,8 @@ Track: Shake Your Tail
 Duration: 3:50
 URLs:
 - https://svix.bandcamp.com/track/shake-your-tail-2
+Referenced Tracks:
+- track:shake-your-tail-original
 Lyrics: |-
     Hold your head up baby
     Hold your head up high

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -53,19 +53,48 @@ Referenced Tracks:
 - track:my-hibernation-original
 - Havoc
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/my-hibernation-2))
+
+    Come and find me when the night's bright
+    the place we like to hear
+    Come defeat me at my own fight
+    and I will keep you near
+
+    Sing to me your incantation
+    and hold onto my waist
+    Wake me from my hibernation
+    and listen to my bass
+
+    ~
+
+    Go end what you've begun
+    before you are outdone
+
+    Take your time and you just might find
+    you're gaining momentum
+
+    <i>[[artist:lilithtreasure|Lilith]], [[artist:quasar-nebula|Lan]]:</i> (wiki lyrics)
+
+    *(1:47-2:11)*
+
     Come and find me when the night's bright
     The place we like to hear
     Come defeat me at my own fight
     And I will keep you near
-
     Sing to me your incantation
     And hold onto my waist
     Wake me from my hibernation
     And listen to my bass
 
-    Go end what you've begun
-    before you are outdone
+    *(2:35-2:58)*
 
+    Come and find me when the night's bright
+    Come defeat me at my own fight
+    Sing to me your incantation
+    Wake me from my hibernation
+
+    Go end what you've begun
+    Before you are outdone
     Take your time and you just might find
     You're gaining momentum
 ---
@@ -78,6 +107,8 @@ URLs:
 Referenced Tracks:
 - track:verisimilitude-original
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/verisimilitude-2))
+
     Colour
     The kind I wish I saw before my feelings were like no
 
@@ -89,6 +120,8 @@ Lyrics: |-
 
     Gave me
     Remember what you said? It went something like this:
+
+    ~
 
     Colour
     The tiny little spark I see when you're going to break
@@ -102,6 +135,8 @@ Lyrics: |-
     could see
     Remember what you said? It went something like this:
 
+    ~
+
     Why can't you recall in your history
     Shades of umber
     I'm caught under
@@ -111,6 +146,28 @@ Lyrics: |-
     Just a semblance
     of true vengeance
     Heed my entrance
+
+    <i>[[artist:lilithtreasure|Lilith]], [[artist:quasar-nebula|Lan]]:</i> (wiki lyrics, help needed)
+
+    Colour - the kind I wish I saw before my feelings were like no
+    Other - you took me by the hand and then showed me the door
+    Maybe - I misinterpreted the way you talked and the looks you
+    Gave me - remember what you said? It went something like this
+
+    Colour - the tiny little spark I see when you're going to break
+    Cover - I look into your eyes and there's nothing there so
+    Tell me - was everything it seemed? or was the light hiding what I
+    Could see - Remember what you said? It went something like this
+
+    Why can't you recall in your history
+    Shades of umber
+    I'm caught under [backing? maybe: "Could you hold me?" x2]
+    Inky thunder
+
+    Your intent to me is a mystery
+    Just a semblance
+    Of true vengeance [backing again, x2]
+    Heed my entrance
 ---
 Track: It Really Doesn't Matter
 Duration: 5:39
@@ -119,6 +176,8 @@ URLs:
 Referenced Tracks:
 - track:it-really-doesnt-matter-original
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/it-really-doesnt-matter-2))
+
     What would you do if I said
     I'm not coming back
     It really doesn't matter
@@ -133,6 +192,8 @@ Lyrics: |-
     How will you fly when I have done all this and why
     d'you think it really matters?
 
+    ~
+
     Turn around, I'm not to follow
     Times have changed, I hope you realise now
     Close your mouth, there's no tomorrow
@@ -142,6 +203,96 @@ Lyrics: |-
     Why persist and make this harder for us
     Can't you see our past was hollow
     Look at you you're falling
+
+    <i>[[artist:lilithtreasure|Lilith]], [[artist:quasar-nebula|Lan]]:</i> (wiki lyrics)
+
+    *(1:12-1:39)*
+
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to
+    When you've lost all faith in your plans to make amends
+    Of which are prone to shatter
+
+    Where will you be
+    When I have left you for the sky
+    It really doesn't matter
+
+    How will you fly
+    When I have done all this and why
+    D'you think it really matters?
+
+    *(2:06-2:34)*
+
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to
+    When you've lost all faith in your plans to make amends
+    Of which are prone to shatter
+
+    Where will you be
+    When I have left you for the sky
+    It really doesn't matter
+
+    How will you fly
+    When I have done all this and why
+    D'you think it really matters?
+
+    *(2:34-3:02)*
+
+    (Really matters?)
+    (Really matters?)
+    (Really matters?)
+    D'you think it really matters?
+
+    (Really matters?)
+    (Really matters?)
+    (Really matters?)
+    D'you think it really matters?
+
+    (Really matters?)
+    (Really matters?)
+    (Really matters?)
+    D'you think it really matters?
+
+    (Really matters?)
+    (Really matters?)
+    (Really matters?)
+    D'you think it really matters?
+
+    *(3:56-4:23)*
+
+    Turn around, I'm not to follow
+    Times have changed, I hope you realise now
+    Close your mouth, there's no tomorrow
+    Who d'you think you're calling?
+
+    Turn around, I'm not to follow
+    Why persist and make this harder for us
+    Can't you see our past was hollow
+    Look at you, you're falling
+
+    *(5:05-5:34)*
+
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to
+    When you've lost all faith in your plans to make amends
+    Of which are prone to shatter
+
+    Where will you be
+    When I have left you for the sky
+    It really doesn't matter
+
+    How will you fly
+    When I have done all this and why
+    D'you think it really matters at all?
 ---
 Track: Goodbye
 Suffix Directory: true
@@ -152,6 +303,8 @@ URLs:
 Referenced Tracks:
 - track:goodbye-original
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/goodbye-2))
+
     Conversation
     No sensation, things I've yet to say
 
@@ -166,6 +319,8 @@ Lyrics: |-
     back to the past
     and they all lead to the same place
 
+    ~
+
     Why do I still call your name?
     After all this time has passed
 
@@ -177,6 +332,8 @@ Lyrics: |-
 
     But I think of what we could have been like
     Think of what we could have
+
+    ~
 
     Former feelings still have meaning
     voids I've yet to fill
@@ -194,6 +351,8 @@ Lyrics: |-
 
     Gotta stop myself from thinking
 
+    ~
+
     Why do I still call your name?
     After all this time has passed
 
@@ -206,6 +365,8 @@ Lyrics: |-
     But I think of what we could have been like
     Think of what we could have
     Think of what we could have been
+
+    ~
 
     Broken
     is how you left me
@@ -231,11 +392,78 @@ Lyrics: |-
     Wonder
     do you still think of me?
 
+    ~
+
     Why was it easy?
     Why was it just me?
     Why did it all make sense?
     It never hit me 'til your hand just slipped right through mine
     until your hand just slipped right through mine
+
+    <i>[[artist:lilithtreasure|Lilith]], [[artist:quasar-nebula|Lan]]:</i> (wiki lyrics)
+
+    *(0:33-2:06)*
+
+    Conversation, no sensation
+    Things I've yet to say
+    Your words still sting just lingering
+    I hang my head in weak (dismay)
+
+    Thoughts of sorrow, bar tomorrow
+    Keep me from the night
+    I walk the paths, back to the past
+    And they all lead to the same place
+
+    Why do I still call your name?
+    After all this time has passed
+    When I think of what we could have been like
+    Think of what we could have been
+
+    Why do I still feel the same?
+    You and I weren't meant to last
+    But I think of what we could have been like
+    Think of what we could have
+
+    Former feelings still have meaning
+    Voids I've yet to fill
+    There's moving on, it's been and gone
+    But I can't help but keep standing still
+
+    Your affection, stark reflection
+    How things used to be
+    Gotta bide my time, gotta keep me mine
+    Gotta stop myself from thinking
+
+    Why do I still call your name?
+    After all this time has passed
+    When I think of what we could have been like
+    Think of what we could have been
+
+    Why do I still feel the same?
+    You and I weren't meant to last
+    But I think of what we could have been like
+    Think of what we could have
+    Think of what we could have (been)
+
+    *(2:29-2:52)*
+
+    Broken, is how you left me
+    Unspoken, your thoughts about me now
+    Shattered, the trust I held in you
+    Mattered - I guess you'd disagree
+
+    Darling, the rift between us is
+    Startling, these shifting waves hold me
+    Under, I hold my breath and I
+    Wonder - do you still think of me?
+
+    *(3:14-3:35)*
+
+    Why was it easy?
+    Why was it just me?
+    Why did it all make sense?
+    It never hit me 'til your hand just slipped right through mine
+    Until your hand just slipped right through mine
 ---
 Track: Wistful
 Suffix Directory: true
@@ -251,6 +479,8 @@ Duration: 3:39
 URLs:
 - https://svix.bandcamp.com/track/you-fade-away-2
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/you-fade-away-2))
+
     Break the rest of my day
     You always look so grey, you fade away
 
@@ -262,6 +492,8 @@ Lyrics: |-
 
     Break the rest of my day
     You always look so grey, you fade away
+
+    ~
 
     Break the rest of my day
     You always look so grey, you fade away
@@ -275,6 +507,8 @@ Lyrics: |-
     Break the rest of my day
     You always look so grey, you fade away
 
+    ~
+
     I see you've learnt how to fly
     But your wings are clipped and the wind is dark and heavy
 
@@ -286,6 +520,67 @@ Lyrics: |-
 
     Maybe it's all a dream
     I'd think it so but the marks you left upon me
+
+    <i>[[artist:lilithtreasure|Lilith]], [[artist:quasar-nebula|Lan]]:</i> (wiki lyrics)
+
+    *(0:54-1:22)*
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    Telling me to obey
+    When really you're the prey, you fade away
+
+    Let me lead you astray
+    Into a blind foray, you fade away
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    *(1:35-2:03)*
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    Try your best to convey
+    Your most dishonest way, you fade away
+
+    Let me leave you halfway
+    Between the night and day, you fade away
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    *(2:16-3:12)*
+
+    I see you've learnt how to fly
+    But your wings are clipped and the wind is dark and heavy
+
+    No you don't have to lie
+    The voice inside reveals what you want me to be
+
+    Fighting your way upstream
+    To tell me everything's fine and then I see (that)
+
+    Maybe it's all [not?] a dream
+    I'd think it so but the marks you left upon me
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    Telling me to obey
+    When really you're the prey, you fade away
+
+    Let me lead you astray
+    Into a blind foray, you fade away
+
+    Break the rest of my day
+    You always look so grey, you fade away
+
+    *(3:25-3:32)*
+
+    Break the rest of my day
+    You always look so grey, you fade away
 ---
 Track: Shake Your Tail
 Duration: 3:50
@@ -294,10 +589,42 @@ URLs:
 Referenced Tracks:
 - track:shake-your-tail-original
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/shake-your-tail-2))
+
     Hold your head up baby
     Hold your head up high
     Shake your tail baby
     Shake it don't be shy
+
+    <i>[[artist:quasar-nebula|Lan]]:</i> (wiki lyrics)
+
+    *(0:39-0:55)*
+
+    Hold your head up baby
+    Hold your head up high
+    Shake your tail baby
+    Shake it don't be shy
+
+    *(1:27-2:00)*
+
+    Hold your head up baby
+
+    Shake your tail baby
+
+    Hold your head up baby
+    Hold your head up high
+    Shake your tail baby
+    Shake it don't be shy
+
+    *(2:49-3:22)*
+
+    Hold your head up baby
+
+    Shake your tail baby
+
+    Hold your head up high
+
+    Shake it don't be shy (shy, shy...)
 ---
 Track: Fire + Forget
 Directory: fire-forget

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -243,6 +243,8 @@ Always Reference By Directory: true
 Duration: 3:42
 URLs:
 - https://svix.bandcamp.com/track/wistful-2
+Referenced Tracks:
+- track:wistful-original
 ---
 Track: You Fade Away
 Duration: 3:39

--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -116,6 +116,8 @@ Track: It Really Doesn't Matter
 Duration: 5:39
 URLs:
 - https://svix.bandcamp.com/track/it-really-doesnt-matter-2
+Referenced Tracks:
+- track:it-really-doesnt-matter-original
 Lyrics: |-
     What would you do if I said
     I'm not coming back
@@ -147,6 +149,8 @@ Always Reference By Directory: true
 Duration: 4:02
 URLs:
 - https://svix.bandcamp.com/track/goodbye-2
+Referenced Tracks:
+- track:goodbye-original
 Lyrics: |-
     Conversation
     No sensation, things I've yet to say
@@ -312,15 +316,15 @@ Duration: 4:33
 URLs:
 - https://www.youtube.com/watch?v=8UFXoZfWagQ
 Referenced Tracks:
-- track:goodbye-induction
+- track:goodbye-original
 - Havoc
 - track:my-hibernation-original
-- track:verisimilitude-induction
+- track:verisimilitude-original
 - track:flying-battery-zone-act-2
 - track:fire-forget
 - track:wistful-induction
 - You Fade Away
-- Shake Your Tail
+- track:shake-your-tail-original
 - The Fox Cub
 Commentary: |-
     <i>Svix:</i> ([YouTube description](https://www.youtube.com/watch?v=8UFXoZfWagQ), excerpt)
@@ -356,4 +360,4 @@ Duration: 4:17
 URLs:
 - https://svix.bandcamp.com/track/goodbye-metawulf-remix
 Referenced Tracks:
-- track:goodbye-induction
+- track:goodbye-original

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -1119,7 +1119,7 @@ Lyrics: |-
 Commentary: |-
     <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/2739374/), excerpt)
 
-    This song wasn't really planned but I kept at it for quite a while and am fairly satisfied with it's length and quality; probably my best so far. I hope you enjoy it too and thank you for listening :\]
+    This song wasn't really planned but I kept at it for quite a while and am fairly satisfied with it's length and quality; probably my best so far. I hope you enjoy it too and thank you for listening :]
 
     Lyrics are somewhat negative, don't worry I'll make some happier music eventually!
 ---

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -46190,6 +46190,15 @@ Duration: 3:41
 URLs:
 - https://www.youtube.com/watch?v=HunRhTyOZu8
 Lyrics: |-
+    <i>msx:</i> (artist's lyrics)
+
+    i yell at the sunlight
+    and tell it to go away
+    i yell at the moonlight
+    and i tell to please stay
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
     I yell at the sunlight
     I yell at the moonlight
 

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -45927,6 +45927,52 @@ URLs:
 - https://www.youtube.com/watch?v=daVdMhArabQ
 - https://disasterpeace.bandcamp.com/track/wagering-lights-feat-derris-kharlan
 ---
+Track: Waiting For The Night
+Artists:
+- msx
+- Furries in a Blender
+Duration: 3:41
+URLs:
+- https://www.youtube.com/watch?v=HunRhTyOZu8
+Lyrics: |-
+    I yell at the sunlight
+    I yell at the moonlight
+
+    I yell at the sunlight
+    I yell at the moonlight
+
+    I yell at the sunlight
+    I yell at the moonlight
+
+    I yell at the sunlight
+    I yell at the moonlight
+
+    I yell at the sunlight
+    And tell it to go away
+    Oh, oh
+    I yell at the moonlight
+    And I tell it to please stay
+    Oh, oh
+
+    I yell at the sunlight
+    And tell it to go away
+    Oh, oh
+    I yell at the moonlight
+    And I tell it to please stay
+    Oh, oh
+
+    I yell at the sunlight
+    And tell it to go away
+    Oh, oh
+    I yell at the moonlight
+    And I tell it to please stay
+    Oh, oh
+
+    I yell at the sunlight
+    I yell at the moonlight
+
+    I yell at the sunlight
+---
 Track: Wake Up Call
 Duration: 3:21
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -903,6 +903,107 @@ Commentary: |-
     <i>Mark J. Hadley:</i>
     Gnarl's Theme, also written for Kid Radd. Since Gnarl was the final boss of Radd's game, it was obvious that his theme should sound like boss fight music.  It has a little of Radd's theme mixed in there, since Radd and Gnarl are brothers (not a spoiler, we find that out pretty quickly in chapter 1).
 ---
+Track: Goodbye
+Directory: goodbye-original
+Always Reference By Directory: true
+Artists:
+- Svix
+Duration: 4:02
+Lyrics: |-
+    Conversation
+    No sensation, things I've yet to say
+
+    Your words still sting
+    just lingering
+    I hang my head in weak dismay
+
+    Thoughts of sorrow
+    bar tomorrow, keep me from the night
+
+    I walk the paths
+    back to the past
+    and they all lead to the same place
+
+    Why do I still call your name?
+    After all this time has passed
+
+    When I think of what we could have been like
+    Think of what we could have been
+    Think of what we could have been
+
+    Why do I still feel the same?
+    You and I weren't meant to last
+
+    But I think of what we could have been like
+    Think of what we could have
+
+    Former feelings still have meaning
+    voids I've yet to fill
+
+    There's moving on
+    It's been and gone
+    But I can't help but keep standing still
+
+    Your affection
+    stark reflection
+    how things used to be
+
+    Gotta bide my time
+    Gotta keep me mine
+
+    Gotta stop myself from thinking
+
+    Why do I still call your name?
+    After all this time has passed
+
+    When I think of what we could have been like
+    Think of what we could have been
+
+    Why do I still feel the same?
+    You and I weren't meant to last
+
+    But I think of what we could have been like
+    Think of what we could have
+    Think of what we could have
+
+    Broken
+    is how you left me
+
+    Unspoken
+    your thoughts about me
+
+    now Shattered
+    the trust I held in you
+
+    Mattered
+    I guess you'd disagree
+
+    Darling
+    The rift between us is
+
+    startling
+    These shifting waves hold
+
+    me under
+    I hold my breath and
+
+    I wonder
+    Do you still think of me?
+
+    Why was it easy?
+    Why was it just me?
+    Why did it all make sense?
+    It never hit me 'til your hand just slipped right through mine
+    until your hand just slipped right through mine
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/4954547/))
+
+    I started this piece months ago and am pleased to have finally finished it. It's certainly my biggest track to date - my project file tells me I've worked on it for 35 hours and 48 minutes! Anyway I quite like the main melody and hopefully the mastering is a bit better than my previous works now that I'm more experienced with things.
+
+    A song for when I'm an emo fox (I'm happier now, honest!), which the vast majority of times is relationship related.
+
+    I can't be everything for everyone.
+---
 Track: Hanging reminder
 Artists:
 - sidewalkbanana
@@ -940,6 +1041,87 @@ Lyrics: |-
 
     William Henry Harrison
     My name is William Henry— [coughs]
+---
+Track: It Really Doesn't Matter
+Directory: it-really-doesnt-matter-original
+Always Reference By Directory: true
+Artists:
+- Svix
+Duration: 5:39
+Lyrics: |-
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to when you've lost all faith
+    in your plans to make amends
+    of which are prone to shatter
+
+    Where will you be when I have left you for the sky
+    It really doesn't matter
+
+    How will you fly when I have done all this and why
+    d'you think it really matters?
+
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to when you've lost all faith
+    in your plans to make amends
+    of which are prone to shatter
+
+    Where will you be when I have left you for the sky
+    It really doesn't matter
+
+    How will you fly when I have done all this and why
+    d'you think it really matters?
+    Really matters, really matters
+    Really matters-
+
+    You think it really matters?
+    Really matters, really matters
+    Really matters-
+
+    You think it really matters?
+    Really matters, really matters
+    Really matters-
+
+    You think it really matters?
+    Really matters, really matters
+    Really matters-
+
+    You think it really matters?
+
+    Turn around, I'm not to follow
+    Times have changed, I hope you realise now
+    Close your mouth, there's no tomorrow
+    Who d'you think you're calling?
+
+    Turn around, I'm not to follow
+    Why persist and make this harder for us
+    Can't you see our past was hollow
+    Look at you you're falling
+
+    What would you do if I said
+    I'm not coming back
+    It really doesn't matter
+
+    Who would you go to when you've lost all faith
+    in your plans to make amends
+    of which are prone to shatter
+
+    Where will you be when I have left you for the sky
+    It really doesn't matter
+
+    How will you fly when I have done all this and why
+    d'you think it really matters at all?
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/2739374/), excerpt)
+
+    This song wasn't really planned but I kept at it for quite a while and am fairly satisfied with it's length and quality; probably my best so far. I hope you enjoy it too and thank you for listening :\]
+
+    Lyrics are somewhat negative, don't worry I'll make some happier music eventually!
 ---
 Track: Kid Radd (Final)
 Artists:
@@ -1509,11 +1691,13 @@ Lyrics: |-
     Shake your tail baby
     Shake it don't be shy
 Commentary: |-
-    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3817678/)
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3817678/), excerpt)
 
     I first started working on this song last Summer and finally got round to completing it a couple of months ago. I wanted to release it along with a piece of art but naturally this puts things back further!
 
     I had a lot of fun with this one, the melody seems strong and the percussion and overdriven synths are hopefully pleasing. The lyrics came naturally:
+
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3817678/), excerpt)
 
     FURRY MUSIC
 ---

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -1905,6 +1905,18 @@ Duration: 3:04
 URLs:
 - https://soundcloud.com/blackholesc/winterfall
 ---
+Track: Wistful
+Directory: wistful-original
+Always Reference By Directory: true
+Artists:
+- Svix
+Duration: 3:43
+URLs:
+- https://www.youtube.com/watch?v=agiOu-Bka4w
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/4092044/))
+    A fairly simple, pleasant piece to get me back into making music for the Summer. Hopefully if you liked [[track:the-fox-cub]] you should enjoy this. I wonder where that little fox has found himself now?
+---
 Track: Your Bed
 Artists:
 - Michael Guy Bowman

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -1697,7 +1697,7 @@ Commentary: |-
 
     I had a lot of fun with this one, the melody seems strong and the percussion and overdriven synths are hopefully pleasing. The lyrics came naturally:
 
-    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3817678/), excerpt)
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3817678/), excerpt, after lyrics)
 
     FURRY MUSIC
 ---

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -1495,6 +1495,28 @@ URLs:
 Referenced Tracks:
 - Seinfeld Theme
 ---
+Track: Shake Your Tail
+Directory: shake-your-tail-original
+Always Reference By Directory: true
+Artists:
+- Svix
+Duration: 3:50
+URLs:
+- https://www.youtube.com/watch?v=mjNmKkfiO0M
+Lyrics: |-
+    Hold your head up baby
+    Hold your head up high
+    Shake your tail baby
+    Shake it don't be shy
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/3817678/)
+
+    I first started working on this song last Summer and finally got round to completing it a couple of months ago. I wanted to release it along with a piece of art but naturally this puts things back further!
+
+    I had a lot of fun with this one, the melody seems strong and the percussion and overdriven synths are hopefully pleasing. The lyrics came naturally:
+
+    FURRY MUSIC
+---
 Track: Sheena Theme
 Artists:
 - Mark J. Hadley
@@ -1613,6 +1635,43 @@ Artists:
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
     From Kalibration's decommissioned Inhibitor album.
+---
+Track: Verisimilitude
+Directory: verisimilitude-original
+Always Reference By Directory: true
+Artists:
+- Svix
+Duration: 3:00
+Lyrics: |-
+    Colour
+    The kind I wish I saw before my feelings were like no
+
+    Other
+    You took me by the hand and then showed me the door
+
+    Maybe
+    I misinterpreted the way you talked and the looks you
+
+    Gave me
+    Remember what you said? It went something like this:
+
+    Colour
+    The kind I wish I saw before my feelings were like no
+
+    Other
+    You took me by the hand and then showed me the door
+
+    Maybe
+    I misinterpreted the way you talked and the looks you
+
+    Gave me
+    Remember what you said? It went something like this:
+Commentary: |-
+    <i>Svix:</i> ([FurAffinity](https://www.furaffinity.net/view/2406887/))
+
+    Song number two! *Dances*
+
+    I created the main synth part to this when I was meant to be revising special relativity, I couldn't help it. This took me around 5 days to complete, which is a vast improvement over how long [[track:my-hibernation-original|my last song]] took. I hope the mastering is ok, it sounds decent on my headphones but I haven't put it through my speakers yet as it's getting late.
 ---
 Track: Vitality
 Directory: vitality-belief
@@ -25363,7 +25422,7 @@ Lyrics: |-
     I guess I'll save the best for last
     My future seems like one big past
     You're left with me 'cause you left me no choice
-    
+
     I push my fingers into my eyes
     It's the only thing that slowly stops the ache
     If the pain goes on
@@ -31853,7 +31912,7 @@ Lyrics: |-
     Pour tirer l'esprit du cachot
     Soufflons nous-mêmes notre forge
     Battons le fer quand il est chaud.
-    
+
     C'est la lutte finale
     Groupons-nous, et demain
     L'Internationale
@@ -42487,7 +42546,7 @@ Lyrics: |-
     Дружбы народов надёжный оплот!
     Знамя советское, знамя народное
     Пусть от победы к победе ведёт!
-    
+
     Мы армию нашу растили в сраженьях.
     Захватчиков подлых с дороги сметём!
     Мы в битвах решаем судьбу поколений,

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -46204,24 +46204,24 @@ Lyrics: |-
 
     I yell at the sunlight
     And tell it to go away
-    Oh, oh
+    Oh, woah
     I yell at the moonlight
     And I tell it to please stay
-    Oh, oh
+    Oh, woah
 
     I yell at the sunlight
     And tell it to go away
-    Oh, oh
+    Oh, woah
     I yell at the moonlight
     And I tell it to please stay
-    Oh, oh
+    Oh, woah
 
     I yell at the sunlight
     And tell it to go away
-    Oh, oh
+    Oh, woah
     I yell at the moonlight
     And I tell it to please stay
-    Oh, oh
+    Oh, woah
 
     I yell at the sunlight
     I yell at the moonlight

--- a/album/showtime-svix-mix.yaml
+++ b/album/showtime-svix-mix.yaml
@@ -14,6 +14,7 @@ Cover Artists:
 Cover Art File Extension: png
 Color: '#909090'
 Groups:
+- Svix
 - Fandom
 ---
 Track: Showtime (Svix Mix)

--- a/album/sun-in-sedona.yaml
+++ b/album/sun-in-sedona.yaml
@@ -1,0 +1,94 @@
+Album: Sun in Sedona
+Artists:
+- Svix
+Date: January 5, 2024
+URLs:
+- https://svix.bandcamp.com/track/sun-in-sedona
+- https://www.youtube.com/watch?v=kR2dIVEd2uY
+- https://open.spotify.com/album/5J2F5kKPBc1k27yabjjuro
+Cover Artists:
+- Svix
+Color: '#ec9b49'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+---
+Track: Sun in Sedona
+Duration: 3:17
+URLs:
+- https://svix.bandcamp.com/track/sun-in-sedona
+- https://www.youtube.com/watch?v=kR2dIVEd2uY
+- https://open.spotify.com/track/1KYW89nItmhyTLXDW1zEkF
+Lyrics: |-
+    Got back the other day
+    Still haven't had no sleep
+    My head is full of things that tumble out
+    And shatter at my feet
+
+    And now I sit at home
+    Somehow forget to eat
+    I thought I wanted this
+    But by myself I never feel complete
+
+    So if you tell me that I should wait a while
+    I'll just do it again
+
+    Cos I
+    Miss the sun in Sedona
+    Endless miles of Arizona
+    Watch the fall in Colorado
+    End the year up in Chicago
+
+    Window seat on the ocean
+    Passing clouds keep my eyes open
+    Maybe see you in December
+    Give me something to remember
+
+    A wave across the room, they think you're having fun
+    You got a thousand friends
+    But no one close to stop you feeling numb
+
+    Too busy missing out on things you should have done
+    And when we try to help
+    You can't relax, you're always on the run
+
+    But if you tell me that I should wait a while
+    I'll just do it again
+
+    Cos I
+    Miss the sun in Sedona
+    Endless miles of Arizona
+    Watch the fall in Colorado
+    End the year up in Chicago
+
+    Window seat on the ocean
+    Passing clouds keep my eyes open
+    Maybe see you in December
+    Give me something to remember
+
+    Cos I
+    Miss the sun in Sedona
+    Endless miles of Arizona
+    Watch the fall in Colorado
+    End the year up in Chicago
+
+    Window seat on the ocean
+    Passing clouds keep my eyes open
+    Maybe see you in December
+    Give me something to remember
+    (No time for getting misty eyes
+    Pack your bags get used to short goodbyes)
+
+    You say
+    I'm gonna be there
+    Promise to try and see ya
+    But I'm almost going home
+    I think it's best to leave it
+
+    I'm still crying through my smile
+    I guess it's gonna be a while
+    No need to keep me near
+    Because there's always next year
+
+    There's always next year

--- a/album/sun-in-sedona.yaml
+++ b/album/sun-in-sedona.yaml
@@ -21,6 +21,8 @@ URLs:
 - https://www.youtube.com/watch?v=kR2dIVEd2uY
 - https://open.spotify.com/track/1KYW89nItmhyTLXDW1zEkF
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/sun-in-sedona))
+
     Got back the other day
     Still haven't had no sleep
     My head is full of things that tumble out

--- a/album/sun-in-sedona.yaml
+++ b/album/sun-in-sedona.yaml
@@ -1,4 +1,5 @@
 Album: Sun in Sedona
+Style: single
 Artists:
 - Svix
 Date: January 5, 2024

--- a/album/the-only-other-thing.yaml
+++ b/album/the-only-other-thing.yaml
@@ -1,4 +1,5 @@
 Album: The Only Other Thing
+Style: single
 Artists:
 - Svix
 Date: June 9, 2020
@@ -13,10 +14,6 @@ Groups:
 - Svix
 - Beyond
 Cover Art File Extension: png
-Commentary: |-
-    <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/track/the-only-other-thing))
-
-    Music video: [youtu.be/n2zh_nusoy4](https://youtu.be/n2zh_nusoy4)
 ---
 Track: The Only Other Thing
 Duration: 3:41
@@ -116,3 +113,7 @@ Lyrics: |-
 
     Say na nana nana
     Say na nana nana
+Commentary: |-
+    <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/track/the-only-other-thing))
+
+    Music video: [youtu.be/n2zh_nusoy4](https://youtu.be/n2zh_nusoy4)

--- a/album/the-only-other-thing.yaml
+++ b/album/the-only-other-thing.yaml
@@ -39,15 +39,7 @@ Lyrics: |-
 
     <i>Lilithtreasure:</i> (wiki lyrics)
 
-    I'll teach you how to move
-    Your left foot to the groove
-    Your right foot on the ground
-    Now move them all around
-
-    I'll teach you how to sing
-    The only other thing
-    Say na nana nana
-    Say na nana nana
+    *(0:16-0:48)*
 
     I'll teach you how to move
     Your left foot to the groove
@@ -58,6 +50,18 @@ Lyrics: |-
     The only other thing
     Say na nana nana
     Say na nana nana
+
+    I'll teach you how to move
+    Your left foot to the groove
+    Your right foot on the ground
+    Now move them all around
+
+    I'll teach you how to sing
+    The only other thing
+    Say na nana nana
+    Say na nana nana
+
+    *(1:21-1:37)*
 
     Nana nana na na nana na na
     Say na nana nana
@@ -67,8 +71,12 @@ Lyrics: |-
     Say na nana nana
     Say na nana nana
 
+    *(1:41-1:46)*
+
     Say na nana nana
     Say na nana nana
+
+    *(2:34-3:06)*
 
     I'll teach you how to move
     Your left foot to the groove
@@ -78,8 +86,9 @@ Lyrics: |-
     I'll teach you how to sing
     The only other thing
     Say na nana nana
-    Say na-
+    Say na n-
 
+    -Na
     I'll teach you how to move
     Your left foot to the groove
     Your right foot on the ground
@@ -90,7 +99,18 @@ Lyrics: |-
     Saaaaa nana nana
     Saaaaa nana nana
 
+    *(3:07-3:22)*
+
     Nana nana na na nana na na
+    Say na nana nana
+    Say na nana nana
+
+    Nana nana na na nana na na
+    Say na nana nana
+    Say na nana nana
+
+    *(3:26-3:37)*
+
     Say na nana nana
     Say na nana nana
 

--- a/album/the-only-other-thing.yaml
+++ b/album/the-only-other-thing.yaml
@@ -25,6 +25,20 @@ URLs:
 - https://www.youtube.com/watch?v=n2zh_nusoy4
 - https://open.spotify.com/track/3RBmvrkmqMVFq8yRRpUQiQ
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/the-only-other-thing))
+
+    I'll teach you how to move
+    Your left foot to the groove
+    Your right foot on the ground
+    Now move them all around
+
+    I'll teach you how to sing
+    The only other thing
+    Say na nana nana
+    Say na nana nana
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
     I'll teach you how to move
     Your left foot to the groove
     Your right foot on the ground

--- a/album/the-only-other-thing.yaml
+++ b/album/the-only-other-thing.yaml
@@ -1,0 +1,84 @@
+Album: The Only Other Thing
+Artists:
+- Svix
+Date: June 9, 2020
+URLs:
+- https://svix.bandcamp.com/track/the-only-other-thing
+- https://www.youtube.com/watch?v=n2zh_nusoy4
+- https://open.spotify.com/album/63IUL69ybxSjmeNUbO4L57
+Cover Artists:
+- Svix
+Color: '#be63d7'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+Commentary: |-
+    <i>Svix:</i> ([Bandcamp about blurb](https://svix.bandcamp.com/track/the-only-other-thing))
+
+    Music video: [youtu.be/n2zh_nusoy4](https://youtu.be/n2zh_nusoy4)
+---
+Track: The Only Other Thing
+Duration: 3:41
+URLs:
+- https://svix.bandcamp.com/track/the-only-other-thing
+- https://www.youtube.com/watch?v=n2zh_nusoy4
+- https://open.spotify.com/track/3RBmvrkmqMVFq8yRRpUQiQ
+Lyrics: |-
+    I'll teach you how to move
+    Your left foot to the groove
+    Your right foot on the ground
+    Now move them all around
+
+    I'll teach you how to sing
+    The only other thing
+    Say na nana nana
+    Say na nana nana
+
+    I'll teach you how to move
+    Your left foot to the groove
+    Your right foot on the ground
+    Now move them all around
+
+    I'll teach you how to sing
+    The only other thing
+    Say na nana nana
+    Say na nana nana
+
+    Nana nana na na nana na na
+    Say na nana nana
+    Say na nana nana
+
+    Nana nana na na nana na na
+    Say na nana nana
+    Say na nana nana
+
+    Say na nana nana
+    Say na nana nana
+
+    I'll teach you how to move
+    Your left foot to the groove
+    Your right foot on the ground
+    Now move them all around
+
+    I'll teach you how to sing
+    The only other thing
+    Say na nana nana
+    Say na-
+
+    I'll teach you how to move
+    Your left foot to the groove
+    Your right foot on the ground
+    Now move them all around
+
+    I'll teach you how to sing
+    The only other thing
+    Saaaaa nana nana
+    Saaaaa nana nana
+
+    Nana nana na na nana na na
+    Say na nana nana
+    Say na nana nana
+
+    Say na nana nana
+    Say na nana nana

--- a/album/unbeatable-demo-tapes.yaml
+++ b/album/unbeatable-demo-tapes.yaml
@@ -800,7 +800,7 @@ Lyrics: |-
 
     [ real rad saxophone doodily doots ]
 
-    <i>HSMusic Wiki:</i> (wiki lyrics—help needed)
+    <i>HSMusic Wiki:</i> (wiki lyrics, help needed)
 
     (Speak-N-Say vocals at 0:26-0:43; seemingly the same words or letters are repeated by a human chorus. The human vocals are more audible toward the end of the track.)
 Commentary: |-

--- a/album/waiting-for-the-night-svix-mix.yaml
+++ b/album/waiting-for-the-night-svix-mix.yaml
@@ -33,6 +33,18 @@ Referenced Tracks:
 Sampled Tracks:
 - Waiting for the Night
 Lyrics: |-
+    <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/waiting-for-the-night-svix-mix))
+
+    I yell at the sunlight and tell it to go away
+    I yell at the moonlight and I tell it to please stay
+
+    Feel my body sink lower, stillness and grey
+    Little somethings come to nothing and I don't know what to say
+    Try to keep my eyes open, 'cos I can't face the day
+    From the corner bleeds the sunrise tell myself I'll be ok
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
     I yell at the sunlight and tell it to go away
     Oh, oh
     I yell at the moonlight and I tell it to please stay

--- a/album/waiting-for-the-night-svix-mix.yaml
+++ b/album/waiting-for-the-night-svix-mix.yaml
@@ -1,4 +1,5 @@
 Album: Waiting for the Night (Svix mix)
+Style: single
 Artists:
 - Svix
 Date: September 4, 2024
@@ -29,9 +30,9 @@ URLs:
 - https://svix.bandcamp.com/track/waiting-for-the-night-svix-mix
 - https://www.youtube.com/watch?v=-iQBVJXoiB0
 Referenced Tracks:
-- Waiting for the Night
+- Waiting For The Night
 Sampled Tracks:
-- Waiting for the Night
+- Waiting For The Night
 Lyrics: |-
     <i>Svix:</i> ([artist's lyrics](https://svix.bandcamp.com/track/waiting-for-the-night-svix-mix))
 

--- a/album/waiting-for-the-night-svix-mix.yaml
+++ b/album/waiting-for-the-night-svix-mix.yaml
@@ -1,0 +1,73 @@
+Album: Waiting for the Night (Svix mix)
+Artists:
+- Svix
+Date: September 4, 2024
+URLs:
+- https://svix.bandcamp.com/track/waiting-for-the-night-svix-mix
+- https://www.youtube.com/watch?v=-iQBVJXoiB0
+Cover Artists:
+- Svix
+Cover Art Dimensions: 3064x1724
+Color: '#c1c1c1'
+Groups:
+- Svix
+- Beyond
+Cover Art File Extension: png
+Commentary: |-
+    <i>Svix:</i> ([Bandcamp credits blurb](https://svix.bandcamp.com/track/waiting-for-the-night-svix-mix))
+
+    Original by [[artist:msx|Lapfox Trax]]: [www.youtube.com/watch?v=HunRhTyOZu8](https://www.youtube.com/watch?v=HunRhTyOZu8)
+---
+Track: Waiting for the Night (Svix mix)
+Additional Names:
+- Name: >-
+    Waiting for the Night (FIAB Svix mix)
+  Annotation: >-
+    [YouTube](https://www.youtube.com/watch?v=-iQBVJXoiB0)
+Duration: 3:36
+URLs:
+- https://svix.bandcamp.com/track/waiting-for-the-night-svix-mix
+- https://www.youtube.com/watch?v=-iQBVJXoiB0
+Referenced Tracks:
+- Waiting for the Night
+Sampled Tracks:
+- Waiting for the Night
+Lyrics: |-
+    I yell at the sunlight and tell it to go away
+    Oh, oh
+    I yell at the moonlight and I tell it to please stay
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    I yell at the sunlight and tell it to go away
+    Oh, oh
+    I yell at the moonlight and I tell it to please stay
+    Oh, oh
+
+    Feel my body sink lower, stillness and grey
+    Little somethings come to nothing and I don't know what to say
+    Try to keep my eyes open, 'cos I can't face the day
+    From the corner bleeds the sunrise tell myself I'll be ok
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh
+
+    Oh, oh

--- a/album/waiting-for-the-night-svix-mix.yaml
+++ b/album/waiting-for-the-night-svix-mix.yaml
@@ -45,41 +45,67 @@ Lyrics: |-
 
     <i>Lilithtreasure:</i> (wiki lyrics)
 
-    I yell at the sunlight and tell it to go away
-    Oh, oh
-    I yell at the moonlight and I tell it to please stay
-    Oh, oh
-
-    Oh, oh
-
-    Oh, oh
-
-    Oh, oh
-
-    Oh, oh
+    *(0:21-0:42)*
 
     I yell at the sunlight and tell it to go away
-    Oh, oh
+    Oh, woah
     I yell at the moonlight and I tell it to please stay
-    Oh, oh
+    Oh, woah
+
+    *(0:51-0:52)*
+
+    Oh, woah
+
+    *(1:01-1:03)*
+
+    Oh, woah
+
+    *(1:12-1:14)*
+
+    Oh, woah
+
+    *(1:23-2:08)*
+
+    Oh, woah
+
+    I yell at the sunlight and tell it to go away
+    Oh, woah
+    I yell at the moonlight and I tell it to please stay
+    Oh, woah
 
     Feel my body sink lower, stillness and grey
-    Little somethings come to nothing and I don't know what to say
+    Little somethings come to nothing and I don't know what to say (Oh, woah)
     Try to keep my eyes open, 'cos I can't face the day
-    From the corner bleeds the sunrise tell myself I'll be ok
+    From the corner bleeds the sunrise tell myself I'll be ok (Oh, woah)
 
-    Oh, oh
+    *(2:16-2:18)*
 
-    Oh, oh
+    Oh, woah
 
-    Oh, oh
+    *(2:27-2:29)*
 
-    Oh, oh
+    Oh, woah
 
-    Oh, oh
+    *(2:38-2:39)*
 
-    Oh, oh
+    Oh, woah
 
-    Oh, oh
+    *(2:49-2:50)*
 
-    Oh, oh
+    Oh, woah
+
+    *(2:59-3:00)*
+
+    Oh, woah
+
+    *(3:10-3:11)*
+
+    Oh, woah
+
+    *(3:20-3:21)*
+
+    Oh, woah
+
+    *(3:31-3:33)*
+
+    Oh, woah

--- a/artists.yaml
+++ b/artists.yaml
@@ -5025,6 +5025,10 @@ URLs:
 - https://www.youtube.com/c/funkmclovin
 - https://twitter.com/BigFunkyJ
 ---
+Artist: Furries in a Blender
+Context Notes: |-
+    Alias of [[artist:msx]].
+---
 Artist: Futurama
 ---
 Artist: Fuzz
@@ -9572,7 +9576,7 @@ Aliases:
 - em essex
 - Emma Essex
 Context Notes: |-
-    Releases music under a variety of names, including on this wiki: [[artist:jackal-queenston]], [[artist:kitcaliber]], [[artist:rotteen]].
+    Releases music under a variety of names, including on this wiki: [[artist:furries-in-a-blender]], [[artist:jackal-queenston]], [[artist:kitcaliber]], [[artist:rotteen]].
 URLs:
 - https://lapfox.bandcamp.com
 - https://msx.horse

--- a/groups.yaml
+++ b/groups.yaml
@@ -555,6 +555,15 @@ URLs:
 Description: |-
     Known primarily for [[track:frost-vol6]] and his solo album [[album:prospit-and-derse]], this artist has been making electronic and orchestral music for many years.
 ---
+Group: Svix
+Closely Linked Artists:
+- Svix
+URLs:
+- https://svix.bandcamp.com/
+- https://www.youtube.com/@Svix
+Description: |-
+    Electronic chiptune pop artist. stub.
+---
 Group: rj lake
 Closely Linked Artists:
 - rj lake

--- a/groups.yaml
+++ b/groups.yaml
@@ -562,7 +562,7 @@ URLs:
 - https://svix.bandcamp.com/
 - https://www.youtube.com/@Svix
 Description: |-
-    Electronica chiptune pop artist, who contributed tracks such as [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]] in Homestuck's discography, with an ongoing solo discography since 2009. 
+    Electronica chiptune pop artist, who contributed tracks such as [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]] in Homestuck's discography, with an ongoing solo discography since 2009.
 ---
 Group: rj lake
 Closely Linked Artists:

--- a/groups.yaml
+++ b/groups.yaml
@@ -561,6 +561,21 @@ Closely Linked Artists:
 URLs:
 - https://svix.bandcamp.com/
 - https://www.youtube.com/@Svix
+Series:
+- Name: Albums
+  Albums:
+  - Induction
+  - Cyberdemon
+- Name: Singles
+  Albums:
+  - Showtime (Svix Mix)
+  - album:fire-forget
+  - I'm Here for the Future
+  - Audacity
+  - Coastline in December
+  - The Only Other Thing
+  - Sun in Sedona
+  - Waiting for the Night (Svix mix)
 Description: |-
     Electronica chiptune pop artist, who contributed tracks such as [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]] in Homestuck's discography, with an ongoing solo discography since 2009.
 ---

--- a/groups.yaml
+++ b/groups.yaml
@@ -562,7 +562,7 @@ URLs:
 - https://svix.bandcamp.com/
 - https://www.youtube.com/@Svix
 Description: |-
-    Artist dabbling in electronica, chiptune, and pop. Composer of [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]]. 
+    Artist dabbling in electronica, chiptune, and pop. Composer of [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]].
 ---
 Group: rj lake
 Closely Linked Artists:

--- a/groups.yaml
+++ b/groups.yaml
@@ -562,7 +562,7 @@ URLs:
 - https://svix.bandcamp.com/
 - https://www.youtube.com/@Svix
 Description: |-
-    Artist dabbling in electronica, chiptune, and pop. Composer of [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]].
+    Electronica chiptune pop artist, who contributed tracks such as [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]] in Homestuck's discography, with an ongoing solo discography since 2009. 
 ---
 Group: rj lake
 Closely Linked Artists:

--- a/groups.yaml
+++ b/groups.yaml
@@ -562,7 +562,7 @@ URLs:
 - https://svix.bandcamp.com/
 - https://www.youtube.com/@Svix
 Description: |-
-    Electronic chiptune pop artist. stub.
+    Artist dabbling in electronica, chiptune, and pop. Composer of [[track:havoc]], [[track:trepidation]], and [[track:negative-aperture]]. 
 ---
 Group: rj lake
 Closely Linked Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -215,7 +215,7 @@ Content: |-
         - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]]
         - fixed [[track:goodbye-induction]] not referencing [[track:goodbye-original]]
         - fixed [[track:shake-your-tail]] not referencing [[track:shake-your-tail-original]]
-        - fixed [[track:fin]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]] instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]]
+        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]] instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]]
     - updated a bunch of Deltarune references to point to in-between WIPs from [[album:deltarune-ch2-rejected-tracks]] (thanks, ruby!)
         - fixed [[track:my-castle-town]] referencing [[track:the-legend]] instead of [[track:castle-town-unfinished]]
         - fixed [[track:attack-of-the-killer-queen]] referencing [[track:queen-deltarune]] instead of [[track:queen-battle-original]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -211,7 +211,7 @@ Content: |-
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
-        - fixed [[track:verisimilitude-induction]], [[track:it-really-doesnt-matter]], [[track:goodbye-induction]], [[track:shake-your-tail]] ([[album:induction]]) not referencing [[track:verisimilitude-original]], [[track:it-really-doesnt-matter-original]], [[track:goodbye-original]], [[track:shake-your-tail-original]] (original singles)
+        - fixed [[track:verisimilitude-induction]], [[track:it-really-doesnt-matter]], [[track:goodbye-induction]], [[track:wistful-induction]], [[track:shake-your-tail]] ([[album:induction]]) not referencing [[track:verisimilitude-original]], [[track:it-really-doesnt-matter-original]], [[track:goodbye-original]], [[track:wistful-original]], [[track:shake-your-tail-original]] (original singles)
         - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]], ([[album:induction]]) instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]] (original singles)
     - updated a bunch of Deltarune references to point to in-between WIPs from [[album:deltarune-ch2-rejected-tracks]] (thanks, ruby!)
         - fixed [[track:my-castle-town]] referencing [[track:the-legend]] instead of [[track:castle-town-unfinished]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -90,7 +90,7 @@ Content: |-
         - added [[album:deltarune-status-update-sept-2022]]!
         - added [[album:deltarune-ch3-status-update]]!
         - added [[album:deltarune-ch2-rejected-tracks]]!
-    - added albums and singles from [[group:svix]]! (thanks, Lilith!)
+    - added albums and singles from [[group:svix]]! (thanks, Lilith, Lan!)
         - added [[album:fire-forget]]!
         - added [[album:im-here-for-the-future]]!
         - added [[album:audacity]]!
@@ -295,6 +295,7 @@ Content: |-
     <details><summary><b>Toggle Directorylog</b></summary>
     - changed directory of [[track:the-respect-you-rightfully-deserve-single]] from `the-respect-you-rightfully-deserve-soundcloud` to `the-respect-you-rightfully-deserve-single`
     - changed directory of [[track:frost-and-frogs-lofam5a2]] from `frost-and-frogs` to `frost-and-frogs-lofam5a2`
+    - changed directory of [[track:audacity]] from `audacity-svix` to `audacity`
     - changed directories of all tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] to be suffixed `-ch1` and `-ch2` respectively; previous directories now used across [[album:deltarune-soundtrack]]
     - changed directory of [[track:bad-apple-lovelight]] from `bad-apple-feat-nomico` to `bad-apple-lovelight`
     - changed directory of [[track:death-mountain-theme]] from `death-mountain-the-legend-of-zelda` to `death-mountain-theme`

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -90,6 +90,14 @@ Content: |-
         - added [[album:deltarune-status-update-sept-2022]]!
         - added [[album:deltarune-ch3-status-update]]!
         - added [[album:deltarune-ch2-rejected-tracks]]!
+    - added albums and singles from [[group:svix]]! (thanks, Lilith!)
+        - added [[album:im-here-for-the-future]]!
+        - added [[album:audacity]]!
+        - added [[album:coastline-in-december]]!
+        - added [[album:the-only-other-thing]]!
+        - added [[album:cyberdemon]]!
+        - added [[album:sun-in-sedona]]!
+        - added [[album:waiting-for-the-night-svix-mix]]!
     - added [[album:so-i-herd-you-liek-homestuck]] by [[artist:sidewalkbanana]] (thanks, Lilith!)
     - added [[album:centauromachy]] and [[album:sbargrist]] by [[artist:curricle]]! (thanks, Jebb!)
     - added [[album:some-artifacts-may-occur]] by [[artist:shinokabe]] (thanks, Lilith, Lan!)
@@ -202,6 +210,12 @@ Content: |-
     - fixed [[track:gold-mage-playtime-is-over-mix]] referencing [[track:gold-mage]] instead of [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
+    - fixed various [[album:induction]]-related references (thanks, Lilith!)
+        - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]]
+        - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]]
+        - fixed [[track:goodbye-induction]] not referencing [[track:goodbye-original]]
+        - fixed [[track:shake-your-tail]] not referencing [[track:shake-your-tail-original]]
+        - fixed [[track:fin]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]] instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]]
     - updated a bunch of Deltarune references to point to in-between WIPs from [[album:deltarune-ch2-rejected-tracks]] (thanks, ruby!)
         - fixed [[track:my-castle-town]] referencing [[track:the-legend]] instead of [[track:castle-town-unfinished]]
         - fixed [[track:attack-of-the-killer-queen]] referencing [[track:queen-deltarune]] instead of [[track:queen-battle-original]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -211,11 +211,8 @@ Content: |-
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
-        - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]]
-        - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]]
-        - fixed [[track:goodbye-induction]] not referencing [[track:goodbye-original]]
-        - fixed [[track:shake-your-tail]] not referencing [[track:shake-your-tail-original]]
-        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]] instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]]
+        - fixed [[track:verisimilitude-induction]], [[track:it-really-doesnt-matter]], [[track:goodbye-induction]], [[track:shake-your-tail]] ([[album:induction]]) not referencing [[track:verisimilitude-original]], [[track:it-really-doesnt-matter-original]], [[track:goodbye-original]], [[track:shake-your-tail-original]] (original singles)
+        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]], ([[album:induction]]) instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]] (original singles)
     - updated a bunch of Deltarune references to point to in-between WIPs from [[album:deltarune-ch2-rejected-tracks]] (thanks, ruby!)
         - fixed [[track:my-castle-town]] referencing [[track:the-legend]] instead of [[track:castle-town-unfinished]]
         - fixed [[track:attack-of-the-killer-queen]] referencing [[track:queen-deltarune]] instead of [[track:queen-battle-original]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -212,8 +212,13 @@ Content: |-
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
-        - fixed [[track:verisimilitude-induction]], [[track:it-really-doesnt-matter]], [[track:goodbye-induction]], [[track:wistful-induction]], [[track:shake-your-tail]], [[track:fire-forget]] ([[album:induction]]), not referencing [[track:verisimilitude-original]], [[track:it-really-doesnt-matter-original]], [[track:goodbye-original]], [[track:wistful-original]], [[track:shake-your-tail-original]], [[track:fire-forget-original]] (original singles)
-        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:fire-forget]], [[track:wistful-induction]], [[track:shake-your-tail]] ([[album:induction]]), instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:fire-forget-original]], [[track:wistful-original]], [[track:shake-your-tail-original]] (original singles)
+        - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]] (original single)
+        - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]] (original single)
+        - fixed [[track:goodbye-induction]] not referencing [[track:goodbye-original]] (original single)
+        - fixed [[track:wistful-induction]] not referencing [[track:wistful-original]] (original single)
+        - fixed [[track:shake-your-tail]] not referencing [[track:shake-your-tail-original]] (original single)
+        - fixed [[track:fire-forget]] not referencing [[track:fire-forget-original]] (original single)
+        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:fire-forget]], [[track:wistful-induction]], [[track:shake-your-tail]], instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:fire-forget-original]], [[track:wistful-original]], [[track:shake-your-tail-original]] (original singles)
     - updated a bunch of Deltarune references to point to in-between WIPs from [[album:deltarune-ch2-rejected-tracks]] (thanks, ruby!)
         - fixed [[track:my-castle-town]] referencing [[track:the-legend]] instead of [[track:castle-town-unfinished]]
         - fixed [[track:attack-of-the-killer-queen]] referencing [[track:queen-deltarune]] instead of [[track:queen-battle-original]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -91,6 +91,7 @@ Content: |-
         - added [[album:deltarune-ch3-status-update]]!
         - added [[album:deltarune-ch2-rejected-tracks]]!
     - added albums and singles from [[group:svix]]! (thanks, Lilith!)
+        - added [[album:fire-forget]]!
         - added [[album:im-here-for-the-future]]!
         - added [[album:audacity]]!
         - added [[album:coastline-in-december]]!
@@ -211,8 +212,8 @@ Content: |-
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
-        - fixed [[track:verisimilitude-induction]], [[track:it-really-doesnt-matter]], [[track:goodbye-induction]], [[track:wistful-induction]], [[track:shake-your-tail]] ([[album:induction]]) not referencing [[track:verisimilitude-original]], [[track:it-really-doesnt-matter-original]], [[track:goodbye-original]], [[track:wistful-original]], [[track:shake-your-tail-original]] (original singles)
-        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:shake-your-tail]], ([[album:induction]]) instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:shake-your-tail-original]] (original singles)
+        - fixed [[track:verisimilitude-induction]], [[track:it-really-doesnt-matter]], [[track:goodbye-induction]], [[track:wistful-induction]], [[track:shake-your-tail]], [[track:fire-forget]] ([[album:induction]]), not referencing [[track:verisimilitude-original]], [[track:it-really-doesnt-matter-original]], [[track:goodbye-original]], [[track:wistful-original]], [[track:shake-your-tail-original]], [[track:fire-forget-original]] (original singles)
+        - fixed [[track:fin-induction]] referencing [[track:goodbye-induction]], [[track:verisimilitude-induction]], [[track:fire-forget]], [[track:wistful-induction]], [[track:shake-your-tail]] ([[album:induction]]), instead of [[track:goodbye-original]], [[track:verisimilitude-original]], [[track:fire-forget-original]], [[track:wistful-original]], [[track:shake-your-tail-original]] (original singles)
     - updated a bunch of Deltarune references to point to in-between WIPs from [[album:deltarune-ch2-rejected-tracks]] (thanks, ruby!)
         - fixed [[track:my-castle-town]] referencing [[track:the-legend]] instead of [[track:castle-town-unfinished]]
         - fixed [[track:attack-of-the-killer-queen]] referencing [[track:queen-deltarune]] instead of [[track:queen-battle-original]]


### PR DESCRIPTION
Resolves the rest of [#397 Album additions: Svix!](https://github.com/hsmusic/hsmusic-data/issues/397)

Adds the remainder of Svix's albums:
- [x] Audacity, 2012
- [x] Coastline in December, 2014
- [x] The Only Other Thing, 2020
- [x] Cyberdemon, 2021
- [x] Sun in Sedona, 2024
- [x] Waiting for the Night (Svix mix), 2024

and also:
- [x] Fire + Forget (original single version), 2009
- [x] I'm Here for the Future, 2010

new group additions:
- Svix
~~- Raid~~ (removed and moved to [#763 Group addition: Raid](https://github.com/hsmusic/hsmusic-data/pull/763) as to not languish in the review of this pull request!)

new artist additions:
- Furries in a Blender (another alias/artist of msx, added as part of adding Waiting for the Night from the Storm World album)

additional changes:
- induction versions of Verisimilitude, Goodbye, It Doesn't Matter, Wistful, Shake Your Tail, and Fire + Forget now reference the original versions of those tracks
- Fin (Induction)'s referenced tracks of Goodbye, Shake Your Tail, Fire + Forget, and Verisimilitude have been changed to the original versions of the tracks

additional track additions:
- Waiting for the Night (first FIAB track on the wiki!)
- original version of Verisimilitude (induction version now references it)
- original version of Goodbye (induction version now references it)
- original version of It Doesn't Matter (induction version now references it)
- original version of Shake Your Tail (induction version now references it)
- original version of Wistful (Induction version now references it)

Merge with: https://github.com/hsmusic/hsmusic-media/pull/118