### PR TITLE
Addition of Double Midnight to Earthsea Borealis reference list + removal of Strider Mixtape Bandcamp URLs

### DIFF
--- a/album/beforusbound.yaml
+++ b/album/beforusbound.yaml
@@ -268,7 +268,7 @@ URLs:
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
-    So for this song i wanted to make a synthwave track since i had just released [a synthwave EP](https://potatoboss.bandcamp.com/album/the-divide-ep), but i figured it didnt fit Aranea all that well.
+    So for this song i wanted to make a synthwave track since i had just released [a synthwave EP](https://potatoboss.bandcamp.com/album/the-divide), but i figured it didnt fit Aranea all that well.
 
     So one day when i was playing Super Mario Galaxy 2 i reached the Cosmic Cove Galaxy and when i heard [the music](https://www.youtube.com/watch?v=zcV7RptHqro) i instantly threw my wiimote into the TV and started editing this song. It turned out exactly as i wanted it and it ended up being synthwave mario galaxy music.
 ---

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -675,11 +675,11 @@ Commentary: |-
 
     The full-size artwork reveals it's the eye of the horrorterror which casts that green underglow onto Rose. Cool!
 Referencing Sources: |-
-    <i>Grace Medley:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/779895315750715422/1362590968557207553), 4/17/2025)
+    <i>Grace Medley:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/779895315750715422/1362590968557207553), excerpt, 4/17/2025)
 
     ok first thing i wanted to mention: i noticed that the wiki doesnt list earthsea borealis as referencing [[track:double-midnight|double midnight]] even though [the nsnd did used to say that.](https://homestuck.net/music/references.html) heres proof that it does i pitch shifted earthsea borealis to be in the same key as the double midnight snippet from [[track:additional-mayhem-universe-a|additional mayhem]]
 
-    <audio src="media/misc/double-midnight-in-earthsea-borealis.wav" inline></audio>
+    <audio src="media/misc/Double Midnight in Earthsea Borealis.wav"></audio>
 ---
 Track: Warhammer of Zillyhoo
 Artists:

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -668,11 +668,18 @@ Track Artwork:
     [MSPA Booru](https://mspabooru.com/index.php?page=post&s=view&id=30318),
     [mspaforums](http://www.mspaforums.com/showthread.php?31993-MSPA-Fan-Art-20-Never-Stop-Drawing&p=4124366&viewfull=1#post4124366) (dead link)
 Referenced Tracks:
+- Double Midnight
 - Endless Climb
 Commentary: |-
     <i>Quasar Nebula:</i> (wiki editor, 4/22/2025)
 
     The full-size artwork reveals it's the eye of the horrorterror which casts that green underglow onto Rose. Cool!
+Referencing Sources: |-
+    <i>Grace Medley:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/779895315750715422/1362590968557207553), 4/17/2025)
+
+    ok first thing i wanted to mention: i noticed that the wiki doesnt list earthsea borealis as referencing [[track:double-midnight|double midnight]] even though [the nsnd did used to say that.](https://homestuck.net/music/references.html) heres proof that it does i pitch shifted earthsea borealis to be in the same key as the double midnight snippet from [[track:additional-mayhem-universe-a|additional mayhem]]
+
+    <audio src="media/misc/double-midnight-in-earthsea-borealis.wav" inline></audio>
 ---
 Track: Warhammer of Zillyhoo
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -3022,7 +3022,6 @@ Artists:
 - Pascal van den Bos
 Duration: 4:18
 URLs:
-- https://potatoboss.bandcamp.com/track/ascending-strife
 - https://www.youtube.com/watch?v=fQkT-28JUHI
 Referenced Tracks:
 - I Warned You About the Elevator Bro
@@ -3054,15 +3053,11 @@ Always Reference By Directory: true
 Artists:
 - Rowyn Berlan
 Duration: 3:46
-URLs:
-- https://potatoboss.bandcamp.com/track/avarice
 ---
 Track: Candlelit Contemplation (Beta)
 Artists:
 - Rowyn Berlan
 Duration: 3:25
-URLs:
-- https://potatoboss.bandcamp.com/track/candlelit-contemplation-beta
 Referenced Tracks:
 - Upward Movement (Dave Owns)
 - Candles and Clockwork
@@ -3073,8 +3068,6 @@ Always Reference By Directory: true
 Artists:
 - Rowyn Berlan
 Duration: 1:42
-URLs:
-- https://potatoboss.bandcamp.com/track/deception
 Commentary: |-
     <i>Pascal van den Bos:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/749067042250031214/1234910765157453875), excerpt)
 
