### PR TITLE
Reference addition: "THE TRUTH" to Trial (TRUTH pt. 2)

### DIFF
--- a/album/do-without.yaml
+++ b/album/do-without.yaml
@@ -55,6 +55,8 @@ Track: Trial (TRUTH pt. 2)
 Duration: 04:30
 URLs:
 - https://screamcatcher.bandcamp.com/track/trial-truth-pt-2
+Referenced Tracks:
+- track:the-truth-inhibitor
 ---
 Track: Reflection
 Suffix Directory: true

--- a/album/grave.yaml
+++ b/album/grave.yaml
@@ -19,7 +19,7 @@ Groups:
 - Beyond
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
-    Around 2020-2021, Grave and [[album:home|Home's]] track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:ikari]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the ninth track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:nagisa]] and [[track:impact-grave]], and [[track:instrumentality-grave]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the eleventh track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:impact-grave]] and [[track:nagisa-ghoti-remix]].
+    Around August 2020, Grave and [[album:home|Home's]] track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:ikari]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the ninth track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:nagisa]] and [[track:impact-grave]], and [[track:instrumentality-grave]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the eleventh track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:impact-grave]] and [[track:nagisa-ghoti-remix]].
 ---
 Section: Main album
 ---
@@ -84,7 +84,7 @@ Duration: 06:47
 Referenced Tracks:
 - Ikari
 ---
-Section: Removed in 2021 release
+Section: Removed in 2020 release
 ---
 Track: Ikari
 Additional Names:

--- a/album/grave.yaml
+++ b/album/grave.yaml
@@ -19,7 +19,12 @@ Groups:
 - Beyond
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
+
     Around August 2020, Grave and [[album:home|Home's]] track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:ikari]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the ninth track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:nagisa]] and [[track:impact-grave]], and [[track:instrumentality-grave]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the eleventh track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:impact-grave]] and [[track:nagisa-ghoti-remix]].
+
+    <i>Quasar Nebula:</i> (wiki editor, 5/14/2025)
+
+    We're taking August 19, 2020 as the likely date that this album and [[album:home]] were updated because on this date *both* albums were updated, and no others were (the other Screamcatcher albums were still untouched, since September 2012 or original album release, as of December 2021). We verified this by visiting the first capture, for all Screamcatcher albums, taken *later* than August 2020, and checking the Bandcamp-provided metadata `TralbumData.current.mod_date`.
 ---
 Section: Main album
 ---
@@ -84,7 +89,7 @@ Duration: 06:47
 Referenced Tracks:
 - Ikari
 ---
-Section: Removed in 2020 release
+Section: Removed in 2020 track list
 ---
 Track: Ikari
 Additional Names:

--- a/album/grave.yaml
+++ b/album/grave.yaml
@@ -78,3 +78,5 @@ Referenced Tracks:
 ---
 Track: Ikari (Instrumental)
 Duration: 06:47
+Referenced Tracks:
+- Ikari

--- a/album/grave.yaml
+++ b/album/grave.yaml
@@ -120,41 +120,6 @@ Lyrics: |-
     Held my head in my hands and I whispered:
     "don't make me feel the way I feel today,
     I don't wanna go on but I mustn't run away."
-
-    <i>Lilithtreasure:</i> (wiki lyrics)
-
-    I never wanted your help
-    I only wanted your hand
-    But you stood so far away
-    Speaking words I couldn't understand
-
-    If I can't have you all to myself I don't want anything from you.
-
-    I never wanted your help
-    I only wanted your hand
-    But you stood so far away
-    Speaking words I couldn't understand
-
-    If I can't have you all to myself I don't want anything from you.
-
-    To hold you in my hands was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something I had so long denied.
-
-    Hold you in my hand was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something that I had long denied.
-
-    And so I ran, as far as I could.
-    Held my head in my hands and I whispered:
-    "don't make me feel the way I feel today,
-    I don't wanna go on but I mustn't run away."
-    
-    "don't make me feel the way I feel today,
-    I don't wanna go on but I [???]"
-
-    Hold you in my hand was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something that I had long denied.
-    
-    Feel you so close was to feel something I had so long denied.
 ---
 Track: Instrumentality
 Additional Names:

--- a/album/grave.yaml
+++ b/album/grave.yaml
@@ -17,6 +17,9 @@ Color: '#a9a9ab'
 Groups:
 - Kalibration
 - Beyond
+Commentary: |-
+    <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
+    Around 2020-2021, Grave and [[album:home|Home's]] track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:ikari]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the ninth track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:nagisa]] and [[track:impact-grave]], and [[track:instrumentality-grave]] ([capture](https://web.archive.org/web/20211230103742/https://screamcatcher.bandcamp.com/album/grave)), which used to be the eleventh track ([capture](https://web.archive.org/web/20130613180227/http://screamcatcher.net/album/grave)) between [[track:impact-grave]] and [[track:nagisa-ghoti-remix]].
 ---
 Section: Main album
 ---
@@ -80,3 +83,110 @@ Track: Ikari (Instrumental)
 Duration: 06:47
 Referenced Tracks:
 - Ikari
+---
+Section: Removed in 2021 release
+---
+Track: Ikari
+Additional Names:
+- Name: >-
+    Ikari (ft. VOTL and gabriel.)
+  Annotation: >-
+    [Bandcamp](https://web.archive.org/web/20130730224734/http://screamcatcher.net/track/ikari-ft-votl-and-gabriel)
+Artists:
+- Kalibration
+- Screamcatcher
+- Alex Votl (featuring)
+- gabriel. (featuring)
+Contributors:
+- Alex Votl (vocals)
+- gabriel. (vocals)
+Duration: 7:04
+Lyrics: |-
+    <i>Kalibration:</i> ([artist's lyrics](https://web.archive.org/web/20130730224734/http://screamcatcher.net/track/ikari-ft-votl-and-gabriel))
+
+    I. ([[artist:alex-votl|VOTL]])
+    I never wanted your help
+    I only wanted your hand
+    But you stood so far away
+    Speaking words I couldn't understand
+
+    If I can't have you all to myself I don't want anything from you.
+
+    II. ([[artist:gabriel]])
+    To hold you in my hand was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something I had so long denied.
+
+    And so I ran, as far as I could.
+    Held my head in my hands and I whispered:
+    "don't make me feel the way I feel today,
+    I don't wanna go on but I mustn't run away."
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
+    I never wanted your help
+    I only wanted your hand
+    But you stood so far away
+    Speaking words I couldn't understand
+
+    If I can't have you all to myself I don't want anything from you.
+
+    I never wanted your help
+    I only wanted your hand
+    But you stood so far away
+    Speaking words I couldn't understand
+
+    If I can't have you all to myself I don't want anything from you.
+
+    To hold you in my hands was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something I had so long denied.
+
+    Hold you in my hand was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something that I had long denied.
+
+    And so I ran, as far as I could.
+    Held my head in my hands and I whispered:
+    "don't make me feel the way I feel today,
+    I don't wanna go on but I mustn't run away."
+    
+    "don't make me feel the way I feel today,
+    I don't wanna go on but I [???]"
+
+    Hold you in my hand was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something that I had long denied.
+    
+    Feel you so close was to feel something I had so long denied.
+---
+Track: Instrumentality
+Additional Names:
+- Name: >-
+    Instrumentality (ft. gabriel.)
+  Annotation: >-
+    [Bandcamp](https://web.archive.org/web/20130728172535/http://screamcatcher.net/track/instrumentality-ft-gabriel)
+Suffix Directory: true
+Always Reference By Directory: true
+Artists:
+- Kalibration
+- Screamcatcher
+- gabriel. (featuring)
+Contributors:
+- gabriel. (vocals)
+Duration: 2:52
+Referenced Tracks:
+- track:komm-susser-tod
+Sampled Tracks:
+- Victim Kin Seek Suit
+Lyrics: |-
+    <i>Kalibration:</i> ([artist's lyrics](https://web.archive.org/web/20130728172535/http://screamcatcher.net/track/instrumentality-ft-gabriel))
+
+    Now, my dream comes to an end.
+    I'll dig a grave and bury these empty feelings.
+    I will shatter my ego and start anew,
+    in this world I can't accept as true.
+
+    But as long
+    as we can feel pain,
+    that means that we can relate,
+    and be as one.
+
+    For the chance to be close to someone,
+    I'd never give that up.

--- a/album/home.yaml
+++ b/album/home.yaml
@@ -12,6 +12,12 @@ Color: '#f68908'
 Groups:
 - Kalibration
 - Beyond
+Commentary: |-
+    <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
+
+    Around 2020-2021, [[album:grave]] and Home's track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:vitality-home]] (https://web.archive.org/web/20211230104052/https://screamcatcher.bandcamp.com/album/home), which used to be the fifth track ([capture](https://web.archive.org/web/20120117153403/http://screamcatcher.net:80/album/home)) after [[track:headed-home-mccoy]].
+---
+Section: Main album
 ---
 Track: Electric District
 Duration: 04:30
@@ -34,3 +40,41 @@ Track: Headed Home (McCoy)
 Duration: 03:36
 URLs:
 - https://screamcatcher.bandcamp.com/track/headed-home-mccoy
+---
+Section: Removed in 2021 release
+---
+Track: Vitality
+Additional Names:
+- Name: >-
+    Vitality (ft. gabriel. & ROMΔNCE)
+  Annotation: >-
+    [Bandcamp](https://web.archive.org/web/20111116044108/http://screamcatcher.net/track/vitality-ft-gabriel-rom-nce)
+Suffix Directory: true
+Always Reference By Directory: true
+Artists:
+- Kalibration
+- Screamcatcher
+- gabriel. (featuring)
+- ROM∆NCE (featuring)
+Contributors:
+- ROM∆NCE (guest production)
+- gabriel. (vocals, lyrics)
+Duration: 4:13
+Referenced Tracks:
+- track:vitality-belief
+Lyrics: |-
+    <i>Kalibration:</i> ([artist's lyrics](https://web.archive.org/web/20111116044108/http://screamcatcher.net/track/vitality-ft-gabriel-rom-nce))
+
+    (Fuck it.)
+    I think you've said enough.
+    You know I've had enough.
+    I've had enough of this stupid bullshit.
+    I'll take you serious
+    When you get serious
+    And you learn how to take a motherfucking hint.
+    I'm out on the attack,
+    so what you holding back?
+    I'll make it up to you tenfold and then some.
+    Say what you want,
+    it's what I really want.
+    Gabriel and Kal, fuck it mayne, I'm done.

--- a/album/home.yaml
+++ b/album/home.yaml
@@ -78,3 +78,21 @@ Lyrics: |-
     Say what you want,
     it's what I really want.
     Gabriel and Kal, fuck it mayne, I'm done.
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
+    (Fuck it.)
+    I think you've said enough.
+    You know I've had enough.
+    I've had enough of this stupid bullshit.
+    I'll take you serious
+    When you get serious
+    And you learn how to take a motherfucking hint.
+    I'm out on the attack,
+    so what, you holding back?
+    I'll make it up to you tenfold and then some.
+    S-S-Say what you want,
+    it's what I really want.
+    Gabriel and Kal, fuck it mayne, I'm done.
+
+    (Fuck it.)

--- a/album/home.yaml
+++ b/album/home.yaml
@@ -15,7 +15,7 @@ Groups:
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
 
-    Around 2020-2021, [[album:grave]] and Home's track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:vitality-home]] (https://web.archive.org/web/20211230104052/https://screamcatcher.bandcamp.com/album/home), which used to be the fifth track ([capture](https://web.archive.org/web/20120117153403/http://screamcatcher.net:80/album/home)) after [[track:headed-home-mccoy]].
+    Around August 2020, [[album:grave]] and Home's track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:vitality-home]] (https://web.archive.org/web/20211230104052/https://screamcatcher.bandcamp.com/album/home), which used to be the fifth track ([capture](https://web.archive.org/web/20120117153403/http://screamcatcher.net:80/album/home)) after [[track:headed-home-mccoy]].
 ---
 Section: Main album
 ---
@@ -41,7 +41,7 @@ Duration: 03:36
 URLs:
 - https://screamcatcher.bandcamp.com/track/headed-home-mccoy
 ---
-Section: Removed in 2021 release
+Section: Removed in 2020 release
 ---
 Track: Vitality
 Additional Names:

--- a/album/home.yaml
+++ b/album/home.yaml
@@ -15,7 +15,11 @@ Groups:
 Commentary: |-
     <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
 
-    Around August 2020, [[album:grave]] and Home's track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:vitality-home]] (https://web.archive.org/web/20211230104052/https://screamcatcher.bandcamp.com/album/home), which used to be the fifth track ([capture](https://web.archive.org/web/20120117153403/http://screamcatcher.net:80/album/home)) after [[track:headed-home-mccoy]].
+    Around August 2020, [[album:grave]] and Home's track listings were modified to not include the vocal tracks; the updated version of the album does not include [[track:vitality-home]] ([capture](https://web.archive.org/web/20211230104052/https://screamcatcher.bandcamp.com/album/home)), which used to be the fifth and final track ([capture](https://web.archive.org/web/20120117153403/http://screamcatcher.net:80/album/home)).
+
+    <i>Quasar Nebula:</i> (wiki editor, 5/14/2025)
+
+    We're taking August 19, 2020 as the likely date that this album and [[album:grave]] were updated because on this date *both* albums were updated, and no others were (the other Screamcatcher albums were still untouched, since September 2012 or original album release, as of December 2021). We verified this by visiting the first capture, for all Screamcatcher albums, taken *later* than August 2020, and checking the Bandcamp-provided metadata `TralbumData.current.mod_date`.
 ---
 Section: Main album
 ---
@@ -41,7 +45,7 @@ Duration: 03:36
 URLs:
 - https://screamcatcher.bandcamp.com/track/headed-home-mccoy
 ---
-Section: Removed in 2020 release
+Section: Removed in 2020 track list
 ---
 Track: Vitality
 Additional Names:

--- a/album/home.yaml
+++ b/album/home.yaml
@@ -78,21 +78,3 @@ Lyrics: |-
     Say what you want,
     it's what I really want.
     Gabriel and Kal, fuck it mayne, I'm done.
-
-    <i>Lilithtreasure:</i> (wiki lyrics)
-
-    (Fuck it.)
-    I think you've said enough.
-    You know I've had enough.
-    I've had enough of this stupid bullshit.
-    I'll take you serious
-    When you get serious
-    And you learn how to take a motherfucking hint.
-    I'm out on the attack,
-    so what, you holding back?
-    I'll make it up to you tenfold and then some.
-    S-S-Say what you want,
-    it's what I really want.
-    Gabriel and Kal, fuck it mayne, I'm done.
-
-    (Fuck it.)

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -929,72 +929,6 @@ Lyrics: |-
     William Henry Harrison
     My name is William Henry— [coughs]
 ---
-Track: Ikari
-Additional Names:
-- Name: >-
-    Ikari (ft. VOTL and gabriel.)
-  Annotation: >-
-    full title
-Artists:
-- Kalibration
-- Screamcatcher
-- Alex Votl (featuring)
-- gabriel. (featuring)
-Lyrics: |-
-    <i>Kalibration:</i> (artist's lyrics)
-
-    I. ([[artist:alex-votl|VOTL]])
-    I never wanted your help
-    I only wanted your hand
-    But you stood so far away
-    Speaking words I couldn't understand
-
-    If I can't have you all to myself I don't want anything from you.
-
-    II. ([[artist:gabriel]])
-    To hold you in my hand was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something I had so long denied.
-
-    And so I ran, as far as I could.
-    Held my head in my hands and I whispered:
-    "don't make me feel the way I feel today,
-    I don't wanna go on but I mustn't run away."
-
-    <i>Lilithtreasure:</i> (wiki lyrics)
-
-    I never wanted your help
-    I only wanted your hand
-    But you stood so far away
-    Speaking words I couldn't understand
-
-    If I can't have you all to myself I don't want anything from you.
-
-    I never wanted your help
-    I only wanted your hand
-    But you stood so far away
-    Speaking words I couldn't understand
-
-    If I can't have you all to myself I don't want anything from you.
-
-    To hold you in my hands was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something I had so long denied.
-
-    Hold you in my hand was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something that I had so long denied.
-
-    And so I ran, as far as I could.
-    Held my head in my hands and I whispered:
-    "don't make me feel the way I feel today,
-    I don't wanna go on but I mustn't run away."
-    
-    "don't make me feel the way I feel today,
-    I don't wanna go on but I [???]"
-
-    Hold you in my hand was to feel my strength that I had tried to hide.
-    To feel you so close was to feel something that I had long denied.
-    
-    Feel you so close was to feel something I had so long denied.
----
 Track: Kid Radd (Final)
 Artists:
 - Mark J. Hadley
@@ -1705,6 +1639,16 @@ Artists:
 Duration: 3:04
 URLs:
 - https://soundcloud.com/blackholesc/winterfall
+---
+Track: Vitality
+Directory: vitality-belief
+Always Reference By Directory: true
+Artists:
+- Kalibration
+- Screamcatcher
+Commentary: |-
+    <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
+    From Kalibration's decommissioned Belief album.
 ---
 Track: Your Fear Is On My Mind (Instrumental)
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -1595,6 +1595,7 @@ URLs:
 Track: "THE TRUTH"
 Directory: the-truth-inhibitor
 Always Reference By Directory: true
+Duration: 3:37
 Artists:
 - Kalibration
 - Screamcatcher

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -45276,6 +45276,17 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=Osqf4oIK0E8
 ---
+Track: Victim Kin Seek Suit
+Artists:
+- The World Is a Beautiful Place & I Am No Longer Afraid to Die
+Duration: 2:24
+URLs:
+- https://www.youtube.com/watch?v=YmxbZWteDnU
+- https://theworldis.bandcamp.com/track/victim-kin-seek-suit
+Lyrics: |-
+    Lying on our backs on the pavement, let there be light. Uou opened our eyes. The apple tree is an open casket. Lying on our backs on the pavement, let there be light, let it be bright. Lying on our backs on the pavement, let there be light. You opened our eyes. The body is a form of failure. Lying on our backs on the pavement, let there be light, let it be bright. Lying on our backs on the pavement, let there be light. You opened our eyes.
+    We’re covered like a flower cart and lying on our backs. Where are you and where have you run to? Where are you and why don’t you just come home?
+---
 Track: Viva la Vida
 Artists:
 - Coldplay

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -929,6 +929,72 @@ Lyrics: |-
     William Henry Harrison
     My name is William Henry— [coughs]
 ---
+Track: Ikari
+Additional Names:
+- Name: >-
+    Ikari (ft. VOTL and gabriel.)
+  Annotation: >-
+    full title
+Artists:
+- Kalibration
+- Screamcatcher
+- Alex Votl (featuring)
+- gabriel. (featuring)
+Lyrics: |-
+    <i>Kalibration:</i> (artist's lyrics)
+
+    I. ([[artist:alex-votl|VOTL]])
+    I never wanted your help
+    I only wanted your hand
+    But you stood so far away
+    Speaking words I couldn't understand
+
+    If I can't have you all to myself I don't want anything from you.
+
+    II. ([[artist:gabriel]])
+    To hold you in my hand was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something I had so long denied.
+
+    And so I ran, as far as I could.
+    Held my head in my hands and I whispered:
+    "don't make me feel the way I feel today,
+    I don't wanna go on but I mustn't run away."
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
+    I never wanted your help
+    I only wanted your hand
+    But you stood so far away
+    Speaking words I couldn't understand
+
+    If I can't have you all to myself I don't want anything from you.
+
+    I never wanted your help
+    I only wanted your hand
+    But you stood so far away
+    Speaking words I couldn't understand
+
+    If I can't have you all to myself I don't want anything from you.
+
+    To hold you in my hands was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something I had so long denied.
+
+    Hold you in my hand was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something that I had so long denied.
+
+    And so I ran, as far as I could.
+    Held my head in my hands and I whispered:
+    "don't make me feel the way I feel today,
+    I don't wanna go on but I mustn't run away."
+    
+    "don't make me feel the way I feel today,
+    I don't wanna go on but I [???]"
+
+    Hold you in my hand was to feel my strength that I had tried to hide.
+    To feel you so close was to feel something that I had long denied.
+    
+    Feel you so close was to feel something I had so long denied.
+---
 Track: Kid Radd (Final)
 Artists:
 - Mark J. Hadley
@@ -1595,7 +1661,6 @@ URLs:
 Track: "THE TRUTH"
 Directory: the-truth-inhibitor
 Always Reference By Directory: true
-Duration: 3:37
 Artists:
 - Kalibration
 - Screamcatcher

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -1592,6 +1592,16 @@ Artists:
 URLs:
 - https://soundcloud.com/machinasolis/till-tomorrow
 ---
+Track: "THE TRUTH"
+Directory: the-truth-inhibitor
+Always Reference By Directory: true
+Artists:
+- Kalibration
+- Screamcatcher
+Commentary: |-
+    <i>Lilithtreasure:</i> (wiki editor, 5/14/2025)
+    From Kalibration's decommissioned Inhibitor album.
+---
 Track: wake128
 Artists:
 - Emelia K.

--- a/artists.yaml
+++ b/artists.yaml
@@ -4945,6 +4945,10 @@ URLs:
 - https://soundcloud.com/z0r8
 - https://twitter.com/zorg_z0rg_z0r8
 ---
+Artist: gabriel.
+Aliases:
+- Gabriel Clarke
+---
 Artist: Gabriel Nezovic
 Aliases:
 - Gabe Nezovic

--- a/artists.yaml
+++ b/artists.yaml
@@ -14849,6 +14849,10 @@ URLs:
 - https://twitter.com/wondendwond
 - https://gamebanana.com/members/1824101
 ---
+Artist: The World Is a Beautiful Place & I Am No Longer Afraid to Die
+URLs:
+- https://theworldis.bandcamp.com/
+---
 Artist: Worthikids
 URLs:
 - https://worthikids.bandcamp.com/

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -817,7 +817,7 @@ Content: |-
     - added Tumblr commentary and alternate artwork to [[track:hunting-the-most-dangerous-game]] (thanks, Lilith!)
     - added SoundCloud commentary, additional name, and listening link to [[track:chronic-infection]] (thanks, Lilith!)
     - added YouTube commentary and listening links to [[track:arcalicious]], [[track:kingdom-come]], and [[track:probable-cause]] (thanks, Lilith!)
-    - added Tumblr commentary blurb excerpt to [[album:freeroam-volume-1]] (thanks, Lilith!
+    - added Tumblr commentary blurb excerpt to [[album:freeroam-volume-1]] (thanks, Lilith!)
     - added Tumblr commentary and full-size artwork to [[track:the-man-of-action-jason-ryders-theme]] (thanks, Lilith, Lan!)
     - added Bandcamp commentary blurb (2022) and related notes to [[album:perfectly-generic-album]] (thanks, Tangle, Lilith!)
     - added Newgrounds commentary to [[track:clockstopper-new-game-plus-all-clocks-percent]] and [[track:deadkidsgodhood]] (thanks, Whisper!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -44,7 +44,7 @@ Content: |-
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
     <!-- track additions -->
     - added [[track:vitality-home]] to [[album:home]]! (thanks, Lan, Lilith!)
-    - added [[track:ikari]] and [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!
+    - added [[track:ikari]] and [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!)
     <!-- new series -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- link additions -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -44,7 +44,7 @@ Content: |-
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
     <!-- track additions -->
     - added [[track:vitality-home]] to [[album:home]]! (thanks, Lan, Lilith!)
-    - added [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!
+    - added [[track:ikari]] and [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!
     <!-- new series -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- link additions -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -51,6 +51,7 @@ Content: |-
     <h3>data fixes</h3>
     <!-- reference fixes -->
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
+    - fixed [[track:trial-truth-pt-2]] not referencing [[track:the-truth-inhibitor]] (Inhibitor; thanks, Lilith!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -52,6 +52,7 @@ Content: |-
     <!-- reference fixes -->
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
     - fixed [[track:trial-truth-pt-2]] not referencing [[track:the-truth-inhibitor]] (Inhibitor; thanks, Lilith!)
+    - fixed [[track:ikari-instrumental]] not referencing [[track:ikari]] (vocal version; thanks, Lilith!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -42,6 +42,9 @@ Content: |-
     <h3>other additions</h3>
     <!-- flash additions -->
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
+    <!-- track additions -->
+    - added [[track:vitality-home]] to [[album:home]]! (thanks, Lan, Lilith!)
+    - added [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!
     <!-- new series -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- link additions -->


### PR DESCRIPTION
Adds "THE TRUTH" from Kalibration's decommissioned Inhibitor album as a reference to Trial (TRUTH pt. 2) in Do Without.
~~Also adds Ikari (vocal version), formerly a part of Grave, as a referenced track in Ikari (Instrumental), in Grave.~~

- [x] ~~move Ikari from References Beyond Homestuck back to Grave~~
- [x] ~~Also adds Instrumentality to Grave (part of removed tracks section)~~
- [x] ~~and Vitality to Home (part of removed tracks section)~~