### PR TITLE
PLASMIC BLAQUACIOUSNESS

### DIFF
--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -623,7 +623,7 @@ URLs:
 - https://homestuck.bandcamp.com/track/black-3
 - https://youtu.be/5NACWZBDtN8
 Referenced Tracks:
-- Plasmic Blaquaciousness
+- Plasmatic Blaquaciousness
 - track:im-a-member-of-the-midnight-crew
 Sampled Tracks:
 - track:im-a-member-of-the-midnight-crew

--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -623,7 +623,7 @@ URLs:
 - https://homestuck.bandcamp.com/track/black-3
 - https://youtu.be/5NACWZBDtN8
 Referenced Tracks:
-- track:liquid-negrocity
+- Plasmic Blaquaciousness
 - track:im-a-member-of-the-midnight-crew
 Sampled Tracks:
 - track:im-a-member-of-the-midnight-crew

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -216,6 +216,8 @@ Duration: 2:10
 URLs:
 - https://homestuck.bandcamp.com/track/liquid-negrocity-2
 - https://youtu.be/r8sBtl3WYZo
+Referenced Tracks:
+- track:liquid-negrocity-original
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
   Files:
@@ -230,20 +232,6 @@ MIDI Project Files:
 - Title: MIDI by MrCheeze
   Files:
   - 'Liquid Negrocity - MrCheeze.mid'
-Commentary: |-
-    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), commentary on early version, excerpt, 6/29/2010)
-
-    This is the first time I ever tried Liquid Negrocity.
-    Ah, this is like, it was way slow, there wasn't anything but a crappy piano.
-    And it doesn't get any faster than this, it just goes like this.
-
-    Oh my god. It's so slow.
-
-    It goes wicked slow.
-    
-    And so I was like, after I made this, I made Liquid Negrocity, and then later I was like, I should remake this, this is gonna be, [[Plasmic Blaquaciousness]], so I made it.
-
-    *(Continued in [[track:plasmic-blaquaciousness]])*
 ---
 Track: Hollow Suit
 Artists:

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -220,7 +220,7 @@ Referenced Tracks:
 - track:liquid-negrocity-original
 Commentary: |-
     <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), adapted to text, 6/29/2010)
-    
+
     *(Continued from [[track:plasmatic-blaquaciousness]])*
 
     "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|Bill Bolin's song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like... well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put a, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something that would fit that page perfectly.

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -221,7 +221,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
     
-    *(Continued from [[track:plasmic-blaquaciousness]])*
+    *(Continued from [[track:plasmatic-blaquaciousness]])*
 
     "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
 

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -241,7 +241,7 @@ Commentary: |-
 
     It goes wicked slow.
     
-    And so I was like, after I made this, I made [[Liquid Negrocity]], and then later I was like, I should remake this, this is gonna be, [[Plasmic Blaquaciousness]], so I made it.
+    And so I was like, after I made this, I made Liquid Negrocity, and then later I was like, I should remake this, this is gonna be, [[Plasmic Blaquaciousness]], so I made it.
 
     *(Continued in [[track:plasmic-blaquaciousness]])*
 ---

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -223,7 +223,7 @@ Commentary: |-
     
     *(Continued from [[track:plasmic-blaquaciousness]])*
 
-    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
+    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity but, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
 
 Sheet Music Files:
 - Title: Sheet music by Gamehunter

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -240,6 +240,8 @@ Commentary: |-
     Oh my god. It's so slow.
 
     It goes wicked slow.
+    
+    And so I was like, after I made this, I made [[Liquid Negrocity]], and then later I was like, I should remake this, this is gonna be, [[Plasmic Blaquaciousness]], so I made it.
 
     *(Continued in [[track:plasmic-blaquaciousness]])*
 ---

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -230,6 +230,18 @@ MIDI Project Files:
 - Title: MIDI by MrCheeze
   Files:
   - 'Liquid Negrocity - MrCheeze.mid'
