### PR TITLE
Reference correction (Silly Billy --> Silly Billy (Churgney Gurgney) + missing lyric addition (Coulrocide)

### DIFF
--- a/album/fondly-regard-illustration.yaml
+++ b/album/fondly-regard-illustration.yaml
@@ -767,9 +767,7 @@ Commentary: |-
     - (5:46) The juggalos' last ditch attempt to kill Strider.
     - (5:55) Single conclusive SLICE to kill them both, the clowns' bodies falling heavily onto the ground.
     And finally,
-    - (6:02)
-    <code style="color: orange">TT: The few witnesses would report seeing only a man with a sword on a shitty skateboard, gently rising into the night sky.<br>
-    TT: No one ever saw him again.</code>
+    - (6:02)<br><code style="color: #f2a400">TT: The few witnesses would report seeing only a man with a sword on a shitty skateboard, gently rising into the night sky.<br>TT: No one ever saw him again.</code>
 
     (P.S, the whistling at the end was me. Since i am kinda bad at whistling, i pitched it up quite a bit.)
 

--- a/album/fondly-regard-illustration.yaml
+++ b/album/fondly-regard-illustration.yaml
@@ -692,6 +692,8 @@ Track: Coulrocide
 Cover Artists:
 - Reese
 Art Tags:
+- Violent J
+- Shaggy 2 Dope
 - Dirk's bro
 - Earth
 - Unbreakable Katana
@@ -706,7 +708,7 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 - Beatdown (Strider Style)
 # - Jupiter (unreleased)
-- Silly Billy
+- track:silly-billy-churgney-gurgney
 - Davesprite
 - Hokus Pokus
 - Imma Kill U
@@ -744,6 +746,7 @@ Lyrics: |-
 
     (Hokus pokus, joker's ride) (Hokus pokus, joker's ride)
     (Hokus pokus, joker's ride) (Hokus pokus, joker's ride)
+    Imma fucking kill you!
 
     (Atomyk Ebonpyre whistling noises)
 Commentary: |-
@@ -764,7 +767,8 @@ Commentary: |-
     - (5:46) The juggalos' last ditch attempt to kill Strider.
     - (5:55) Single conclusive SLICE to kill them both, the clowns' bodies falling heavily onto the ground.
     And finally,
-    - (6:02) <span style="color: orange">TT: The few witnesses would report seeing only a man with a sword on a shitty skateboard, gently rising into the night sky. / TT: No one ever saw him again</span>.
+    - (6:02) <code style="color: orange">TT: The few witnesses would report seeing only a man with a sword on a shitty skateboard, gently rising into the night sky.<br>
+    TT: No one ever saw him again.</code>
 
     (P.S, the whistling at the end was me. Since i am kinda bad at whistling, i pitched it up quite a bit.)
 

--- a/album/fondly-regard-illustration.yaml
+++ b/album/fondly-regard-illustration.yaml
@@ -767,7 +767,8 @@ Commentary: |-
     - (5:46) The juggalos' last ditch attempt to kill Strider.
     - (5:55) Single conclusive SLICE to kill them both, the clowns' bodies falling heavily onto the ground.
     And finally,
-    - (6:02) <code style="color: orange">TT: The few witnesses would report seeing only a man with a sword on a shitty skateboard, gently rising into the night sky.<br>
+    - (6:02)
+    <code style="color: orange">TT: The few witnesses would report seeing only a man with a sword on a shitty skateboard, gently rising into the night sky.<br>
     TT: No one ever saw him again.</code>
 
     (P.S, the whistling at the end was me. Since i am kinda bad at whistling, i pitched it up quite a bit.)

--- a/album/fondly-regard-illustration.yaml
+++ b/album/fondly-regard-illustration.yaml
@@ -708,7 +708,7 @@ Referenced Tracks:
 - Atomyk Ebonpyre
 - Beatdown (Strider Style)
 # - Jupiter (unreleased)
-- track:silly-billy-churgney-gurgney
+- track:silly-billy-hit-single
 - Davesprite
 - Hokus Pokus
 - Imma Kill U

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -8959,15 +8959,35 @@ Lyrics: |-
     [Largely indecipherable French whispering]
 ---
 Track: Silly Billy
-Directory: silly-billy-churgney-gurgney
+Directory: silly-billy-hit-single
 Always Reference By Directory: true
 Duration: 6:14
 Artists:
 - Friday Night Funkin'
 - churgney gurgney
+- Ironik (featuring)
+- Duccly (featuring)
+- Spacenautica (featuring)
+- honkish (featuring)
+- HassenXBlu (featuring)
 URLs:
 - https://www.youtube.com/watch?v=jwhSUmN5zTk
+- https://open.spotify.com/track/7eMEN37TY5YcYvSel1Ya4k
 - https://soundcloud.com/gurgney/silly-billy
+Lyrics: |-
+    I'll make
+    You say
+    How proud
+    You are of me
+    So stay
+    Awake
+    Just long
+    Enough to see
+    My way
+
+    My way
+    
+    My way
 ---
 Track: Simian Segue
 # Reference:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -8963,7 +8963,7 @@ Directory: silly-billy-churgney-gurgney
 Always Reference By Directory: true
 Duration: 6:14
 Artists:
-- Friday Night Funkin
+- Friday Night Funkin'
 - churgney gurgney
 URLs:
 - https://www.youtube.com/watch?v=jwhSUmN5zTk

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -8958,6 +8958,16 @@ URLs:
 Lyrics: |-
     [Largely indecipherable French whispering]
 ---
+Track: Silly Billy
+Directory: silly-billy-churgney-gurgney
+Always Reference By Directory: true
+Duration: 6:14
+Artists:
+- churgney gurgney
+URLs:
+- https://www.youtube.com/watch?v=jwhSUmN5zTk
+- https://soundcloud.com/gurgney/silly-billy
+---
 Track: Simian Segue
 # Reference:
 #   https://vgmdb.net/album/429

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -8963,6 +8963,7 @@ Directory: silly-billy-churgney-gurgney
 Always Reference By Directory: true
 Duration: 6:14
 Artists:
+- Friday Night Funkin
 - churgney gurgney
 URLs:
 - https://www.youtube.com/watch?v=jwhSUmN5zTk

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -8986,8 +8986,6 @@ Lyrics: |-
     My way
 
     My way
-    
-    My way
 ---
 Track: Simian Segue
 # Reference:

--- a/artists.yaml
+++ b/artists.yaml
@@ -2491,6 +2491,11 @@ Aliases:
 URLs:
 - https://chuchumi.tumblr.com/
 ---
+Artist: churgney gurgney
+URLs:
+- https://www.youtube.com/@churgneygurgney9895
+- https://soundcloud.com/gurgney
+---
 Artist: Churro Lord
 URLs:
 - https://churro-lord.tumblr.com/

--- a/artists.yaml
+++ b/artists.yaml
@@ -6058,13 +6058,13 @@ Artist: Irkens
 ---
 Artist: irl-porrim-maryam
 ---
+Artist: Iron Maiden
+---
 Artist: Ironik
 Aliases:
 - Ironik0422
 URLs:
 - https://www.youtube.com/@Ironik0422
----
-Artist: Iron Maiden
 ---
 Artist: Ironside
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -2491,9 +2491,10 @@ Aliases:
 URLs:
 - https://chuchumi.tumblr.com/
 ---
-Artist: churgney gurgney
+Artist: Churgney Gurgney
 URLs:
 - https://www.youtube.com/@churgneygurgney9895
+- https://open.spotify.com/artist/3LAEZsCc4CdQdyUUrdy0WK
 - https://soundcloud.com/gurgney
 ---
 Artist: Churro Lord
@@ -3909,6 +3910,10 @@ Artist: DrWorm
 Artist: DSNAKE
 URLs:
 - https://www.instagram.com/disorderly.snake/
+---
+Artist: Duccly
+URLs:
+- https://www.youtube.com/@duccly
 ---
 Artist: Duck Hunt
 ---
@@ -5476,6 +5481,12 @@ Artist: Haruko Komiya
 ---
 Artist: Haruko Yano
 ---
+Artist: HassenXBlu
+Aliases:
+- HassenXMP4
+URLs:
+- https://www.youtube.com/@HassenXMP4
+---
 Artist: Hatsune Miku
 ---
 Artist: Haunter
@@ -5776,6 +5787,10 @@ URLs:
 - https://twitter.com/hone_skl
 - https://honesk1.tumblr.com/
 ---
+Artist: honkish
+URLs:
+- https://www.youtube.com/@honkish
+---
 Artist: Honor DeVabb
 ---
 Artist: horizon
@@ -6042,6 +6057,12 @@ Artist: iridescentSkeptic
 Artist: Irkens
 ---
 Artist: irl-porrim-maryam
+---
+Artist: Ironik
+Aliases:
+- Ironik0422
+URLs:
+- https://www.youtube.com/@Ironik0422
 ---
 Artist: Iron Maiden
 ---
@@ -12525,6 +12546,12 @@ URLs:
 Dead URLs:
 - https://www.deviantart.com/wiresthatconnect2us
 # deviantart URL still exists, inactive, points to her/their twitter handle
+---
+Artist: Spacenautica
+Aliases:
+- spacenautics
+URLs:
+- https://www.youtube.com/@spacenautics
 ---
 Artist: SpaceWaifu
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -2491,7 +2491,7 @@ Aliases:
 URLs:
 - https://chuchumi.tumblr.com/
 ---
-Artist: Churgney Gurgney
+Artist: churgney gurgney
 URLs:
 - https://www.youtube.com/@churgneygurgney9895
 - https://open.spotify.com/artist/3LAEZsCc4CdQdyUUrdy0WK

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -38,7 +38,7 @@ Content: |-
     - fixed "+edits" tooltips in wallpaper and banner credits sometimes getting cut off
     <h3>additions</h3>
     <!-- art tags additions -->
-    - added real-world people tags: [[tag:silent-j]], [[tag:shaggy-2-dope]] (thanks, Lilith!)
+    - added real-world people tags: [[tag:violent-j]], [[tag:shaggy-2-dope]] (thanks, Lilith!)
     <h3>data changes</h3>
     - updated SiIvaGunner wiki link in description for [[artist:siivagunner]] (thanks, literallyn01imp0rtant!)
     <h3>data fixes</h3>
@@ -47,7 +47,7 @@ Content: |-
     <!-- merged artists -->
     - fixed [[artist:the-voicing-guy]] having some credits under another name (thanks, Lilith!)
     <!-- art tag fixes -->
-    - added [[tag:silent-j]] and [[tag:shaggy-2-dope]] to [[track:coulrocide]] (thanks, Lilith!)
+    - added [[tag:violent-j]] and [[tag:shaggy-2-dope]] to [[track:coulrocide]] (thanks, Lilith!)
     <!-- lyric fixes -->
     - fixed lyrics in [[track:coulrocide]] (was missing subtle "Imma fucking kill you!" at the end of final "(Hokus pokus, joker's ride) (Hokus pokus, joker's ride)" section (thanks, Jebb, Lilith!)
     <!-- general data fixes -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -43,7 +43,7 @@ Content: |-
     - updated SiIvaGunner wiki link in description for [[artist:siivagunner]] (thanks, literallyn01imp0rtant!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
-    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] instead of [[track:silly-billy-churgney-gurgney]] (thanks, Jebb, Lilith!)
+    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] instead of [[track:silly-billy-hit-single]] (thanks, Jebb, Lilith!)
     <!-- merged artists -->
     - fixed [[artist:the-voicing-guy]] having some credits under another name (thanks, Lilith!)
     <!-- art tag fixes -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -43,7 +43,7 @@ Content: |-
     - updated SiIvaGunner wiki link in description for [[artist:siivagunner]] (thanks, literallyn01imp0rtant!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
-    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] instead of [[track:silly-billy-hit-single]] (thanks, Jebb, Lilith!)
+    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] instead of [[track:silly-billy-hit-single]] (thanks, Jebb, Bagel, Lilith!)
     <!-- merged artists -->
     - fixed [[artist:the-voicing-guy]] having some credits under another name (thanks, Lilith!)
     <!-- art tag fixes -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -43,7 +43,7 @@ Content: |-
     - updated SiIvaGunner wiki link in description for [[artist:siivagunner]] (thanks, literallyn01imp0rtant!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
-    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] instead of [[track:silly-billy-hit-single]] (thanks, Jebb, Bagel, Lilith!)
+    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] ([[album:riddle-of-dixy-path-of-mind-ost]]) instead of [[track:silly-billy-hit-single]] (Hit Single; thanks, Jebb, Bagel, Lilith!)
     <!-- merged artists -->
     - fixed [[artist:the-voicing-guy]] having some credits under another name (thanks, Lilith!)
     <!-- art tag fixes -->
