### PR TITLE
(Oops we forgot this) Jailbreak Vol. 1 Bandcamp credits blurb remedy: mistaken melodiousDiscord credit that we forgot to correct to Rebecca Harding

### DIFF
--- a/album/jailbreak-vol-1.yaml
+++ b/album/jailbreak-vol-1.yaml
@@ -77,7 +77,7 @@ Commentary: |-
     featuring art by:<br>
     [[artist:rj-lake|Robert J! Lake]]<br>
     [[artist:paige-turner]]<br>
-    [[artist:melodiousdiscord]]<br>
+    [[artist:rebecca-harding]]<br>
     and [[artist:ginnie-sea]]
 
     album art by [[artist:rj-lake|Robert J! Lake]]

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -51,8 +51,6 @@ Content: |-
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
-    <!-- crediting fixes -->
-    - fixed Bandcamp credits blurb for [[album:jailbreak-vol-1]] crediting [[artist:melodiousdiscord]] instead of [[artist:rebecca-harding]] (thanks, Lilith!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"
@@ -64,6 +62,8 @@ Content: |-
     - fixed [[track:danger-on-the-dance-floor-mid-boss]] being named "Danger on the Dance Floor (Mid-Boss)" (to align with soundtrack release; thanks, ruby!)
     <!-- art tag fixes -->
     - removed [[tag:john]] tag from [[album:the-baby-is-june]] (and [[album:the-baby-is-june-instrumental|instrumental]]), [[track:planet-healer]], and [[track:urban-jungle]] (thanks, Lan!)
+    <!-- commentary fixes -->
+    - fixed Bandcamp credits blurb for [[album:jailbreak-vol-1]] listing [[artist:melodiousdiscord]] instead of [[artist:rebecca-harding]] (thanks, Lilith!)
     <!-- general data fixes -->
     - fixed duration of various tracks to align with Nintendo Music: (thanks, ruby!)
         - fixed duration of [[track:death-mountain-theme]] (was 0:59, now 1:00)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -51,6 +51,8 @@ Content: |-
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
+    <!-- crediting fixes -->
+    - fixed Bandcamp credits blurb for [[album:jailbreak-vol-1]] crediting [[artist:melodiousdiscord]] instead of [[artist:rebecca-harding]] (thanks, Lilith!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"


### PR DESCRIPTION
corrects last stray mistaken melodiousDiscord credit to Rebecca Harding in Jailbreak Vol. 1's yaml. hopefully this is the last one.