### PR TITLE
Group addition: Raid

### DIFF
--- a/album/beatdown-raid-remix.yaml
+++ b/album/beatdown-raid-remix.yaml
@@ -12,6 +12,7 @@ Cover Artists:
 - Homestuck
 Color: '#e00707'
 Groups:
+- Raid
 - Fandom
 Art Tags:
 - Dave

--- a/album/black-raid-remix.yaml
+++ b/album/black-raid-remix.yaml
@@ -15,6 +15,7 @@ Cover Artists:
 Color: '#ff3b3b'
 Cover Art File Extension: png
 Groups:
+- Raid
 - Fandom
 Wallpaper Artists:
 - Lilithtreasure (edits for wiki)

--- a/album/doctor-raid-remix.yaml
+++ b/album/doctor-raid-remix.yaml
@@ -13,6 +13,7 @@ Cover Artists:
 Cover Art Dimensions: 1402x1401
 Color: '#4f8bd6'
 Groups:
+- Raid
 - Fandom
 Art Tags:
 - LoWaS

--- a/album/flare-raid-remix.yaml
+++ b/album/flare-raid-remix.yaml
@@ -11,6 +11,7 @@ Cover Artists:
 - Raid
 Color: '#5bcb03'
 Groups:
+- Raid
 - Fandom
 Art Tags:
 - Green Sun

--- a/album/i-warned-you-about-stairs.yaml
+++ b/album/i-warned-you-about-stairs.yaml
@@ -14,6 +14,7 @@ Cover Artists:
 Cover Art File Extension: png
 Color: '#388be5'
 Groups:
+- Raid
 - Fandom
 Art Tags:
 - Gate

--- a/album/moonslayer.yaml
+++ b/album/moonslayer.yaml
@@ -12,6 +12,7 @@ Cover Artists:
 Cover Art File Extension: png
 Color: '#ac91ff'
 Groups:
+- Raid
 - Fandom
 Wallpaper Artists:
 - Raid

--- a/album/universal-umbrosity.yaml
+++ b/album/universal-umbrosity.yaml
@@ -12,6 +12,7 @@ Cover Artists:
 Color: '#d193fb'
 Cover Art File Extension: png
 Groups:
+- Raid
 - Fandom
 Wallpaper Artists:
 - Raid

--- a/groups.yaml
+++ b/groups.yaml
@@ -486,6 +486,16 @@ URLs:
 Description: |-
     Best known to Homestuck fans for creating some of its [[Skies of Skaia|foundational]] [[Aggrieve|themes]], and to the internet at large for Slender: The Eight Pages and [[album:slender-the-arrival-soundtrack|its sequel]], Mark J. Hadley is a multitalented composer and independent developer.
 ---
+Group: Raid
+Closely Linked Artists:
+- Raid
+URLs:
+- https://rudecustard.bandcamp.com/
+- https://soundcloud.com/raidsrc
+- https://youtube.com/@raidsrc
+Description: |-
+    Jack-of-most-trades musician who also happens to be a biologist, educator, and computer programmer, with an extensive library of Homestuck covers, spanning from [[track:moonslayer]], to his latest album, [[album:i-warned-you-about-stairs]].
+---
 Group: Solatrus
 Closely Linked Artists:
 - Solatrus

--- a/groups.yaml
+++ b/groups.yaml
@@ -494,7 +494,7 @@ URLs:
 - https://soundcloud.com/raidsrc
 - https://youtube.com/@raidsrc
 Description: |-
-    Jack-of-most-trades musician who also happens to be a biologist, educator, and computer programmer, with an extensive library of Homestuck covers, spanning from [[track:moonslayer]], to his latest album, [[album:i-warned-you-about-stairs]].
+    Jack-of-all-trades musician who also happens to be a biologist, educator, and computer programmer, with an extensive library of Homestuck covers, spanning from [[track:moonslayer]], to his latest album, [[album:i-warned-you-about-stairs]].
 ---
 Group: Solatrus
 Closely Linked Artists:

--- a/groups.yaml
+++ b/groups.yaml
@@ -493,6 +493,18 @@ URLs:
 - https://rudecustard.bandcamp.com/
 - https://soundcloud.com/raidsrc
 - https://youtube.com/@raidsrc
+Series:
+- Name: Albums
+  Albums:
+  - I Warned You About Stairs
+- Name: Singles
+  Albums:
+  - Doctor (Raid Remix)
+  - Beatdown (Raid Remix)
+  - album:black-raid-remix
+  - Moonslayer
+  - Universal Umbrosity
+  - Flare (Raid Remix)
 Description: |-
     Jack-of-all-trades musician who also happens to be a biologist, educator, and computer programmer, with an extensive library of Homestuck covers, spanning from [[track:moonslayer]], to his latest album, [[album:i-warned-you-about-stairs]].
 ---

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -67,7 +67,9 @@ Content: |-
     <!-- track additions -->
     - added [[track:vitality-home]] to [[album:home]]! (thanks, Lan, Lilith!)
     - added [[track:ikari]] and [[track:instrumentality-grave]] to [[album:grave]]! (thanks, Lilith!)
-    <!-- new series -->
+    <!-- group additions -->
+    - added [[group:raid]] group (thanks, Lilith!)
+    <!-- series additions -->
     - added series for [[group:desynced]] (thanks, Lilith!)
     <!-- commentary additions -->
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)


### PR DESCRIPTION
Adds Raid as a group, making it easier to sift through his works, also by series:
- Albums
- Singles

Split from [#734 Album additions: Svix's Audacity to Waiting for the Night (Svix mix) (also I'm Waiting for the Future from 2010) + groups (Svix, and Raid)](https://github.com/hsmusic/hsmusic-data/pull/734)