@@ -53,7 +53,7 @@ Content: |-
     <!-- general data fixes -->
     - fixed [[album:sns-act-3-sampler]] appearing before [[album:fondly-regard-illustration]] in chronology links (thanks, Jebb!)
     <!-- commentary fixes -->
-    - tweaked formatting of commentary for [[track:coulrocide]] (thanks, Lilith!)
+    - tweaked formatting of commentary for [[track:coulrocide]] (thanks, Lilith, Tangle!)
 
     <h2 id="13-apr-2025" class="major-release"><html:a href="#13-apr-2025">[[date:13 April 2025]] - The Apple Wizard of Mount Fuji</a></h2>
     <h3>site changes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -36,11 +36,22 @@ Content: |-
     <h3>bug fixes</h3>
     - fixed [[listing:tracks/with-lyrics|"Tracks - with Lyrics"]] listing including *every* track
     - fixed "+edits" tooltips in wallpaper and banner credits sometimes getting cut off
+    <h3>additions</h3>
+    <!-- art tags additions -->
+    - added real-world people tags: [[tag:silent-j]], [[tag:shaggy-2-dope]] (thanks, Lilith!)
     <h3>data changes</h3>
     - updated SiIvaGunner wiki link in description for [[artist:siivagunner]] (thanks, literallyn01imp0rtant!)
     <h3>data fixes</h3>