+Commentary: |-
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+
+    This is the first time I ever tried Liquid Negrocity.
+    Ah, this is like, it was way slow, there wasn't anything but a crappy piano.
+    And it doesn't get any faster than this, it just goes like this.
+
+    Oh my god. It's so slow.
+
+    It goes wicked slow.
+
+    *(Continued in [[track:plasmic-blaquaciousness]])*
 ---
 Track: Hollow Suit
 Artists:

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -218,6 +218,13 @@ URLs:
 - https://youtu.be/r8sBtl3WYZo
 Referenced Tracks:
 - track:liquid-negrocity-original
+Commentary: |-
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+    
+    *(Continued from [[track:plasmic-blaquaciousness]])*
+
+    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
+
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
   Files:

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -231,7 +231,7 @@ MIDI Project Files:
   Files:
   - 'Liquid Negrocity - MrCheeze.mid'
 Commentary: |-
-    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), commentary on early version, excerpt, 6/29/2010)
 
     This is the first time I ever tried Liquid Negrocity.
     Ah, this is like, it was way slow, there wasn't anything but a crappy piano.

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -219,12 +219,11 @@ URLs:
 Referenced Tracks:
 - track:liquid-negrocity-original
 Commentary: |-
-    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), adapted to text, 6/29/2010)
     
     *(Continued from [[track:plasmatic-blaquaciousness]])*
 
-    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
-
+    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|Bill Bolin's song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like... well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put a, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something that would fit that page perfectly.
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
   Files:

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -223,7 +223,7 @@ Commentary: |-
     
     *(Continued from [[track:plasmic-blaquaciousness]])*
 
-    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity but, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
+    "I should do a longer version." I was thinking of, I actually volunteered, you know [[flash:833|that Mark J. Hadley page]], where it has, uh, [[Dead Shuffle]] where [[Nightlife (Extended)|a Bill Bolin song used to be?]] I volunteered to do uh, a long version of Liquid Negrocity, but uhm, uh, Andrew was like, well, Andrew actually agreed to that, but the thing is, I was too busy doing [[album:homestuck-vol-5|album 5 stuff]], so he just put up, Mark J. Hadley song, and obviously they're not gonna change it now, that'd be weird. But I still want to make something (unintelligible) for that page perfectly.
 
 Sheet Music Files:
 - Title: Sheet music by Gamehunter

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1275,6 +1275,20 @@ Lyrics: |-
     I'm a member of the Midnight Crew!
     I'm a- I'm a- I'm a member of the-
     I'm a member of the Midnight Crew!
+Commentary: |-
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+
+    *(Continued from [[track:liquid-negrocity)*
+
+    And so I was like, after I made this, I made [[Liquid Negrocity]], and then later I was like, I should remake this, this is gonna be, Plasmic Blaquaciousness, so I made it.
+
+    And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
+
+    But yeah, that's Plasmic Blaquaciousness.
+    But yeah, that's slightly more dense and then I just- I made [[Black]], which is the best.
+
+    Which kicks ass. And it's probably overall, the best song I've ever made.
+    I mean, [[Descend]] is great, but overall, Black, it's the better package.
 ---
 Track: Post-Apocalyptic Fedora
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1305,7 +1305,7 @@ Commentary: |-
 
     And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
 
-    I- Uh, I think I've done this evolution before.
+    I- I think I've done this evolution before.
 
     But yeah, that's Plasmic Blaquaciousness.
     But yeah, that's slightly more dense and then I just- I made [[Black]], which is the best.

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1278,7 +1278,7 @@ Lyrics: |-
 Commentary: |-
     <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
 
-    *(Continued from [[track:liquid-negrocity)*
+    *(Continued from [[track:liquid-negrocity]])*
 
     And so I was like, after I made this, I made [[Liquid Negrocity]], and then later I was like, I should remake this, this is gonna be, Plasmic Blaquaciousness, so I made it.
 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1305,7 +1305,7 @@ Commentary: |-
 
     And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
 
-    I- I think I've done this evolution before.
+    I- Uh, I think I've done this evolution before.
 
     But yeah, that's Plasmic Blaquaciousness.
     But yeah, that's slightly more dense and then I just- I made [[Black]], which is the best.

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1280,8 +1280,6 @@ Commentary: |-
 
     *(Continued from [[track:liquid-negrocity]])*
 
-    And so I was like, after I made this, I made [[Liquid Negrocity]], and then later I was like, I should remake this, this is gonna be, Plasmic Blaquaciousness, so I made it.
-
     And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
 
     But yeah, that's Plasmic Blaquaciousness.

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1006,7 +1006,7 @@ Always Reference By Directory: true
 Artists:
 - Toby Fox
 Commentary: |-
-    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), adapted to text, 6/29/2010)
 
     This is the first time I ever tried [[Liquid Negrocity]].<br>
     Ah, this is like, it was way slow, there wasn't anything but a crappy piano.<br>
@@ -1299,7 +1299,7 @@ Lyrics: |-
     I'm a- I'm a- I'm a member of the-
     I'm a member of the Midnight Crew!
 Commentary: |-
-    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), adapted to text, 6/29/2010)
 
     *(Continued from [[track:liquid-negrocity-original]])*
 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1305,6 +1305,8 @@ Commentary: |-
 
     And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
 