@@ -3124,15 +3117,11 @@ Always Reference By Directory: true
 Artists:
 - Pascal van den Bos
 Duration: 0:45
-URLs:
-- https://potatoboss.bandcamp.com/track/proletariat
 ---
 Track: Spritely Gardener (Beta)
 Artists:
 - Rainy
 Duration: 0:46
-URLs:
-- https://potatoboss.bandcamp.com/track/spritely-gardener-beta
 Referenced Tracks:
 - Jadesprite
 ---
@@ -3149,8 +3138,6 @@ Always Reference By Directory: true
 Artists:
 - Rowyn Berlan
 Duration: 3:40
-URLs:
-- https://potatoboss.bandcamp.com/track/vexation
 ---
 Track: Violet and Proud
 Artists:
@@ -3163,8 +3150,6 @@ Track: WilyEsp Remix Attempt WIP
 Artists:
 - Rainy
 Duration: 1:18
-URLs:
-- https://potatoboss.bandcamp.com/track/wilyesp-remix-attempt-wip
 Referenced Tracks:
 - Wily Espionage
 ---

--- a/album/stlap2.yaml
+++ b/album/stlap2.yaml
@@ -1115,7 +1115,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Rainy:</i> (composer, booklet commentary)
 
-    I know there has already been [[track:dungeness-showdown|a remix of showdown on a PMT album before]] (sorry Calikid), but I really wanted to do a hard rock version of the song so oh well. Funnily enough it was that remix on AHaM that inspired me to write Threxecute, so i guess it’s fine???. This song is also the most controversial song I have ever written. I will admit that part of it was my own stubbornness, but I will also admit that I didn’t think that UGK2 would sound good with this song. If you want to hear that version of the song, [check out the soundtest.](https://potatoboss.bandcamp.com/track/cool-threxecute)
+    I know there has already been [[track:dungeness-showdown|a remix of showdown on a PMT album before]] (sorry Calikid), but I really wanted to do a hard rock version of the song so oh well. Funnily enough it was that remix on AHaM that inspired me to write Threxecute, so i guess it’s fine???. This song is also the most controversial song I have ever written. I will admit that part of it was my own stubbornness, but I will also admit that I didn’t think that UGK2 would sound good with this song. If you want to hear that version of the song, check out the soundtest.
 ---
 Track: Windwielder
 Additional Names:

--- a/album/the-strider-mixtape.yaml
+++ b/album/the-strider-mixtape.yaml
@@ -5,7 +5,6 @@ Artists:
 Date: July 19, 2019
 Date Added: June 12, 2024
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/album/the-strider-mixtape
 - https://www.youtube.com/playlist?list=PLtcgklmZsk9Ac7DKm_Z36R64b8u1xW2q5
 Cover Artists:
 - Phos
@@ -24,11 +23,11 @@ Groups:
 - The Paradox Music Team
 - Fandom
 Commentary: |-
-    <i>The Paradox Music Team:</i> ([Bandcamp about blurb](https://pascalpotatovandenbos.bandcamp.com/album/the-strider-mixtape))
+    <i>The Paradox Music Team:</i> ([Bandcamp about blurb](https://web.archive.org/web/20241229120827/https://pascalpotatovandenbos.bandcamp.com/album/the-strider-mixtape))
 
     From sweet chill Lo-Fi beats to kickin’ rad 16-Bit CARNAGE, The Strider Mixtape has it all! 14 tracks based on all your favorite Striders, a PDF with commentary from [[artist:pascal-van-den-bos]] AND an extra bonus track at the end!
 
-    <i>The Paradox Music Team:</i> ([Bandcamp credits blurb](https://pascalpotatovandenbos.bandcamp.com/album/the-strider-mixtape))
+    <i>The Paradox Music Team:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20241229120827/https://pascalpotatovandenbos.bandcamp.com/album/the-strider-mixtape))
 
     Music by: [[artist:pascal-van-den-bos]]
 
@@ -45,7 +44,6 @@ Section: Main album
 Track: New Ironic Depths
 Duration: 3:52
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/new-ironic-depths
 - https://www.youtube.com/watch?v=KuCsCoOFzNU
 Cover Artists:
 - Phos
@@ -63,7 +61,6 @@ Commentary: |-
 Track: Blankest Stare
 Duration: 3:06
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/blankest-stare
 - https://www.youtube.com/watch?v=ntC2C2cp2yc
 Cover Artists:
 - Phos
@@ -78,7 +75,6 @@ Commentary: |-
 Track: The Remains of the Rambunctious Crow
 Duration: 2:01
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/the-remains-of-the-rambunctious-crow
 - https://www.youtube.com/watch?v=4gmwjz8Yrk8
 Cover Artists:
 - Phos
@@ -101,7 +97,6 @@ Contributors:
 #unsure about if being the one who still had the project file counts as contributing, but it probably does
 Duration: 1:55
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/mr-orange-creamsicles
 - https://www.youtube.com/watch?v=rl7g7apoDqY
 Cover Artists:
 - Phos
@@ -121,7 +116,6 @@ Commentary: |-
 Track: Heart Beat
 Duration: 2:49
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/heart-beat
 - https://www.youtube.com/watch?v=Wj_gN138rd4
 Cover Artists:
 - Phos
@@ -158,7 +152,6 @@ Contributors:
 - Funk McLovin (trumpets)
 Duration: 2:16
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/brobot-scrimmage
 - https://www.youtube.com/watch?v=SlBic0tJpok
 Cover Artists:
 - Phos
@@ -179,7 +172,6 @@ Commentary: |-
 Track: Good Morning, Dirk
 Duration: 2:09
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/good-morning-dirk
 - https://www.youtube.com/watch?v=Tozc5YQFpW4
 Cover Artists:
 - Phos
@@ -196,7 +188,6 @@ Track: Shattered
 Suffix Directory: true
 Duration: 2:03
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/shattered
 - https://www.youtube.com/watch?v=cLJnHK83mGQ
 Cover Artists:
 - Phos
@@ -223,7 +214,6 @@ Review Points:
 Track: Waveform Showdown!
 Duration: 1:26
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/waveform-showdown
 - https://www.youtube.com/watch?v=lFTxVrRPAes
 Cover Artists:
 - Phos
@@ -240,7 +230,6 @@ Commentary: |-
 Track: Jittery Optimist
 Duration: 2:13
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/jittery-optimist
 - https://www.youtube.com/watch?v=Iob2jQgiY4I
 Cover Artists:
 - Phos
@@ -258,7 +247,6 @@ Commentary: |-
 Track: To Die A Legend
 Duration: 3:08
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/to-die-a-legend
 - https://www.youtube.com/watch?v=8963O41BxwI
 Cover Artists:
 - Phos
@@ -279,7 +267,6 @@ Commentary: |-
 Track: Infinity Beatdown
 Duration: 3:05
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/infinity-beatdown
 - https://www.youtube.com/watch?v=4P_bhfQXBUk
 Cover Artists:
 - Phos
@@ -307,7 +294,6 @@ Commentary: |-
 Track: Gamebro (1989 Hip-Hop Mix)
 Duration: 2:18
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/gamebro-1989-hip-hop-mix
 - https://www.youtube.com/watch?v=m6nUcvRAqV0
 Cover Artists:
 - Phos
@@ -376,7 +362,6 @@ Track: Rematch
 Suffix Directory: true
 Duration: 2:15
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/rematch
 - https://www.youtube.com/watch?v=V3MhvkhUXz8
 Cover Artists:
 - Phos
@@ -399,7 +384,6 @@ Section: Bonus track
 Track: Of Striders and UAHHGs
 Duration: 1:04
 URLs:
-- https://pascalpotatovandenbos.bandcamp.com/track/of-striders-and-uahhgs-bonus
 - https://www.youtube.com/watch?v=eOrX4Sntaxo
 Cover Artists:
 - Phos

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -107,10 +107,13 @@ Content: |-
     - touched up commentary in [[album:7th-gate-project]]
     <!-- tracks newly marked as a secondary release -->
     - marked tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] as secondary releases, with main releases now on [[album:deltarune-soundtrack]] (thanks, ruby!)
+    <!-- general removals -->
+    - removed Bandcamp listening links for [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
+    - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)
     - fixed [[track:a-common-occurrance-every-night-to-be-exact]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:bowstutzlogic]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -168,7 +168,7 @@ Content: |-
     - fixed some sneaky capitalization errors where the name of the track on the wiki was used, instead of the capitalization written in source commentary, in [[track:dance-stab-dance]], [[track:a-life-worth-living]], and [[track:cinders-oceanfalls]] (thanks, Lan!)
     - fixed broken image embed in [[track:aaaaaaaaaaaaa-post-canon-version]] (for "In the Court of the Crimson King")
     - made a handful of formatting or transcription tweaks across YouTube video commentary for [[album:of-troles-and-chiptumes]] (thanks, cookiefonster!)
-    - fixed Bandcamp link in booklet commentary for [[track:dwelling-among-the-dream-bubbles]] (was to a functioning "the-divide-ep" URL; thanks, Lilith!)
+    - fixed Bandcamp link in booklet commentary for [[track:dwelling-among-the-dream-bubbles]] (was to a functioning, but outdated, "the-divide-ep" URL; thanks, Lilith!)
     <!-- general data fixes -->
     - fixed duration of various tracks to align with Nintendo Music: (thanks, ruby!)
         - fixed duration of [[track:death-mountain-theme]] (was 0:59, now 1:00)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -108,6 +108,7 @@ Content: |-
     <!-- tracks newly marked as a secondary release -->
     - marked tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] as secondary releases, with main releases now on [[album:deltarune-soundtrack]] (thanks, ruby!)
     <!-- general removals -->
+    - removed dead link in [[track:threxecute]] commentary (thanks, Lilith!)
     - removed Bandcamp listening links for [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -109,7 +109,7 @@ Content: |-
     - marked tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] as secondary releases, with main releases now on [[album:deltarune-soundtrack]] (thanks, ruby!)
     <!-- general removals -->
     - removed dead link in commentary for [[track:threxecute]] (thanks, Lilith!)
-    - removed Bandcamp listening links for [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
+    - removed Bandcamp listening links across [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -109,6 +109,7 @@ Content: |-
     - marked tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] as secondary releases, with main releases now on [[album:deltarune-soundtrack]] (thanks, ruby!)
     <!-- general removals -->
     - removed Bandcamp listening links for [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
+    - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -108,7 +108,7 @@ Content: |-
     <!-- tracks newly marked as a secondary release -->
     - marked tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] as secondary releases, with main releases now on [[album:deltarune-soundtrack]] (thanks, ruby!)
     <!-- general removals -->
-    - removed dead link in [[track:threxecute]] commentary (thanks, Lilith!)
+    - removed dead link in commentary for [[track:threxecute]] (thanks, Lilith!)
     - removed Bandcamp listening links for [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
@@ -168,6 +168,7 @@ Content: |-
     - fixed some sneaky capitalization errors where the name of the track on the wiki was used, instead of the capitalization written in source commentary, in [[track:dance-stab-dance]], [[track:a-life-worth-living]], and [[track:cinders-oceanfalls]] (thanks, Lan!)
     - fixed broken image embed in [[track:aaaaaaaaaaaaa-post-canon-version]] (for "In the Court of the Crimson King")
     - made a handful of formatting or transcription tweaks across YouTube video commentary for [[album:of-troles-and-chiptumes]] (thanks, cookiefonster!)
+    - fixed Bandcamp link in booklet commentary for [[track:dwelling-among-the-dream-bubbles]] (was to a functioning "the-divide-ep" URL; thanks, Lilith!)
     <!-- general data fixes -->
     - fixed duration of various tracks to align with Nintendo Music: (thanks, ruby!)
         - fixed duration of [[track:death-mountain-theme]] (was 0:59, now 1:00)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -109,7 +109,7 @@ Content: |-
     - marked tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] as secondary releases, with main releases now on [[album:deltarune-soundtrack]] (thanks, ruby!)
     <!-- general removals -->
     - removed Bandcamp listening links for [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
-    - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
+    - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)


### PR DESCRIPTION
Adds Double Midnight back to Earthsea Borealis's references, placing it before Endless Climb. Thanks Grace!

- removes The Strider Mixtape's bandcamp urls (hast been deleted) Thanks, Geese!
- removes deleted bandcamp URLs for Ascending Strife, Avarice, Candlelit Contemplation (Beta), Deception, Proletariat, Spritely Gardener (Beta), Vexation, and WilyEsp Remix WIP.

- removed dead link to Cool Threxecute in Threxecute's commentary
- removed ``-ep`` from ``the-divide`` in Dwelling Among the Dream Bubbles commentary