### PR TITLE
Album single addition: Epic of Jack Noir (Director's Cut) by Witch's Cadence

### DIFF
--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -39,6 +39,7 @@ Crediting Sources: |-
     Track art by [[artist:dizzims|Dizzims.]]
 ---
 Track: Epic of Jack Noir (Director's Cut)
+Count In Artist Totals: false
 Contributors:
 - Witch's Cadence (mastering)
 Duration: 9:20

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -1,0 +1,45 @@
+Album: Epic of Jack Noir (Director's Cut)
+Date: July 28, 2024
+Artists:
+- Witch's Cadence
+Cover Artists:
+- dizzims.
+Cover Art File Extension: jpg
+URLs:
+- https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
+Color: '#cc6c71'
+Groups:
+- Fandom
+Art Tags:
+- Jack Noir
+- Jack Noir (Desynced)
+- Lord Noir (Desynced)
+Commentary: |-
+    <i>Witch's Cadence:</i> ([SoundCloud description](https://soundcloud.com/witchs-cadence/cognitive-coalescence), excerpt, 7/24/2024)
+
+    [[track:the-epic-of-jack-noir|"Epic of Jack Noir"]] was a song I made for the album [[album:noirscape]]. It is a 9 minute behemoth of a song, that I spent lots of time and effort on to make it just right. However, I have a couple issues with the version featured on both official releases of the album, those being
+
+    A) Multiple mistakes that were never fixed in the final master<br>
+    B) I personally am not really a fan of the mastering that was done on this track specifically
+
+    Now, first thing's first, I want to make a couple things clear. I hold no grudges with the person who did the mastering initially, and I think they are likely much more knowledgeable on the topic than I am, and yet, even when I first heard the original master it has always sounded too compressed and lacking in a certain clarity that I wanted for the song. This "new" version of the master that I am presenting to you now, is actually a version I did while waiting for the official master. It also fixes a couple of mistakes that I fixed and sent to the person mastering for the album, but wasn't included in the final version.
+
+    Considering all of these things, I also want to make it clear that I don't see either one as the "True" version of this song. If you like the other one better, than please by all means, continue to enjoy it! I however could not rest leaving my personal vision for it unseen.
+
+    This is all I have to say, thank you for reading my spiel.
+Crediting Sources: |-
+    <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
+
+    Track art by [[artist:dizzims|Dizzims.]]
+---
+Track: Epic of Jack Noir (Director's Cut)
+Main Release: The Epic of Jack Noir
+Contributors:
+- Witch's Cadence (mastering)
+Duration: 9:20
+URLs:
+- https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
+Crediting Sources: |-
+    <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
+
+    References [[track:liquid-negrocity|"Liquid Negrocity"]], [[track:the-ballad-of-jack-noir|"Ballad of Jack Noir"]] and [[track:double-midnight|"Double Midnight]] by [[artist:toby-fox]] and [[track:the-dirty-snakes-coup|"The Dirty Snake's Coup"]] and [[track:im-sorry|"I'm Sorry"]] by Witch's Cadence.

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -31,8 +31,6 @@ URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
 Referenced Tracks:
 - The Epic of Jack Noir
-Sampled Tracks:
-- The Epic of Jack Noir
 Lyrics: |-
     A split in the multiverse
     A crack in God’s will

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -29,9 +29,7 @@ Contributors:
 Duration: 9:20
 URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
-Referenced Tracks:
-- The Epic of Jack Noir
-Sampled Tracks:
+Previous Productions:
 - The Epic of Jack Noir
 Lyrics: |-
     A split in the multiverse

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -1,5 +1,5 @@
 Album: Epic of Jack Noir (Director's Cut)
-Date: July 28, 2024
+Date: May 27, 2025
 Artists:
 - Witch's Cadence
 Cover Artists:

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -44,7 +44,7 @@ Sampled Tracks:
 - The Epic of Jack Noir
 Lyrics: |-
     A split in the multiverse
-    A crack in God's will
+    A crack in God’s will
     Can you smell the smoke rising from the ashes?
 
     A fire burns in the distance

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -29,7 +29,9 @@ Contributors:
 Duration: 9:20
 URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
-Previous Productions:
+Referenced Tracks:
+- The Epic of Jack Noir
+Sampled Tracks:
 - The Epic of Jack Noir
 Lyrics: |-
     A split in the multiverse

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -31,6 +31,17 @@ URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
 Referenced Tracks:
 - The Epic of Jack Noir
+- Dominus Decem Propugnator
+- Oppa Toby Style
+- Liquid Negrocity
+- The Ballad of Jack Noir
+- Double Midnight
+# - I'm a Member of the Midnight Crew
+- The Dirty Snake's Coup
+- I'm Sorry
+Sampled Tracks:
+- Black
+- I'm a Member of the Midnight Crew
 Lyrics: |-
     A split in the multiverse
     A crack in God’s will

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -15,7 +15,7 @@ Art Tags:
 - Jack Noir (Desynced)
 - Lord Noir (Desynced)
 Commentary: |-
-    <i>Witch's Cadence:</i> ([SoundCloud description](https://soundcloud.com/witchs-cadence/cognitive-coalescence), excerpt, 7/24/2024)
+    <i>Witch's Cadence:</i> ([Bandcamp about blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut))
 
     [[track:the-epic-of-jack-noir|"Epic of Jack Noir"]] was a song I made for the album [[album:noirscape]]. It is a 9 minute behemoth of a song, that I spent lots of time and effort on to make it just right. However, I have a couple issues with the version featured on both official releases of the album, those being
 

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -3,8 +3,14 @@ Date: May 27, 2025
 Artists:
 - Witch's Cadence
 Cover Artists:
-- dizzims.
+- artist:dizzims
+Wallpaper Artists:
+- artist:dizzims
 Cover Art File Extension: jpg
+Wallpaper File Extension: png
+Wallpaper Style: |-
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
 URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
 Color: '#cc6c71'

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -42,6 +42,60 @@ Referenced Tracks:
 - The Epic of Jack Noir
 Sampled Tracks:
 - The Epic of Jack Noir
+Lyrics: |-
+    A split in the multiverse
+    A crack in God's will
+    Can you smell the smoke rising from the ashes?
+
+    A fire burns in the distance
+    Hell is coming
+    They are coming
+    Heed these words, Jack
+
+    The gates of heaven have been opened
+    Hear the call of the angels
+    And reach out and claim what is yours
+    The fate of those you love depends on it
+
+    Make her a member of the Midnight Crew...
+
+    Make her- Make her- Make her- Make her-
+    Make her a member of the Midnight Crew!
+
+    Make her a member of- Make her a member of-
+    Make- Make- Make her- Make her- Midnight Crew!
+    Make her a member of- Make her a member of-
+    Make- Make- Make her- Make her- Midnight Crew!
+
+    Make- Make make make- Make her a member of the-
+    Make- Make make make- Make her a member of the-
+    Make- Make make make- Make her a member of the-
+    Mid- Mid- Midnight Crew!
+    Make- Make make make- Make her a member of the-
+    Make- Make make make- Make her a member of the-
+    Make- Make make make- Make her a member of the-
+    Mid- Mid- Midnight Crew!
+
+    Make her a member of- Make her a member of-
+    Mid- Mid- Midnight Crew! Mid- Mid- Midnight Crew!
+    Make her a member of- Make her a member of-
+    Make- Make- Make her- Make her- Mid- Mid- Midnight Crew!
+    Make her a member of- Make her a member of-
+    Make- Make- Make her- Make her- Mid- Mid- Midnight Crew!
+    Make her a member of- Make her a member of-
+    Make- Make- Make her- Make her- Mid- Mid- Midnight Crew!
+
+    Make her a member of the-
+    Make her a- Make her a-
+    Make her a member of the- Make her a member of the-
+    Make- Make- Make her- Make her-
+    Make her a member of the-
+    Make her a- Make her a-
+    Make her a member of the- Make her a member of the-
+    Make- Make- Make her- Make her-
+
+    Make her- Make her- Make her- Make her-
+    RRROOOOOOOOOOOOOOOOOOOOOAR
 Crediting Sources: |-
     <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
 

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -102,7 +102,7 @@ Lyrics: |-
 
     Make her- Make her- Make her- Make her-
     RRROOOOOOOOOOOOOOOOOOOOOAR
-Crediting Sources: |-
+Referencing Sources: |-
     <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
 
     References [[track:liquid-negrocity|"Liquid Negrocity"]], [[track:the-ballad-of-jack-noir|"Ballad of Jack Noir"]] and [[track:double-midnight|"Double Midnight]] by [[artist:toby-fox]] and [[track:the-dirty-snakes-coup|"The Dirty Snake's Coup"]] and [[track:im-sorry|"I'm Sorry"]] by Witch's Cadence.

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -33,12 +33,15 @@ Crediting Sources: |-
     Track art by [[artist:dizzims|Dizzims.]]
 ---
 Track: Epic of Jack Noir (Director's Cut)
-Main Release: The Epic of Jack Noir
 Contributors:
 - Witch's Cadence (mastering)
 Duration: 9:20
 URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
+Referenced Tracks:
+- The Epic of Jack Noir
+Sampled Tracks:
+- The Epic of Jack Noir
 Crediting Sources: |-
     <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
 

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -23,79 +23,12 @@ Art Tags:
 - Lord Noir (Desynced)
 ---
 Track: Epic of Jack Noir (Director's Cut)
-Count In Artist Totals: false
+Main Release: The Epic of Jack Noir # Noirscape
 Contributors:
 - Witch's Cadence (mastering)
 Duration: 9:20
 URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
-Referenced Tracks:
-- The Epic of Jack Noir
-- Dominus Decem Propugnator
-- Oppa Toby Style
-- Liquid Negrocity
-- The Ballad of Jack Noir
-- Double Midnight
-# - I'm a Member of the Midnight Crew
-- The Dirty Snake's Coup
-- I'm Sorry
-Sampled Tracks:
-- Black
-- I'm a Member of the Midnight Crew
-Lyrics: |-
-    A split in the multiverse
-    A crack in God’s will
-    Can you smell the smoke rising from the ashes?
-
-    A fire burns in the distance
-    Hell is coming
-    They are coming
-    Heed these words, Jack
-
-    The gates of heaven have been opened
-    Hear the call of the angels
-    And reach out and claim what is yours
-    The fate of those you love depends on it
-
-    Make her a member of the Midnight Crew...
-
-    Make her- Make her- Make her- Make her-
-    Make her a member of the Midnight Crew!
-
-    Make her a member of- Make her a member of-
-    Make- Make- Make her- Make her- Midnight Crew!
-    Make her a member of- Make her a member of-
-    Make- Make- Make her- Make her- Midnight Crew!
-
-    Make- Make make make- Make her a member of the-
-    Make- Make make make- Make her a member of the-
-    Make- Make make make- Make her a member of the-
-    Mid- Mid- Midnight Crew!
-    Make- Make make make- Make her a member of the-
-    Make- Make make make- Make her a member of the-
-    Make- Make make make- Make her a member of the-
-    Mid- Mid- Midnight Crew!
-
-    Make her a member of- Make her a member of-
-    Mid- Mid- Midnight Crew! Mid- Mid- Midnight Crew!
-    Make her a member of- Make her a member of-
-    Make- Make- Make her- Make her- Mid- Mid- Midnight Crew!
-    Make her a member of- Make her a member of-
-    Make- Make- Make her- Make her- Mid- Mid- Midnight Crew!
-    Make her a member of- Make her a member of-
-    Make- Make- Make her- Make her- Mid- Mid- Midnight Crew!
-
-    Make her a member of the-
-    Make her a- Make her a-
-    Make her a member of the- Make her a member of the-
-    Make- Make- Make her- Make her-
-    Make her a member of the-
-    Make her a- Make her a-
-    Make her a member of the- Make her a member of the-
-    Make- Make- Make her- Make her-
-
-    Make her- Make her- Make her- Make her-
-    RRROOOOOOOOOOOOOOOOOOOOOAR
 Commentary: |-
     <i>Witch's Cadence:</i> ([Bandcamp about blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut))
 

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -1,4 +1,5 @@
 Album: Epic of Jack Noir (Director's Cut)
+Style: single
 Date: May 27, 2025
 Artists:
 - Witch's Cadence
@@ -20,23 +21,6 @@ Art Tags:
 - Jack Noir
 - Jack Noir (Desynced)
 - Lord Noir (Desynced)
-Commentary: |-
-    <i>Witch's Cadence:</i> ([Bandcamp about blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut))
-
-    [[track:the-epic-of-jack-noir|"Epic of Jack Noir"]] was a song I made for the album [[album:noirscape]]. It is a 9 minute behemoth of a song, that I spent lots of time and effort on to make it just right. However, I have a couple issues with the version featured on both official releases of the album, those being
-
-    A) Multiple mistakes that were never fixed in the final master<br>
-    B) I personally am not really a fan of the mastering that was done on this track specifically
-
-    Now, first thing's first, I want to make a couple things clear. I hold no grudges with the person who did the mastering initially, and I think they are likely much more knowledgeable on the topic than I am, and yet, even when I first heard the original master it has always sounded too compressed and lacking in a certain clarity that I wanted for the song. This "new" version of the master that I am presenting to you now, is actually a version I did while waiting for the official master. It also fixes a couple of mistakes that I fixed and sent to the person mastering for the album, but wasn't included in the final version.
-
-    Considering all of these things, I also want to make it clear that I don't see either one as the "True" version of this song. If you like the other one better, than please by all means, continue to enjoy it! I however could not rest leaving my personal vision for it unseen.
-
-    This is all I have to say, thank you for reading my spiel.
-Crediting Sources: |-
-    <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
-
-    Track art by [[artist:dizzims|Dizzims.]]
 ---
 Track: Epic of Jack Noir (Director's Cut)
 Count In Artist Totals: false
@@ -103,6 +87,23 @@ Lyrics: |-
 
     Make her- Make her- Make her- Make her-
     RRROOOOOOOOOOOOOOOOOOOOOAR
+Commentary: |-
+    <i>Witch's Cadence:</i> ([Bandcamp about blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut))
+
+    [[track:the-epic-of-jack-noir|"Epic of Jack Noir"]] was a song I made for the album [[album:noirscape]]. It is a 9 minute behemoth of a song, that I spent lots of time and effort on to make it just right. However, I have a couple issues with the version featured on both official releases of the album, those being
+
+    A) Multiple mistakes that were never fixed in the final master<br>
+    B) I personally am not really a fan of the mastering that was done on this track specifically
+
+    Now, first thing's first, I want to make a couple things clear. I hold no grudges with the person who did the mastering initially, and I think they are likely much more knowledgeable on the topic than I am, and yet, even when I first heard the original master it has always sounded too compressed and lacking in a certain clarity that I wanted for the song. This "new" version of the master that I am presenting to you now, is actually a version I did while waiting for the official master. It also fixes a couple of mistakes that I fixed and sent to the person mastering for the album, but wasn't included in the final version.
+
+    Considering all of these things, I also want to make it clear that I don't see either one as the "True" version of this song. If you like the other one better, than please by all means, continue to enjoy it! I however could not rest leaving my personal vision for it unseen.
+
+    This is all I have to say, thank you for reading my spiel.
+Crediting Sources: |-
+    <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
+
+    Track art by [[artist:dizzims|Dizzims.]]
 Referencing Sources: |-
     <i>Witch's Cadence:</i> ([Bandcamp credits blurb](https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut), excerpt)
 

--- a/album/epic-of-jack-noir-directors-cut.yaml
+++ b/album/epic-of-jack-noir-directors-cut.yaml
@@ -13,7 +13,7 @@ Wallpaper Style: |-
     image-rendering: crisp-edges;
 URLs:
 - https://witchscadence.bandcamp.com/track/epic-of-jack-noir-directors-cut
-Color: '#cc6c71'
+Color: '#ff3b40'
 Groups:
 - Fandom
 Art Tags:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -134,6 +134,7 @@ Content: |-
     - added [[album:surprise-were-back]] by [[artist:sean-flare-gorter]]! (thanks, Surge, Lan!)
     - added [[album:mauk-is-reimagining-karkat-vantas]] by [[group:maukustus]]! (thanks, Jebb!)
     - added [[album:the-home-stretch]] by [[artist:tycoon]]! (thanks, Jebb!)
+    - added [[album:epic-of-jack-noir-directors-cut]] by [[artist:witchs-cadence]] (thanks, Lilith!)
     - added [[album:cascade]] by [[group:tensei]]! (thanks, ruby, Jebb, Lan!)
     - added [[album:de-novo]] by [[artist:viixyz]]! (thanks, Jebb, Lan!)
     - added [[album:hs-bc-a1]] by [[artist:guffy]]! (thanks, <<Guffy:album data, presentation, track references, additional review>>, <<Lan:data review>>, plus <<ruby:track referencing help>>!)


### PR DESCRIPTION
<i>Technically</i> a rerelease? Self-mastered as opposed to final Noirscape (album) mastering, but was mastered before the final album master.

- Merge with: https://github.com/hsmusic/hsmusic-media/pull/139