### PR TITLE
Tracks addition: Chained (Official Soundtrack) bonus tracks

### DIFF
--- a/album/chained-official-soundtrack.yaml
+++ b/album/chained-official-soundtrack.yaml
@@ -16,6 +16,8 @@ Commentary: |-
     <i>Gryotharian:</i> ([Bandcamp about blurb](https://gryotharian.bandcamp.com/album/chained-official-soundtrack))
     Soundtrack for the chain novel webcomic "[Chained](https://mspfa.com/?s=53466&p=1)".
 ---
+Section: Main album
+---
 Track: Chained (Trailer Music)
 Duration: '0:49'
 URLs:
@@ -207,3 +209,16 @@ URLs:
 Commentary: |-
     <i>Gryotharian:</i> ([Bandcamp about blurb, excerpt](https://gryotharian.bandcamp.com/track/5-headed-ouroboros))
     The exciting conclusion you've all been waiting for and have already heard!
+---
+Section: Bonus tracks
+---
+Track: Freeflight (Canon Edit)
+Duration: 0:47
+Referenced Tracks:
+- Freeflight
+---
+Track: Revelawful
+Duration: 0:41
+---
+Track: Bad Disgusting Torturous Sludge Song for [REDACTED]
+Duration: 2:17

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -85,6 +85,7 @@ Content: |-
     - added [[flash:combustion]] and [[flash:body-mind-soul]] flashes from [[group:desynced]] (thanks, Jebb!)
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
     <!-- track additions -->
+    - added missing bonus tracks to [[album:chained-official-soundtrack]]! (thanks, Lilith!)
     - added [[track:vitality-home]] to [[album:home]]! (thanks, Lan, Lilith!)
     - added [[track:ikari]] and [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!)
     <!-- group additions -->


### PR DESCRIPTION
Adds the hidden bonus tracks from Chained (Official Soundtrack)'s download to Chained (Official Soundtrack):
- Freeflight (Canon Edit)
- Revelawful
- Bad Disgusting Torturous Sludge Song for [REDACTED]

The only concrete track reference so far is Freeflight in (obv) Freeflight (Canon Edit), but I haven't been able to hear any track references, if any, in Revelawful, or in Bad Disgusting Torturous Sludge Song for [REDACTED].