+    I- Uh, I think I've done this evolution before.
+
     But yeah, that's Plasmic Blaquaciousness.
     But yeah, that's slightly more dense and then I just- I made [[Black]], which is the best.
 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1244,6 +1244,38 @@ URLs:
 - https://www.youtube.com/watch?v=RIq4GrMv96I
 - https://www.youtube.com/watch?v=OdntMzdkFnk
 ---
+Track: Plasmic Blaquaciousness
+Artists:
+- Toby Fox
+Duration: 2:18
+URLs:
+- https://soundcloud.com/slick-rick-101707440/plasmic-blaquaciousness
+- https://media.hsmusic.wiki/misc/archive/Plasmic%20Blaquaciousness.mp3
+Referenced Tracks:
+- Liquid Negrocity
+- track:im-a-member-of-the-midnight-crew
+Sampled Tracks:
+- track:im-a-member-of-the-midnight-crew
+Lyrics: |-
+    Make her a member of the Midnight Crew!
+
+    I'm a member of the-
+    I'm a member of the-
+    I'm a member of the Midnight Crew!
+
+    I'm a member of the-
+    I'm a member of the-
+
+    I'm a member of the-
+    I'm a member of the Midnight Crew!
+    I'm a member of the-
+    I'm a member of the Midnight Crew!
+
+    I'm a member of the-
+    I'm a member of the Midnight Crew!
+    I'm a- I'm a- I'm a member of the-
+    I'm a member of the Midnight Crew!
+---
 Track: Post-Apocalyptic Fedora
 Artists:
 - Thomas Ferkol

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1000,7 +1000,7 @@ Lyrics: |-
     My love lies with the sea
     My love lies with the ocean
 ---
-Track: Liquid Negrocity
+Track: Liquid Negrocity (original)
 Directory: liquid-negrocity-original
 Always Reference By Directory: true
 Artists:
@@ -1008,18 +1008,20 @@ Artists:
 Commentary: |-
     <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
 
-    This is the first time I ever tried [[Liquid Negrocity]].
-    Ah, this is like, it was way slow, there wasn't anything but a crappy piano.
+    This is the first time I ever tried [[Liquid Negrocity]].<br>
+    Ah, this is like, it was way slow, there wasn't anything but a crappy piano.<br>
     And it doesn't get any faster than this, it just goes like this.
 
     Oh my god. It's so slow.
 
-    It goes wicked slow.
-    
-    And so I was like, after I made this, I made Liquid Negrocity.
+    It goes wicked slow.<br>
+    And so I was like, after I made this, I made Liquid Negrocity. And then later I was like, I should remake this, this is gonna be, [[Plasmatic Blaquaciousness]], so I made it.
 
     *(Continued in [[track:plasmatic-blaquaciousness]])*
 
+    <i>Quasar Nebula:</i> (wiki editor, 6/12/2025)
+
+    Unofficial name - this track has probably only ever played in the radio episode.
 ---
 Track: Long Night Ahead
 Artists:
@@ -1307,11 +1309,10 @@ Commentary: |-
 
     I- Uh, I think I've done this evolution before.
 