-    - fixed [[album:sns-act-3-sampler]] appearing before [[album:fondly-regard-illustration]] in chronology links (thanks, Jebb!)
+    <!-- reference fixes -->
+    - fixed [[track:coulrocide]] referencing [[track:silly-billy]] instead of [[track:silly-billy-churgney-gurgney]] (thanks, Jebb, Lilith!)
+    <!-- merged artists -->
     - fixed [[artist:the-voicing-guy]] having some credits under another name (thanks, Lilith!)
+    <!-- art tag fixes -->
+    - added [[tag:silent-j]] and [[tag:shaggy-2-dope]] to [[track:coulrocide]] (thanks, Lilith!)
+    <!-- lyric fixes -->
+    - fixed lyrics in [[track:coulrocide]] (was missing subtle "Imma fucking kill you!" at the end of final "(Hokus pokus, joker's ride) (Hokus pokus, joker's ride)" section (thanks, Jebb, Lilith!)
+    <!-- general data fixes -->
+    - fixed [[album:sns-act-3-sampler]] appearing before [[album:fondly-regard-illustration]] in chronology links (thanks, Jebb!)
 
     <h2 id="13-apr-2025" class="major-release"><html:a href="#13-apr-2025">[[date:13 April 2025]] - The Apple Wizard of Mount Fuji</a></h2>
     <h3>site changes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -49,9 +49,11 @@ Content: |-
     <!-- art tag fixes -->
     - added [[tag:violent-j]] and [[tag:shaggy-2-dope]] to [[track:coulrocide]] (thanks, Lilith!)
     <!-- lyric fixes -->
-    - fixed lyrics in [[track:coulrocide]] (was missing subtle "Imma fucking kill you!" at the end of final "(Hokus pokus, joker's ride) (Hokus pokus, joker's ride)" section (thanks, Jebb, Lilith!)
+    - fixed lyrics in [[track:coulrocide]] (was missing subtle "Imma fucking kill you!" at the end of final "(Hokus pokus, joker's ride) (Hokus pokus, joker's ride)" section; thanks, Jebb, Lilith!)
     <!-- general data fixes -->
     - fixed [[album:sns-act-3-sampler]] appearing before [[album:fondly-regard-illustration]] in chronology links (thanks, Jebb!)
+    <!-- commentary fixes -->
+    - tweaked formatting of commentary for [[track:coulrocide]] (thanks, Lilith!)
 
     <h2 id="13-apr-2025" class="major-release"><html:a href="#13-apr-2025">[[date:13 April 2025]] - The Apple Wizard of Mount Fuji</a></h2>
     <h3>site changes</h3>

--- a/tags.yaml
+++ b/tags.yaml
@@ -2517,8 +2517,10 @@ Direct Descendant Tags:
 - Rowyn Berlan
 - Ross Federman
 - Scott Stutzman
+- Shaggy 2 Dope
 - Tavia Morra
 - Toby Fox
+- Violent J
 - Weird Al
 - Zubin Sedghi
 ---
@@ -5061,6 +5063,11 @@ Color: '#e5e5e5'
 Extra Reading URLs:
 - https://wiki.hiddeninthesand.com/Ross_Federman
 ---
+Tag: Shaggy 2 Dope
+Color: '#e5e5e5'
+Extra Reading URLs:
+- https://en.wikipedia.org/wiki/Shaggy_2_Dope
+---
 Tag: Scott Stutzman
 Color: '#32c7fe'
 ---
@@ -5071,6 +5078,11 @@ Tag: Toby Fox
 Color: '#32c7fe'
 Extra Reading URLs:
 - https://en.wikipedia.org/wiki/Toby_Fox
+---
+Tag: Violent J
+Color: '#e5e5e5'
+Extra Reading URLs:
+- https://en.wikipedia.org/wiki/Violent_J 
 ---
 Tag: Weird Al
 Color: '#e5e5e5'


### PR DESCRIPTION
Thanks Jebb!
Changes Silly Billy (not Churgney Gurgney) to Silly Billy (Churgney Gurgney) in Coulrocide's referenced tracks, as well as adding missing "Imma fucking kill you!" at the end of final "(Hokus pokus, joker's ride) (Hokus pokus, joker's ride)" section

Also does the following other stuff:
- tweaked formatting of commentary so that Dirk's text was in the code style and not span style
- adds Violent J and Shaggy 2 Dope to real world people tags, and those tags are also added to Coulrocide as well.