### PR TITLE
Stalemate: Adieu section fix (but what do we do with track 61???)

### DIFF
--- a/album/stalemate-adieu.yaml
+++ b/album/stalemate-adieu.yaml
@@ -582,14 +582,14 @@ Artists:
 URLs:
 - https://stalematecomic.bandcamp.com/track/passing-through-to-somewhere-new
 ---
+Section: To say goodbye
+---
 Track: Closure and Goodbyes
 Duration: 0:59
 Artists:
 - Ell Young
 URLs:
 - https://stalematecomic.bandcamp.com/track/closure-and-goodbyes
----
-Section: To say goodbye
 ---
 Track: A Bitter Ending
 Duration: 1:32

--- a/album/stalemate-adieu.yaml
+++ b/album/stalemate-adieu.yaml
@@ -607,6 +607,8 @@ Cover Artists:
 URLs:
 - https://stalematecomic.bandcamp.com/track/what-remains
 ---
+Section: Adieu
+---
 Track: STALEMATE
 Duration: 7:16
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -57,6 +57,8 @@ Content: |-
     - fixed [[track:scratch]] referencing [[track:the-final-battle]] ([[album:super-smash-bros-ultimate]]) instead of [[track:the-final-battle-super-mario-64]] (thanks, Lilith!)
     - fixed [[track:trial-truth-pt-2]] not referencing [[track:the-truth-inhibitor]] (Inhibitor; thanks, Lilith!)
     - fixed [[track:ikari-instrumental]] not referencing [[track:ikari]] (vocal version; thanks, Lilith!)
+    <!-- track section/placement fixes -->
+    - fixed placement of "To say goodbye" section in [[album:stalemate-adieu]] per Bandcamp blurb (didn't include [[track:closure-and-goodbyes]]; thanks, Lilith!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"


### PR DESCRIPTION
Repositions "To say goodbye" section based on [Bandcamp blurb](https://stalematecomic.bandcamp.com/album/stalemate-adieu) (58-60, though unsure how to handle 61 (what section would it even be in???) considering it's not counted there (?)) (edit: but maybe... an Adieu section for 61? maybe???)

"58 - 60 are songs that a few of the music team members decided to create after the comics end was announced, to say goodbye."