-    But yeah, that's Plasmatic Blaquaciousness.
+    But yeah, that's Plasmatic Blaquaciousness.<br>
     But yeah, that's slightly more dense and then I just- I made [[Black]], which is the best.
 
-    Which kicks ass. And it's probably overall, the best song I've ever made.
-    I mean, [[Descend]] is great, but overall, Black, it's the better package.
+    Which kicks ass. And it's probably overall, the best song I've ever made. I mean, [[Descend]] is great, but overall, Black, it's the better package.
 
     *(Continued in [[track:liquid-negrocity]])*
 ---

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1000,6 +1000,27 @@ Lyrics: |-
     My love lies with the sea
     My love lies with the ocean
 ---
+Track: Liquid Negrocity
+Directory: liquid-negrocity-original
+Always Reference By Directory: true
+Artists:
+- Toby Fox
+Commentary: |-
+    <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
+
+    This is the first time I ever tried [[Liquid Negrocity]].
+    Ah, this is like, it was way slow, there wasn't anything but a crappy piano.
+    And it doesn't get any faster than this, it just goes like this.
+
+    Oh my god. It's so slow.
+
+    It goes wicked slow.
+    
+    And so I was like, after I made this, I made Liquid Negrocity.
+
+    *(Continued in [[track:plasmic-blaquaciousness]])*
+
+---
 Track: Long Night Ahead
 Artists:
 - Tensei
