### PR TITLE
Reference correction in Scratch: The Final Battle (SSBU) ==> The Final Battle (Super Mario 64)

### DIFF
--- a/album/the-felt.yaml
+++ b/album/the-felt.yaml
@@ -320,7 +320,7 @@ URLs:
 - https://youtu.be/3OVpWgisy0o
 Referenced Tracks:
 - Toccata and Fugue in D minor
-- The Final Battle
+- The Final Battle (Super Mario 64)
 Sheet Music Files:
 - Title: Sheet music by Max Wright
   Files:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -49,6 +49,8 @@ Content: |-
     - replaced YouTube listening link for [[track:danger-on-the-dance-floor-mid-boss]] with official upload (thanks, ruby!)
     <h3>data changes</h3>
     <h3>data fixes</h3>
+    <!-- reference fixes -->
+    - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"


### PR DESCRIPTION
Corrects [The Final Battle (Super Smash Bros. Ultimate)](https://hsmusic.wiki/track/the-final-battle/) reference in [Scratch](https://hsmusic.wiki/track/scratch/) back to [The Final Battle (Super Mario 64)](https://hsmusic.wiki/track/the-final-battle-super-mario-64/), which was formerly Ultimate Koopa.

## Breakdown for what caused this: 
Before [#662 Nintendo Music fixes and additions 2025-01-21](https://github.com/hsmusic/hsmusic-data/pull/662), Scratch used to point to Ultimate Koopa as a reference; however, when Ultimate Koopa was replaced by/renamed to The Final Battle (Super Mario 64), Scratch's reference to it was changed to The Final Battle, but without the supplementary text (Super Mario 64), causing it to reference Super Smash Bros. Ultimate's The Final Battle instead!