@@ -1278,7 +1299,9 @@ Lyrics: |-
 Commentary: |-
     <i>Toby Fox:</i> ([Skaianet Radio](https://web.archive.org/web/20130407202125/http://blog.skaia.net/2010/06/radiation-show-29th/), excerpt, 6/29/2010)
 
-    *(Continued from [[track:liquid-negrocity]])*
+    *(Continued from [[track:liquid-negrocity-original]])*
+
+    And then later I was like, I should remake this, this is gonna be, Plasmic Blaquaciousness, so I made it.
 
     And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1018,7 +1018,7 @@ Commentary: |-
     
     And so I was like, after I made this, I made Liquid Negrocity.
 
-    *(Continued in [[track:plasmic-blaquaciousness]])*
+    *(Continued in [[track:plasmatic-blaquaciousness]])*
 
 ---
 Track: Long Night Ahead
@@ -1265,13 +1265,13 @@ URLs:
 - https://www.youtube.com/watch?v=RIq4GrMv96I
 - https://www.youtube.com/watch?v=OdntMzdkFnk
 ---
-Track: Plasmic Blaquaciousness
+Track: Plasmatic Blaquaciousness
 Artists:
 - Toby Fox
 Duration: 2:18
 URLs:
 - https://soundcloud.com/slick-rick-101707440/plasmic-blaquaciousness
-- https://media.hsmusic.wiki/misc/archive/Plasmic%20Blaquaciousness.mp3
+- https://media.hsmusic.wiki/misc/archive/Plasmatic%20Blaquaciousness.mp3
 Referenced Tracks:
 - Liquid Negrocity
 - track:im-a-member-of-the-midnight-crew
@@ -1301,13 +1301,13 @@ Commentary: |-
 
     *(Continued from [[track:liquid-negrocity-original]])*
 
-    And then later I was like, I should remake this, this is gonna be, Plasmic Blaquaciousness, so I made it.
+    And then later I was like, I should remake this, this is gonna be, Plasmatic Blaquaciousness, so I made it.
 
     And I added [[track:im-a-member-of-the-midnight-crew|this quote]] at the beginning, and it even did this. And it was almost badass.
 
     I- Uh, I think I've done this evolution before.
 
-    But yeah, that's Plasmic Blaquaciousness.
+    But yeah, that's Plasmatic Blaquaciousness.
     But yeah, that's slightly more dense and then I just- I made [[Black]], which is the best.
 
     Which kicks ass. And it's probably overall, the best song I've ever made.

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1312,6 +1312,8 @@ Commentary: |-
 
     Which kicks ass. And it's probably overall, the best song I've ever made.
     I mean, [[Descend]] is great, but overall, Black, it's the better package.
+
+    *(Continued in [[track:liquid-negrocity]])*
 ---
 Track: Post-Apocalyptic Fedora
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -72,6 +72,7 @@ Content: |-
     <!-- series additions -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- commentary additions -->
+    - added Skaianet Radio excerpt from [[artist:toby-fox]] to [[track:liquid-negrocity]] (thanks, Lilith!)
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
     - added Tumblr commentary ([[artist:myotishi]]) to [[track:teal-hunter]] (thanks, Lan!)
     - added Tumblr commentary ([[artist:grue]]) to [[track:cobalt-corsair]] and [[track:spider8ite]] (thanks, Lan, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -115,6 +115,7 @@ Content: |-
     - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
+    - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmic-blaquaciousness]] (thanks, Lilith!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -72,7 +72,7 @@ Content: |-
     <!-- series additions -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- commentary additions -->
-    - added Skaianet Radio commentary from [[artist:toby-fox]] to [[track:liquid-negrocity]] (thanks, Lilith!)
+    - added Skaianet Radio commentary to [[track:liquid-negrocity]] (thanks, Lilith, Jackie!)
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
     - added Tumblr commentary ([[artist:myotishi]]) to [[track:teal-hunter]] (thanks, Lan!)
     - added Tumblr commentary ([[artist:grue]]) to [[track:cobalt-corsair]] and [[track:spider8ite]] (thanks, Lan, Lilith!)
@@ -116,8 +116,8 @@ Content: |-
     - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
-    - fixed [[track:liquid-negrocity]] not referencing [[track:liquid-negrocity-original]] (thanks, Lilith!)
-    - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith!)
+    - fixed [[track:liquid-negrocity]] not referencing [[track:liquid-negrocity-original]] (thanks, Lilith, Jackie!)
+    - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -72,7 +72,7 @@ Content: |-
     <!-- series additions -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- commentary additions -->
-    - added Skaianet Radio excerpt from [[artist:toby-fox]] to [[track:liquid-negrocity]] (thanks, Lilith!)
+    - added Skaianet Radio commentary from [[artist:toby-fox]] to [[track:liquid-negrocity]] (thanks, Lilith!)
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
     - added Tumblr commentary ([[artist:myotishi]]) to [[track:teal-hunter]] (thanks, Lan!)
     - added Tumblr commentary ([[artist:grue]]) to [[track:cobalt-corsair]] and [[track:spider8ite]] (thanks, Lan, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -72,7 +72,6 @@ Content: |-
     <!-- series additions -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- commentary additions -->
-    - added Skaianet Radio excerpt from [[artist:toby-fox]] to [[track:liquid-negrocity]] (thanks, Lilith!)
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
     - added Tumblr commentary ([[artist:myotishi]]) to [[track:teal-hunter]] (thanks, Lan!)
     - added Tumblr commentary ([[artist:grue]]) to [[track:cobalt-corsair]] and [[track:spider8ite]] (thanks, Lan, Lilith!)
@@ -116,6 +115,7 @@ Content: |-
     - removed Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     <h3>data fixes</h3>
     <!-- reference fixes -->
+    - fixed [[track:liquid-negrocity]] not referencing [[track:liquid-negrocity-original]] (thanks, Lilith!)
     - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmic-blaquaciousness]] (thanks, Lilith!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -117,7 +117,7 @@ Content: |-
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:liquid-negrocity]] not referencing [[track:liquid-negrocity-original]] (thanks, Lilith!)
-    - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmic-blaquaciousness]] (thanks, Lilith!)
+    - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)


### PR DESCRIPTION
adds Toby's Plasmic Blaquaciousness (a middle of sorts inbetween Liquid Negrocity and Black), as well as related excerpt commentary relating to an early version of Liquid Negrocity and Plasmic Blaquaciousness, as well as commentary regarding a could've been long version of Liquid Negrocity.

Plasmic Blaquaciousness now takes the place of Liquid Negrocity in Black

Liquid Negrocity now references original version (ala Ballad of Jack Noir)

Merge with: https://github.com/hsmusic/hsmusic-media/pull/129