### PR TITLE
Nintendo Music Week 20: Pokémon Sword and Pokémon Shield

### DIFF
--- a/album/gba-pokemon-unbound-super-music-collection.yaml
+++ b/album/gba-pokemon-unbound-super-music-collection.yaml
@@ -1282,7 +1282,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/battle-max-raid
 - https://www.youtube.com/watch?v=T2zzOvI2zJE
 Referenced Tracks:
-- Max Raid Battle!
+- Battle! (Max Raid Battle)
 ---
 Track: Crater Town (Night)
 Duration: 1:07

--- a/album/gba-pokemon-unbound-super-music-collection.yaml
+++ b/album/gba-pokemon-unbound-super-music-collection.yaml
@@ -1236,7 +1236,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/battle-legendary-birds
 - https://www.youtube.com/watch?v=BSyL7ksO270
 Referenced Tracks:
-- Battle! (Legendary Bird Pokémon)
+- Battle! (The Bird Pokémon of Legend)
 - Battle! Galarian Legendary Birds - Gen 5 Remix
 ---
 Track: Bellin Town (Night)

--- a/album/pokemon-scarlet-violet-super-music-collection.yaml
+++ b/album/pokemon-scarlet-violet-super-music-collection.yaml
@@ -34,6 +34,7 @@ Commentary: |-
     [[track:celestial]] and [[track:celestial-toby-fox|the Toby Fox remix]] are not on this album.
 ---
 Section: Disc 1
+Start Counting From: 1
 Color: '#d5101e'
 ---
 Track: Welcome to Paldea
@@ -523,6 +524,7 @@ Referenced Tracks:
 - 'Fanfare: Evolution (Pokémon Red / Pokémon Blue)'
 ---
 Section: Disc 2
+Start Counting From: 1
 Color: '#bc4cb4'
 ---
 Track: Gym Reception
@@ -900,6 +902,7 @@ Referenced Tracks:
 - Team Star
 ---
 Section: Disc 3
+Start Counting From: 1
 Color: '#d5101e'
 ---
 Track: North Province
@@ -1099,6 +1102,7 @@ Referenced Tracks:
 - Battle! (Nemona)
 ---
 Section: Disc 4
+Start Counting From: 1
 Color: '#bc4cb4'
 ---
 Track: Battle! (Director Clavell)
@@ -1401,6 +1405,7 @@ Referenced Tracks:
 - 'Title Screen: Main Theme (Pokémon Ruby / Pokémon Sapphire)'
 ---
 Section: Disc 5
+Start Counting From: 1
 Color: '#01b5ac'
 ---
 Track: 'The Hidden Treasure of Area Zero: The Teal Mask'
@@ -1759,6 +1764,7 @@ Referenced Tracks:
 - Blueberry Academy
 ---
 Section: Disc 6
+Start Counting From: 1
 Color: '#1494b7'
 ---
 Track: Terarium (Central Plaza)

--- a/album/pokemon-scarlet-violet-super-music-collection.yaml
+++ b/album/pokemon-scarlet-violet-super-music-collection.yaml
@@ -156,6 +156,7 @@ Referenced Tracks:
 - Obtained a Berry! (Pokémon Ruby / Pokémon Sapphire)
 ---
 Track: Obtained an Item!
+Suffix Directory: true
 Duration: 0:04
 Artists:
 - Hitomi Sato (arranger)

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1230,7 +1230,7 @@ URLs:
 Referenced Tracks:
 - Battle! (Legendary Bird Pokémon)
 ---
-Track: Battle! (Legendary Bird Pokémon)
+Track: Battle! (The Bird Pokémon of Legend)
 Duration: 4:19
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1205,7 +1205,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=27GaAUbE8LA
 ---
-Track: You Found a Hint!
+Track: You Found a Clue!
 Duration: 0:04
 Artists:
 - Keita Okamoto

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -802,7 +802,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=VhZuzadFIlY
 Referenced Tracks:
-- Battle! (Final Tournament)
+- Battle! (Finals)
 ---
 Track: The Darkest Day
 Duration: 0:32

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -327,7 +327,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=n-2AXr46JsM
 ---
-Track: Legends of History
+Track: An Old Legend
 Duration: 3:34
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1152,7 +1152,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=Wlz9M18G1zw
 Referenced Tracks:
-- Battle! (King of Bountiful Harvests)
+- Battle! (The King of Bountiful Harvests)
 ---
 Track: Battle! (Calyrex)
 Duration: 3:21
@@ -1161,7 +1161,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=g77AYV2kirs
 Referenced Tracks:
-- Battle! (King of Bountiful Harvests)
+- Battle! (The King of Bountiful Harvests)
 ---
 Track: Dance of Bountiful Harvests
 Duration: 0:09
@@ -1177,7 +1177,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=lhzGAcuTOH8
 Referenced Tracks:
-- Battle! (King of Bountiful Harvests)
+- Battle! (The King of Bountiful Harvests)
 ---
 Track: Crown Shrine
 Duration: 1:56
@@ -1186,7 +1186,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=pnLHmfqhgtY
 Referenced Tracks:
-- Battle! (King of Bountiful Harvests)
+- Battle! (The King of Bountiful Harvests)
 ---
 Track: As One
 Duration: 1:13
@@ -1196,9 +1196,9 @@ URLs:
 - https://www.youtube.com/watch?v=9xXhO2j8A40
 Referenced Tracks:
 - Crown Shrine
-- Battle! (King of Bountiful Harvests)
+- Battle! (The King of Bountiful Harvests)
 ---
-Track: Battle! (King of Bountiful Harvests)
+Track: Battle! (The King of Bountiful Harvests)
 Duration: 2:37
 Artists:
 - Junichi Masuda

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1024,7 +1024,7 @@ Referenced Tracks:
 - Mustard's Theme
 ---
 Track: Obtained an Item...?
-directory: obtained-an-item-but
+Directory: obtained-an-item-but
 Duration: 0:04
 Artists:
 - Keita Okamoto
@@ -1229,7 +1229,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=d-kGPBy4Jtw
 Referenced Tracks:
-- Battle! (Legendary Bird Pokémon)
+- Battle! (The Bird Pokémon of Legend)
 ---
 Track: Battle! (The Bird Pokémon of Legend)
 Duration: 4:19

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -518,7 +518,7 @@ URLs:
 Referenced Tracks:
 - Victory! (Trainer Battle) (Pokémon Red / Pokémon Blue)
 ---
-Track: Gym Mission Cleared!!
+Track: Gym Mission Cleared!
 Duration: 0:04
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -779,7 +779,7 @@ Referenced Tracks:
 - Rose Tower
 - Chairman Rose
 ---
-Track: Final Tournament Begin!
+Track: The Finals Begin
 Duration: 0:29
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -701,7 +701,7 @@ URLs:
 Referenced Tracks:
 - Team Yell Appears!
 ---
-Track: Battle! (Gym Leader Piers)
+Track: Battle! (Gym Leader: Piers)
 Duration: 3:11
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -896,7 +896,7 @@ URLs:
 Referenced Tracks:
 - Decisive Battle! (Champion Leon)
 ---
-Track: To Create a Bright Future
+Track: For a Bright Future
 Duration: 1:16
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -26,6 +26,7 @@ Wallpaper Style: |-
     opacity: 0.45;
 ---
 Section: Disc 1
+Start Counting From: 1
 Color: '#00a2e7'
 ---
 Track: Title Screen
@@ -365,6 +366,7 @@ URLs:
 - https://www.youtube.com/watch?v=-zlaWWRr-vs
 ---
 Section: Disc 2
+Start Counting From: 1
 Color: '#dd005d'
 ---
 Track: Route 3
@@ -683,6 +685,7 @@ URLs:
 - https://www.youtube.com/watch?v=D1-Eg5bMZp8
 ---
 Section: Disc 3
+Start Counting From: 1
 Color: '#fff001'
 ---
 Track: Spikemuth
@@ -959,6 +962,7 @@ Referenced Tracks:
 - In the Fog
 ---
 Section: Disc 4
+Start Counting From: 1
 Color: '#38ad69'
 ---
 Track: Isle of Armor

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -159,7 +159,7 @@ URLs:
 Referenced Tracks:
 - Pokémon Center (Pokémon Red / Pokémon Blue)
 ---
-Track: Recovery
+Track: Pokémon Healed
 Suffix Directory: true
 Duration: 0:05
 Artists:

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -760,7 +760,7 @@ URLs:
 Referenced Tracks:
 - Chairman Rose
 ---
-Track: Arrival at the Top
+Track: Reaching the Top
 Duration: 2:24
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -652,7 +652,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=MK-1dlZ2LRU
 Referenced Tracks:
-- Truth of the Ruins
+- The Truth Behind the Mural
 ---
 Track: The Truth Behind the Mural
 Duration: 4:52

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1221,7 +1221,7 @@ URLs:
 Referenced Tracks:
 - Battle! (Regirock/Regice/Registeel) (Pokémon Ruby / Pokémon Sapphire)
 ---
-Track: Gather at the Dyna Tree
+Track: Gathering at the Tree
 Duration: 1:06
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1212,7 +1212,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=F_cQmGvvOD8
 ---
-Track: Battle! (Legendary Giants)
+Track: Battle! (The Giant of Legend)
 Duration: 2:30
 Artists:
 - Hitomi Sato

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -187,7 +187,8 @@ URLs:
 Referenced Tracks:
 - Victory! (Wild Pokémon) (Pokémon Red / Pokémon Blue)
 ---
-Track: Lead the Way
+Track: Guide
+Suffix Directory: true
 Duration: 1:02
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1024,6 +1024,7 @@ Referenced Tracks:
 - Mustard's Theme
 ---
 Track: Obtained an Item...?
+directory: obtained-an-item-but
 Duration: 0:04
 Artists:
 - Keita Okamoto

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -867,7 +867,7 @@ Referenced Tracks:
 - Battle! (Eternatus)
 - In the Fog
 ---
-Track: Caught an Eternatus
+Track: You Caught Eternatus!
 Duration: 0:28
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1188,7 +1188,7 @@ URLs:
 Referenced Tracks:
 - Battle! (King of Bountiful Harvests)
 ---
-Track: Unity of Rider and Horse
+Track: As One
 Duration: 1:13
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -91,7 +91,6 @@ URLs:
 - https://www.youtube.com/watch?v=tUzpeApK0k0
 ---
 Track: Time for a Breather
-Suffix Directory: true
 Duration: 0:06
 Artists:
 - Minako Adachi
@@ -337,6 +336,7 @@ URLs:
 - https://www.youtube.com/watch?v=Aj0PmmA0PSk
 ---
 Track: Boutique
+Suffix Directory: true
 Duration: 2:09
 Artists:
 - Minako Adachi
@@ -681,6 +681,7 @@ URLs:
 - https://www.youtube.com/watch?v=v1WtWJYwcdY
 ---
 Track: Hair Salon
+Suffix Directory: true
 Duration: 1:54
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -125,7 +125,7 @@ URLs:
 Referenced Tracks:
 - Level Up! (Pokémon Red / Pokémon Blue)
 ---
-Track: Pokémon Laboratory
+Track: Pokémon Research Lab
 Duration: 1:59
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -197,7 +197,7 @@ URLs:
 Referenced Tracks:
 - Guide (Pokémon Red / Pokémon Blue)
 ---
-Track: Wild Area Station
+Track: At the Train Station
 Duration: 2:52
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1145,7 +1145,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=F4FMyZ0Td5Y
 ---
-Track: King of Bountiful Harvests
+Track: The King of Bountiful Harvests
 Duration: 1:36
 Artists:
 - Hitomi Sato

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -383,7 +383,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=JbAjbT_YyUc
 Referenced Tracks:
-- track:battle-trainer-battle-pokemon-sword-shield
+- track:battle-trainer-pokemon-sword-shield
 ---
 Track: Battle! (Trainer)
 Suffix Directory: true

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -820,7 +820,7 @@ URLs:
 Referenced Tracks:
 - In the Fog
 ---
-Track: Abnormal Situation
+Track: A Bizarre Situation
 Duration: 1:59
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -949,7 +949,7 @@ Commentary: |- ##https://www.pokemon.com/us/pokemon-news/a-special-letter-and-so
     <i>ruby:</i> (wiki editor, 4/3/2024)
     It doesn't seem to be an intentional reference, but people pointed out this song has a similar melody to [[track:a-baby-legend]].
 ---
-Track: Battle! (Zacian / Zamazenta)
+Track: Battle! (Zacian/Zamazenta)
 Duration: 4:19
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -804,7 +804,7 @@ URLs:
 Referenced Tracks:
 - Battle! (Final Tournament)
 ---
-Track: Darkest Day
+Track: The Darkest Day
 Duration: 0:32
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -562,7 +562,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=NRUxNUlaVN4
 ---
-Track: Poké Job
+Track: Poké Jobs
 Duration: 4:01
 Artists:
 - Go Ichinose (arranger)

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1023,7 +1023,7 @@ URLs:
 Referenced Tracks:
 - Mustard's Theme
 ---
-Track: Obtained an Item, But...
+Track: Obtained an Item...?
 Duration: 0:04
 Artists:
 - Keita Okamoto

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -654,7 +654,7 @@ URLs:
 Referenced Tracks:
 - Truth of the Ruins
 ---
-Track: Truth of the Ruins
+Track: The Truth Behind the Mural
 Duration: 4:52
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -848,7 +848,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=6ocbwkxaFuI
 ---
-Track: Infinite Power
+Track: Eternal Power
 Duration: 2:42
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -311,7 +311,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=jwue8IVikMc
 ---
-Track: Stadium
+Track: At the Stadium
 Duration: 1:46
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -984,7 +984,7 @@ URLs:
 Referenced Tracks:
 - Krazy for Klara
 ---
-Track: Super Avery
+Track: The Amazing Avery
 Duration: 1:26
 Artists:
 - Hitomi Sato
@@ -998,7 +998,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=Gs0Lj1nsJCE
 Referenced Tracks:
-- Super Avery
+- The Amazing Avery
 ---
 Track: Master Dojo
 Duration: 1:53

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1138,7 +1138,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=v7Rg7dyb6zY
 ---
-Track: A Legend! A Legend of Legends!
+Track: Legends of Legendary Pokémon
 Duration: 0:09
 Artists:
 - Hitomi Sato

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -507,7 +507,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=I2S8DBx_PeU
 Referenced Tracks:
-- track:battle-trainer-battle-pokemon-sword-shield
+- track:battle-trainer-pokemon-sword-shield
 ---
 Track: Victory! (Gym Trainer)
 Duration: 0:37

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -645,7 +645,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=d0FE9PYLWW8
 ---
-Track: Crumbling Ruins
+Track: The Ancient Mural Crumbles
 Duration: 0:28
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -82,7 +82,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=tUzpeApK0k0
 ---
-Track: Take a Break
+Track: Time for a Breather
 Suffix Directory: true
 Duration: 0:06
 Artists:

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -385,7 +385,7 @@ URLs:
 Referenced Tracks:
 - track:battle-trainer-battle-pokemon-sword-shield
 ---
-Track: Battle! (Trainer Battle)
+Track: Battle! (Trainer)
 Suffix Directory: true
 Duration: 3:08
 Artists:
@@ -395,7 +395,7 @@ URLs:
 Referenced Tracks:
 - Title Screen (Pokémon Red / Pokémon Blue)
 ---
-Track: Victory! (Trainer Battle)
+Track: Victory! (Trainer)
 Suffix Directory: true
 Duration: 0:33
 Artists:

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1121,7 +1121,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=v0ly6leTwVk
 Referenced Tracks:
-- Max Raid Battle!
+- Battle! (Max Raid Battle)
 ---
 Track: Battle! (Dynamax Adventure)
 Duration: 3:05
@@ -1130,7 +1130,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=m2MlMwJWdxw
 Referenced Tracks:
-- Max Raid Battle!
+- Battle! (Max Raid Battle)
 ---
 Track: Freezington
 Duration: 3:00

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -701,7 +701,7 @@ URLs:
 Referenced Tracks:
 - Team Yell Appears!
 ---
-Track: Battle! (Gym Leader: Piers)
+Track: 'Battle! (Gym Leader: Piers)'
 Duration: 3:11
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -234,7 +234,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=towrVDZT7Kk
 ---
-Track: 'Curry: Koffing Class'
+Track: Curry (Koffing Class)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -243,7 +243,7 @@ URLs:
 Referenced Tracks:
 - Let's Make Curry!
 ---
-Track: 'Curry: Wobbuffet Class'
+Track: Curry (Wobbuffet Class)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -252,7 +252,7 @@ URLs:
 Referenced Tracks:
 - Let's Make Curry!
 ---
-Track: 'Curry: Milcery Class'
+Track: Curry (Milcery Class)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -261,7 +261,7 @@ URLs:
 Referenced Tracks:
 - Let's Make Curry!
 ---
-Track: 'Curry: Copperajah Class'
+Track: Curry (Copperajah Class)
 Duration: 0:07
 Artists:
 - Go Ichinose
@@ -270,7 +270,7 @@ URLs:
 Referenced Tracks:
 - Let's Make Curry!
 ---
-Track: 'Curry: Charizard Class'
+Track: Curry (Charizard Class)
 Duration: 0:08
 Artists:
 - Go Ichinose
@@ -279,7 +279,7 @@ URLs:
 Referenced Tracks:
 - Let's Make Curry!
 ---
-Track: 'Curry Dex: Do Your Best!'
+Track: Curry Dex—Keep Going!
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -288,7 +288,7 @@ URLs:
 Referenced Tracks:
 - Let's Make Curry!
 ---
-Track: 'Curry Dex: Completed!'
+Track: Curry Dex—Complete!
 Duration: 0:07
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -786,7 +786,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=9fj3jKL8N34
 ---
-Track: Battle! (Final Tournament)
+Track: Battle! (Finals)
 Duration: 4:33
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1076,7 +1076,7 @@ URLs:
 Referenced Tracks:
 - Battle! (Serious Mustard)
 ---
-Track: Kubfu and Victory
+Track: Victory with Kubfu
 Duration: 0:26
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -1170,7 +1170,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=eHcoVQwAb48
 ---
-Track: Battle! (Glastrier / Spectrier)
+Track: Battle! (Glastrier/Spectrier)
 Duration: 2:12
 Artists:
 - Junichi Masuda

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -213,7 +213,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=cH2c9XM5zeY
 ---
-Track: Max Raid Battle!
+Track: Battle! (Max Raid Battle)
 Duration: 2:22
 Artists:
 - Go Ichinose

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -613,7 +613,7 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=v1WtWJYwcdY
 ---
-Track: Salon
+Track: Hair Salon
 Duration: 1:54
 Artists:
 - Minako Adachi

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -35,6 +35,7 @@ Duration: 1:25
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/759f2f39-3ecd-4d76-8fd2-5beafa787298
 - https://www.youtube.com/watch?v=BJ3HOz8OWOE
 Referenced Tracks:
 - Hall of Fame (Pokémon Red / Pokémon Blue)
@@ -45,6 +46,7 @@ Duration: 1:54
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/8b05319c-b2b3-4d91-a7bf-4333ad2f0e68
 - https://www.youtube.com/watch?v=FxotlznPMFg
 ---
 Track: Postwick
@@ -52,6 +54,7 @@ Duration: 3:25
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/5734e254-6da4-4a5f-8196-50467f5399e9
 - https://www.youtube.com/watch?v=_UjfJAw51vY
 ---
 Track: Hop's Theme
@@ -59,6 +62,7 @@ Duration: 2:36
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/488abc24-f3d8-45f7-bc54-8b81b251d4d1
 - https://www.youtube.com/watch?v=TkOcfawy8vU
 ---
 Track: Route 1
@@ -67,6 +71,7 @@ Duration: 1:17
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/6d563b34-0263-47d3-b456-562a80009ae1
 - https://www.youtube.com/watch?v=F_oKi-e3Dv0
 ---
 Track: Wedgehurst
@@ -74,6 +79,7 @@ Duration: 2:57
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/1602e2d8-6efa-48e1-99b5-e94090e92364
 - https://www.youtube.com/watch?v=F_oKi-e3Dv0
 ---
 Track: Let's Have a Champion Time!
@@ -81,6 +87,7 @@ Duration: 1:27
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d22ce1dd-fc1b-4db3-9827-ad91c41f0b80
 - https://www.youtube.com/watch?v=tUzpeApK0k0
 ---
 Track: Time for a Breather
@@ -89,6 +96,7 @@ Duration: 0:06
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/32ff3804-24c9-44c7-88da-0497e6c5665f
 - https://www.youtube.com/watch?v=yMXa_2W6MSU
 Referenced Tracks:
 - Pokémon Healed (Pokémon Red / Pokémon Blue)
@@ -98,6 +106,7 @@ Duration: 3:18
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/7f972a69-42be-4ef7-8738-4b6407f121b6
 - https://www.youtube.com/watch?v=qvMoWhyBUTk
 Referenced Tracks:
 - Hop's Theme
@@ -107,6 +116,7 @@ Duration: 4:04
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/67eb7952-2e12-43e1-ac7a-c160fcf454ee
 - https://www.youtube.com/watch?v=4puWpbtrn1U
 ---
 Track: In the Fog
@@ -114,6 +124,7 @@ Duration: 1:45
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/4980e488-7297-4483-9155-385f6ab5f34f
 - https://www.youtube.com/watch?v=FidGR2tps-o
 ---
 Track: Obtained an Item!
@@ -131,6 +142,7 @@ Duration: 1:59
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/290334f2-c018-4b07-b57e-223db7e4aad9
 - https://www.youtube.com/watch?v=AkQcpMxhyh0
 ---
 Track: Sonia's Theme
@@ -138,6 +150,7 @@ Duration: 2:08
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a8b2b9d7-d4e5-4121-a162-c4232aacee57
 - https://www.youtube.com/watch?v=sRHXOydAFxs
 ---
 Track: Obtained a Key Item!
@@ -156,6 +169,7 @@ Duration: 2:17
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/e402f745-d02f-4d60-96fe-3ddf86c62c3d
 - https://www.youtube.com/watch?v=AIorxLocNz0
 Referenced Tracks:
 - Pokémon Center (Pokémon Red / Pokémon Blue)
@@ -166,6 +180,7 @@ Duration: 0:05
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/92c969ec-54b8-4202-9570-1aa17623c821
 - https://www.youtube.com/watch?v=BB4Cy0kkQWg
 Referenced Tracks:
 - Pokémon Healed (Pokémon Red / Pokémon Blue)
@@ -176,6 +191,7 @@ Duration: 2:22
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2eb9792b-e57b-4e65-995c-3270bb891d81
 - https://www.youtube.com/watch?v=lV30h2U-k-4
 ---
 Track: Victory! (Wild Pokémon)
@@ -184,6 +200,7 @@ Duration: 0:31
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/3823fa8e-717d-4a38-8505-fa852635af28
 - https://www.youtube.com/watch?v=Pn59YXZLuBg
 Referenced Tracks:
 - Victory! (Wild Pokémon) (Pokémon Red / Pokémon Blue)
@@ -194,6 +211,7 @@ Duration: 1:02
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d91eff81-b29c-4332-ae3d-a7418486fe8f
 - https://www.youtube.com/watch?v=VDdhcuy09n0
 Referenced Tracks:
 - Guide (Pokémon Red / Pokémon Blue)
@@ -203,6 +221,7 @@ Duration: 2:52
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c40b2628-f044-4ddc-a81b-6e2cdaa723ca
 - https://www.youtube.com/watch?v=1iq50ZJ05Rk
 Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
@@ -212,6 +231,7 @@ Duration: 3:58
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b0270e01-b337-43a8-9275-4388e51959db
 - https://www.youtube.com/watch?v=cH2c9XM5zeY
 ---
 Track: Battle! (Max Raid Battle)
@@ -219,6 +239,7 @@ Duration: 2:22
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9eb27982-d5ae-4800-8c08-9a8acf600472
 - https://www.youtube.com/watch?v=n2ym36JHmjA
 ---
 Track: Victory! (Dynamax Pokémon)
@@ -226,6 +247,7 @@ Duration: 0:37
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/dcc68f78-27f2-4324-8fb6-e28acd088dc3
 - https://www.youtube.com/watch?v=d0lEIjeb-WI
 ---
 Track: Let's Make Curry!
@@ -233,6 +255,7 @@ Duration: 1:56
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/f312903f-d3a1-42de-b49f-1898f681e420
 - https://www.youtube.com/watch?v=towrVDZT7Kk
 ---
 Track: Curry (Koffing Class)
@@ -240,6 +263,7 @@ Duration: 0:05
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/fd6f4441-7603-4ffa-9d59-07ed4704106c
 - https://www.youtube.com/watch?v=Q2l8a_FH6wg
 Referenced Tracks:
 - Let's Make Curry!
@@ -249,6 +273,7 @@ Duration: 0:05
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d6f27966-6201-4d34-8aa9-e5cea9fb144f
 - https://www.youtube.com/watch?v=Dqidq5WpGQc
 Referenced Tracks:
 - Let's Make Curry!
@@ -258,6 +283,7 @@ Duration: 0:05
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/1a436746-0a58-4950-a4ec-7d0aa67e4ede
 - https://www.youtube.com/watch?v=0P6lVwALFOY
 Referenced Tracks:
 - Let's Make Curry!
@@ -267,6 +293,7 @@ Duration: 0:07
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ab9f310a-f13f-4e8f-9bdc-a6fc3274af64
 - https://www.youtube.com/watch?v=Q2l8a_FH6wg
 Referenced Tracks:
 - Let's Make Curry!
@@ -276,6 +303,7 @@ Duration: 0:08
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/369a4b75-9d25-4f7c-afb1-1d3bd6b3a98f
 - https://www.youtube.com/watch?v=3RR1-iHqx40
 Referenced Tracks:
 - Let's Make Curry!
@@ -285,6 +313,7 @@ Duration: 0:05
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c785cde2-224d-4e07-b359-7f1cd7dc6058
 - https://www.youtube.com/watch?v=Q2l8a_FH6wg
 Referenced Tracks:
 - Let's Make Curry!
@@ -294,6 +323,7 @@ Duration: 0:07
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2a7408ae-7c9b-4155-b1b5-9d9ec0b5c882
 - https://www.youtube.com/watch?v=-Gp1I7MyS1Y
 Referenced Tracks:
 - Let's Make Curry!
@@ -303,6 +333,7 @@ Duration: 3:13
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ea11a1ea-0900-4ed8-b74e-b827a9090afc
 - https://www.youtube.com/watch?v=Aj0PmmA0PSk
 ---
 Track: Boutique
@@ -310,6 +341,7 @@ Duration: 2:09
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9c2be362-26fb-4826-8dcd-094aa66c409f
 - https://www.youtube.com/watch?v=jwue8IVikMc
 ---
 Track: At the Stadium
@@ -317,6 +349,7 @@ Duration: 1:46
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/100e32a2-e699-457f-ae42-1e0015e23534
 - https://www.youtube.com/watch?v=cgVnRMjfhL4
 Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
@@ -326,6 +359,7 @@ Duration: 2:26
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/5917eef1-976b-428d-ba42-ab2e9430c029
 - https://www.youtube.com/watch?v=n-2AXr46JsM
 ---
 Track: An Old Legend
@@ -333,6 +367,7 @@ Duration: 3:34
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/dd94f490-df2c-4b16-ac3d-2bca92ebbc03
 - https://www.youtube.com/watch?v=HXWF-tJaxz0
 ---
 Track: Team Yell Appears!
@@ -340,6 +375,7 @@ Duration: 2:49
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/05ff4603-4ec9-419f-bf25-f936e2c9a0ad
 - https://www.youtube.com/watch?v=-BDOBGLaVSs
 ---
 Track: Marnie's Theme
@@ -347,6 +383,7 @@ Duration: 2:35
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/7899082d-5dff-449b-8a6b-0e1fd0f3bc3f
 - https://www.youtube.com/watch?v=lpgK0k0TkSs
 ---
 Track: Gym Challenge Opening Ceremony
@@ -354,6 +391,7 @@ Duration: 1:04
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a1ead8e2-8cb1-4827-bc72-dd1f4d607126
 - https://www.youtube.com/watch?v=WrIniyktAPY
 Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
@@ -363,6 +401,7 @@ Duration: 1:50
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ad8e6c51-9051-4b9b-afc6-98d39c6d29af
 - https://www.youtube.com/watch?v=-zlaWWRr-vs
 ---
 Section: Disc 2
@@ -375,6 +414,7 @@ Duration: 2:57
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c402fd8a-d710-47bb-8cb4-e3b0fa88dc1a
 - https://www.youtube.com/watch?v=6oYY6ZfJ_KE
 ---
 Track: Trainers' Eyes Meet (Trainer)
@@ -383,6 +423,7 @@ Duration: 0:18
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/030479fb-4148-41d4-b948-22c16f94adc5
 - https://www.youtube.com/watch?v=JbAjbT_YyUc
 Referenced Tracks:
 - track:battle-trainer-pokemon-sword-shield
@@ -393,6 +434,7 @@ Duration: 3:08
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2fc0f3b8-21ff-45e0-acdb-ba8a58775bfe
 - https://www.youtube.com/watch?v=a3yUcFCVZPc
 Referenced Tracks:
 - Title Screen (Pokémon Red / Pokémon Blue)
@@ -403,6 +445,7 @@ Duration: 0:33
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/93a72d82-20e5-4ac9-951c-5b11c9a5c423
 - https://www.youtube.com/watch?v=a3yUcFCVZPc
 Referenced Tracks:
 - Victory! (Trainer Battle) (Pokémon Red / Pokémon Blue)
@@ -413,6 +456,7 @@ Duration: 0:18
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/5237ff4b-5aeb-4c0e-8000-f24526e966e3
 - https://www.youtube.com/watch?v=JbAjbT_YyUc
 Referenced Tracks:
 - A Trainer Appears (Girl Version) (Pokémon Red / Pokémon Blue)
@@ -423,6 +467,7 @@ Duration: 0:59
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c3008a4d-ffcb-41dd-a986-6520fca50028
 - https://www.youtube.com/watch?v=rOMQT5dVeTY
 Referenced Tracks:
 - Evolution (Pokémon Red / Pokémon Blue)
@@ -434,6 +479,7 @@ Duration: 0:59
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/fbe941c6-376f-4df0-8a6f-5da4d7072c1b
 - https://www.youtube.com/watch?v=rdbOxYOcWZI
 Referenced Tracks:
 - Evolution (Pokémon Red / Pokémon Blue)
@@ -454,6 +500,7 @@ Duration: 2:27
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ea375b50-af89-4f10-9105-e0c0d25ea6f5
 - https://www.youtube.com/watch?v=Nu4bZ6RaNMY
 ---
 Track: Trainers' Eyes Meet (Worker)
@@ -461,6 +508,7 @@ Duration: 0:27
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d9e33a5e-0aac-4e9c-a245-68fb2285524b
 - https://www.youtube.com/watch?v=4Dy_QA4qrg4
 ---
 Track: Bede's Theme
@@ -468,6 +516,7 @@ Duration: 1:41
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/08349dc3-7ab3-4267-a162-c0448d35c369
 - https://www.youtube.com/watch?v=w_3uePaatFo
 ---
 Track: Battle! (Bede)
@@ -475,6 +524,7 @@ Duration: 3:01
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/09a3285b-a1f7-44fe-a405-8404fd2303ba
 - https://www.youtube.com/watch?v=F4PTKblZ3uc
 Referenced Tracks:
 - Bede's Theme
@@ -484,6 +534,7 @@ Duration: 1:04
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b73c2030-5eaa-49f0-b704-cbf241995993
 - https://www.youtube.com/watch?v=wVR-HijcJwA
 ---
 Track: Turffield
@@ -491,6 +542,7 @@ Duration: 2:56
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/8a1f1666-047e-43ab-bf77-807174cd2bc2
 - https://www.youtube.com/watch?v=fvF_FCIj2KA
 ---
 Track: Gym Mission!
@@ -498,6 +550,7 @@ Duration: 1:40
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a66a8d62-b5bc-4817-8974-de4bb1cabfc7
 - https://www.youtube.com/watch?v=xK81WBgcvfQ
 Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
@@ -507,6 +560,7 @@ Duration: 0:19
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/fad982d7-5bc6-4f2e-a6bc-1b4d82fe2e25
 - https://www.youtube.com/watch?v=I2S8DBx_PeU
 Referenced Tracks:
 - track:battle-trainer-pokemon-sword-shield
@@ -516,6 +570,7 @@ Duration: 0:37
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/eef9aaa2-2e9b-4c91-b173-40905c262e1d
 - https://www.youtube.com/watch?v=Y3hp5XGXG5M
 Referenced Tracks:
 - Victory! (Trainer Battle) (Pokémon Red / Pokémon Blue)
@@ -525,6 +580,7 @@ Duration: 0:04
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9e2b7709-1ea1-4eba-9882-3e693c7aadf0
 - https://www.youtube.com/watch?v=9CAEsGmvsgE
 Referenced Tracks:
 - Gym Mission!
@@ -535,6 +591,7 @@ Duration: 5:14
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/af153a7d-0f60-40ca-823d-840b5f0117e5
 - https://www.youtube.com/watch?v=JJJZ5s1ddoI
 ---
 Track: Victory! (Gym Leader)
@@ -543,6 +600,7 @@ Duration: 0:45
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/99ccd4ed-63c4-4395-ae08-d99e93bd6bc3
 - https://www.youtube.com/watch?v=etOhpfPI5JE
 Referenced Tracks:
 - Victory! (Gym Leader Battle) (Pokémon Red / Pokémon Blue)
@@ -553,6 +611,7 @@ Duration: 0:10
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a342233a-18a7-4ecf-a17c-f2123378d257
 - https://www.youtube.com/watch?v=3QS8AzBn6TU
 Referenced Tracks:
 - Obtained a Gym Badge (Pokémon Red / Pokémon Blue)
@@ -562,6 +621,7 @@ Duration: 2:31
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b207a37a-f39c-4a76-9a6c-b1603bb19f41
 - https://www.youtube.com/watch?v=NRUxNUlaVN4
 ---
 Track: Poké Jobs
@@ -569,8 +629,9 @@ Duration: 4:01
 Artists:
 - Go Ichinose (arranger)
 Contributors:
-- Keita Okamoto
+- Keita Okamoto (composer)
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/7a24d26a-afea-43f0-8bee-7ef0afa8f771
 - https://www.youtube.com/watch?v=GTdhAHjGfP4
 ---
 Track: Battle! (Marnie)
@@ -578,6 +639,7 @@ Duration: 2:43
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/4f95cf9f-8bf2-4544-b365-0261767250d5
 - https://www.youtube.com/watch?v=bcKhiDC19bQ
 Referenced Tracks:
 - Marnie's Theme
@@ -588,6 +650,7 @@ Duration: 3:52
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ff2f0d01-ae79-40c1-8ed5-5c69d50a0acf
 - https://www.youtube.com/watch?v=SBxYkxU1z8Q
 Referenced Tracks:
 - Wild Area (South)
@@ -597,6 +660,7 @@ Duration: 2:27
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/f82a49cc-1e61-4677-944b-18db1d41e37d
 - https://www.youtube.com/watch?v=YwqBri2xEUQ
 ---
 Track: Reach Goal in Rotom Rally!
@@ -613,6 +677,7 @@ Duration: 1:55
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b2f8714b-b7ba-4d84-ac88-9ada3bf37b69
 - https://www.youtube.com/watch?v=v1WtWJYwcdY
 ---
 Track: Hair Salon
@@ -620,6 +685,7 @@ Duration: 1:54
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/96d5d428-093d-42e1-beda-85d762a50f96
 - https://www.youtube.com/watch?v=p7K2yebT0aQ
 ---
 Track: Route 6
@@ -628,6 +694,7 @@ Duration: 2:48
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2cdc9090-cd2d-47aa-9f57-398e43a3308b
 - https://www.youtube.com/watch?v=lAjwgu_JZyE
 Referenced Tracks:
 - Wild Area (North)
@@ -638,6 +705,7 @@ Duration: 0:31
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b3bc64ee-cf18-4e1b-9040-c0504be3114d
 - https://www.youtube.com/watch?v=8YyJjeizRVk
 ---
 Track: Stow-on-Side
@@ -645,6 +713,7 @@ Duration: 2:42
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b0e3b53e-8452-4f92-b55c-fdc592661e3c
 - https://www.youtube.com/watch?v=d0FE9PYLWW8
 ---
 Track: The Ancient Mural Crumbles
@@ -652,6 +721,7 @@ Duration: 0:28
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/53ae0fd0-0142-46b4-b064-3a5119364ff7
 - https://www.youtube.com/watch?v=MK-1dlZ2LRU
 Referenced Tracks:
 - The Truth Behind the Mural
@@ -661,6 +731,7 @@ Duration: 4:52
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/708af6b0-16a9-46d0-88b3-5654c4d4e7f0
 - https://www.youtube.com/watch?v=emiLhRPsgIM
 ---
 Track: Glimwood Tangle
@@ -668,6 +739,7 @@ Duration: 3:13
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/32b7d90d-40af-4de1-be86-d80fc2aa205f
 - https://www.youtube.com/watch?v=csGNQoR-n_s
 ---
 Track: Ballonlea
@@ -675,6 +747,7 @@ Duration: 3:55
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/1093631e-ee2f-4d46-b1d8-3096c58774de
 - https://www.youtube.com/watch?v=_qNxTGgbGfM
 ---
 Track: Circhester
@@ -682,6 +755,7 @@ Duration: 3:07
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/db4c028c-8979-459c-b3c3-6e4fafe9c0bf
 - https://www.youtube.com/watch?v=D1-Eg5bMZp8
 ---
 Section: Disc 3
@@ -693,6 +767,7 @@ Duration: 2:06
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/6524a29e-284e-4732-9c8b-cc9511beb97f
 - https://www.youtube.com/watch?v=5yVnAemSAKM
 ---
 Track: Battle! (Team Yell)
@@ -700,6 +775,7 @@ Duration: 2:39
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/f008e734-4b5c-49b9-9dfb-6068c2867ea3
 - https://www.youtube.com/watch?v=BMaGn2IQdDI
 Referenced Tracks:
 - Team Yell Appears!
@@ -709,6 +785,7 @@ Duration: 3:11
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/54bd2169-c821-4272-9090-83077459ced5
 - https://www.youtube.com/watch?v=TeO--Tqdhu0
 Referenced Tracks:
 - Battle! (Team Yell)
@@ -718,6 +795,7 @@ Duration: 1:38
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d0d20467-c452-470d-a275-5359f288ea34
 - https://www.youtube.com/watch?v=dwoRVf6PVIc
 ---
 Track: Wyndon
@@ -725,6 +803,7 @@ Duration: 4:01
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2eed26ea-e82d-4ae4-8a87-fdfe41e9a92c
 - https://www.youtube.com/watch?v=Q3lqHojx1Nk
 ---
 Track: Wyndon Stadium
@@ -732,6 +811,7 @@ Duration: 2:11
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9257aa03-ac92-4a9d-92cc-aac1b43e462f
 - https://www.youtube.com/watch?v=XVXVIbqhcKg
 Referenced Tracks:
 - Gym Challenge Opening Ceremony
@@ -741,6 +821,7 @@ Duration: 3:24
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d96468c0-3cd4-490c-8289-1df641969205
 - https://www.youtube.com/watch?v=g_ltrT3CdAc
 Referenced Tracks:
 - Battle! (Marnie)
@@ -750,6 +831,7 @@ Duration: 3:15
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/dd8c46e1-9936-4e89-a66d-d2bee656d52c
 - https://www.youtube.com/watch?v=g_ETWuhy3Hc
 Referenced Tracks:
 - Battle! (Hop)
@@ -759,6 +841,7 @@ Duration: 2:25
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/7347515c-a532-464e-a32a-b135b99d7fcf
 - https://www.youtube.com/watch?v=qXjBmyM2yw4
 Referenced Tracks:
 - Chairman Rose
@@ -768,6 +851,7 @@ Duration: 2:24
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/23f60e25-487b-44ec-81b3-5d5e0972a1da
 - https://www.youtube.com/watch?v=e1y038iJTbw
 Referenced Tracks:
 - Rose Tower
@@ -777,6 +861,7 @@ Duration: 2:27
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/365acbb1-17fe-49c9-86f8-0d0d0b179384
 - https://www.youtube.com/watch?v=6zB5n0yMPKA
 Referenced Tracks:
 - Rose Tower
@@ -787,6 +872,7 @@ Duration: 0:29
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c8f41039-1d14-4275-9ecb-52a43360b875
 - https://www.youtube.com/watch?v=9fj3jKL8N34
 ---
 Track: Battle! (Finals)
@@ -794,6 +880,7 @@ Duration: 4:33
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/0856d7ec-91d9-4f61-8aa2-9d015ab0f4b1
 - https://www.youtube.com/watch?v=w9c6lT43XjU
 Referenced Tracks:
 - track:battle-gym-leader-pokemon-sword-shield
@@ -803,6 +890,7 @@ Duration: 0:36
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/fa5a6dfd-e202-4c4c-b5c9-cebc5aaa5560
 - https://www.youtube.com/watch?v=VhZuzadFIlY
 Referenced Tracks:
 - Battle! (Finals)
@@ -812,6 +900,7 @@ Duration: 0:32
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d1d1e6a7-2d1f-44f5-9190-f89806619067
 - https://www.youtube.com/watch?v=sCpVnlx8ySA
 ---
 Track: Deep in the Forest
@@ -819,6 +908,7 @@ Duration: 2:04
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/5c9c5438-3c4d-4996-af2a-61b68cdef2f3
 - https://www.youtube.com/watch?v=pm6ggEbvYFA
 Referenced Tracks:
 - In the Fog
@@ -828,6 +918,7 @@ Duration: 1:59
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/6ae06ea3-a99a-4e62-9481-39681f07828e
 - https://www.youtube.com/watch?v=62An3smV0NU
 ---
 Track: Battle! (Rose)
@@ -835,6 +926,7 @@ Duration: 3:01
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/63bd06df-aeb1-4f74-91fd-878e6c78e18e
 - https://www.youtube.com/watch?v=S9H2Vbtl9OM
 ---
 Track: Leon and Eternatus
@@ -842,6 +934,7 @@ Duration: 0:29
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/d79a6b12-58be-464e-94fa-4bc036544e5b
 - https://www.youtube.com/watch?v=SFaMOms5OSg
 ---
 Track: Battle! (Eternatus)
@@ -849,6 +942,7 @@ Duration: 3:34
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9ca136bc-2126-41d8-8d11-6974d7a1b42d
 - https://www.youtube.com/watch?v=6ocbwkxaFuI
 ---
 Track: Eternal Power
@@ -856,6 +950,7 @@ Duration: 2:42
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a8eb7bad-e48d-45b9-a4cd-3fcbd3ec8354
 - https://www.youtube.com/watch?v=34cHD0bpP6s
 Referenced Tracks:
 - Battle! (Eternatus)
@@ -865,6 +960,7 @@ Duration: 4:29
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c6fdb252-45e9-40f3-9d68-6b00821121ef
 - https://www.youtube.com/watch?v=a-f6HJQRars
 Referenced Tracks:
 - Battle! (Eternatus)
@@ -875,6 +971,7 @@ Duration: 0:28
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/b12fd539-b547-46bb-a990-cbe4d3373984
 - https://www.youtube.com/watch?v=6xnB5zv5EFk
 Referenced Tracks:
 - 'Fanfare: Evolution (Pokémon Red / Pokémon Blue)'
@@ -885,6 +982,7 @@ Duration: 5:07
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/e3ec78e1-fa1d-4de6-a494-c43da28ab490
 - https://www.youtube.com/watch?v=ztf6DFCjk_g
 Referenced Tracks:
 - Hall of Fame (Pokémon Red / Pokémon Blue)
@@ -895,6 +993,7 @@ Duration: 0:36
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9bc037f8-b3eb-4a86-afd3-6b6bb06e36bd
 - https://www.youtube.com/watch?v=Y_5MBWxMwXo
 Referenced Tracks:
 - Decisive Battle! (Champion Leon)
@@ -904,6 +1003,7 @@ Duration: 1:16
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a6e0634b-7689-4d84-aa85-cf461c6eefb4
 - https://www.youtube.com/watch?v=up2cIL5T6Mg
 Referenced Tracks:
 - Hall of Fame (Pokémon Red / Pokémon Blue)
@@ -916,6 +1016,7 @@ Duration: 1:48
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2da12f37-1e77-4617-8223-6a6bec7eddba
 - https://www.youtube.com/watch?v=NL95xW_8UxE
 Referenced Tracks:
 - Battle Tower (Johto) (Pokémon Crystal)
@@ -925,6 +1026,7 @@ Duration: 5:16
 Artists:
 - Toby Fox
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/e3443cdc-4058-4625-8e14-393e2647fd8b
 - https://www.youtube.com/watch?v=shzaFbvGnhw
 Commentary: |- ##https://www.pokemon.com/us/pokemon-news/a-special-letter-and-song-from-undertale-game-creator-toby-fox
     <i>Toby Fox:</i> ([A Special Letter and Song from Undertale Game Creator Toby Fox](https://www.pokemon.com/us/pokemon-news/a-special-letter-and-song-from-undertale-game-creator-toby-fox))
@@ -957,6 +1059,7 @@ Duration: 4:19
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/3176c1dc-579e-4772-8efd-52912c88ba17
 - https://www.youtube.com/watch?v=i6vvseDF5_M
 Referenced Tracks:
 - In the Fog
@@ -970,6 +1073,7 @@ Duration: 2:41
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/1be8978d-0c29-4962-92f0-0638ceff65a6
 - https://www.youtube.com/watch?v=92xKA9VmxLE
 ---
 Track: Krazy for Klara
@@ -977,6 +1081,7 @@ Duration: 1:36
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/6bbccf6b-5bfe-4387-b3cc-65a8d478b452
 - https://www.youtube.com/watch?v=1ZqZhDmpD04
 ---
 Track: Battle! (Klara)
@@ -984,6 +1089,7 @@ Duration: 2:03
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/9da8242c-509c-4458-99b6-503a274ded18
 - https://www.youtube.com/watch?v=Bh_AReiKtPA
 Referenced Tracks:
 - Krazy for Klara
@@ -993,6 +1099,7 @@ Duration: 1:26
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a68e5626-810d-4682-9ef9-bebd791792d2
 - https://www.youtube.com/watch?v=8RJAMvT1I8s
 ---
 Track: Battle! (Avery)
@@ -1000,6 +1107,7 @@ Duration: 1:42
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/4624b4bb-9194-47fe-bdf4-526077b89acf
 - https://www.youtube.com/watch?v=Gs0Lj1nsJCE
 Referenced Tracks:
 - The Amazing Avery
@@ -1009,6 +1117,7 @@ Duration: 1:53
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/2e0c07fa-4567-45f0-aee5-d62c7c03f549
 - https://www.youtube.com/watch?v=7I_YCZUKkPI
 ---
 Track: Mustard's Theme
@@ -1016,6 +1125,7 @@ Duration: 2:07
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/771c52a1-45d2-4420-b320-74931003701c
 - https://www.youtube.com/watch?v=4Xni9LM9J-0
 ---
 Track: Battle! (Mustard)
@@ -1023,6 +1133,7 @@ Duration: 2:20
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/f9c173eb-cbe7-4fac-abac-ff48fb8c3b1b
 - https://www.youtube.com/watch?v=AuUzfEb_RD4
 Referenced Tracks:
 - Mustard's Theme
@@ -1033,6 +1144,7 @@ Duration: 0:04
 Artists:
 - Keita Okamoto
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c638d1d3-aba7-4663-9ae1-1ab47942df04
 - https://www.youtube.com/watch?v=fZqPwXeXpPU
 Sampled Tracks:
 - track:obtained-an-item-pokemon-sword-shield
@@ -1042,6 +1154,7 @@ Duration: 0:41
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/6a500585-f057-4641-acdb-3392007d2853
 - https://www.youtube.com/watch?v=57lkN9w-kfA
 Referenced Tracks:
 - Battle! (Mustard)
@@ -1051,6 +1164,7 @@ Duration: 3:07
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/04b5f424-2e22-436a-8fa7-1e068e364476
 - https://www.youtube.com/watch?v=bPm5Zki1joM
 ---
 Track: Tower of Darkness
@@ -1058,6 +1172,7 @@ Duration: 3:07
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/de35a873-e0ed-4dd7-a737-04bc5374b3f0
 - https://www.youtube.com/watch?v=-CVlRIH0xLE
 Referenced Tracks:
 - Tower of Waters
@@ -1067,6 +1182,7 @@ Duration: 2:50
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/e904f2dc-f375-42d7-bf62-2b270274c148
 - https://www.youtube.com/watch?v=31hXoEhY8RE
 Referenced Tracks:
 - Battle! (Mustard)
@@ -1077,6 +1193,7 @@ Duration: 0:57
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/76bcc4de-e572-468a-bbad-f62b91ea3f61
 - https://www.youtube.com/watch?v=hyXJFzSNXgk
 Referenced Tracks:
 - Battle! (Serious Mustard)
@@ -1086,6 +1203,7 @@ Duration: 0:26
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a043c986-ecab-49e9-a2ef-df5b1b64f74b
 - https://www.youtube.com/watch?v=Ad-vYBokF50
 Referenced Tracks:
 - Mustard's Theme
@@ -1095,6 +1213,7 @@ Duration: 4:32
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/20422112-9d57-4e3d-a0cf-f4b10266cf3b
 - https://www.youtube.com/watch?v=ESOTrCO-bF4
 ---
 Track: Peony's Theme
@@ -1102,6 +1221,7 @@ Duration: 1:53
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ebfd328a-8dae-4830-956c-387ebffa5994
 - https://www.youtube.com/watch?v=gdRCcp63qkM
 ---
 Track: Battle! (Peony)
@@ -1109,6 +1229,7 @@ Duration: 2:54
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a2dcf84e-d999-49a8-ad57-eade09cd141e
 - https://www.youtube.com/watch?v=6Np45H24SGI
 ---
 Track: Max Lair
@@ -1116,6 +1237,7 @@ Duration: 1:29
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/01e2c6ce-85ff-4e85-8df9-11f716569b35
 - https://www.youtube.com/watch?v=owYdSVoMXqU
 ---
 Track: Dynamax Adventure
@@ -1123,6 +1245,7 @@ Duration: 3:00
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/efa69647-334b-481a-a9f2-84554c1e7272
 - https://www.youtube.com/watch?v=v0ly6leTwVk
 Referenced Tracks:
 - Battle! (Max Raid Battle)
@@ -1132,6 +1255,7 @@ Duration: 3:05
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/e52211fa-9ebd-44e8-a47f-fa4448ad6780
 - https://www.youtube.com/watch?v=m2MlMwJWdxw
 Referenced Tracks:
 - Battle! (Max Raid Battle)
@@ -1141,6 +1265,7 @@ Duration: 3:00
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/772711c8-3e96-4ba0-9b77-9b9e296f4219
 - https://www.youtube.com/watch?v=v7Rg7dyb6zY
 ---
 Track: Legends of Legendary Pokémon
@@ -1148,6 +1273,7 @@ Duration: 0:09
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/881f4ee1-a1d9-4a57-802f-c122144e5458
 - https://www.youtube.com/watch?v=F4FMyZ0Td5Y
 ---
 Track: The King of Bountiful Harvests
@@ -1155,6 +1281,7 @@ Duration: 1:36
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/e21a5d3d-958b-46b9-a9c8-67322dedade5
 - https://www.youtube.com/watch?v=Wlz9M18G1zw
 Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
@@ -1164,6 +1291,7 @@ Duration: 3:21
 Artists:
 - Junichi Masuda
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/a6e041a4-7114-49c8-9eb8-35f703f99173
 - https://www.youtube.com/watch?v=g77AYV2kirs
 Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
@@ -1173,6 +1301,7 @@ Duration: 0:09
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/c51a7a9f-a774-441b-9645-2adad26f7331
 - https://www.youtube.com/watch?v=eHcoVQwAb48
 ---
 Track: Battle! (Glastrier/Spectrier)
@@ -1180,6 +1309,7 @@ Duration: 2:12
 Artists:
 - Junichi Masuda
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/dbe7d892-fae9-45ed-9994-1e05c0f6cbfc
 - https://www.youtube.com/watch?v=lhzGAcuTOH8
 Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
@@ -1189,6 +1319,7 @@ Duration: 1:56
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/cb48bf6b-07de-4617-8b49-bacfec51e978
 - https://www.youtube.com/watch?v=pnLHmfqhgtY
 Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
@@ -1198,6 +1329,7 @@ Duration: 1:13
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/3a307704-6d1f-42cf-8aa9-a6eaaf93964e
 - https://www.youtube.com/watch?v=9xXhO2j8A40
 Referenced Tracks:
 - Crown Shrine
@@ -1208,6 +1340,7 @@ Duration: 2:37
 Artists:
 - Junichi Masuda
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/5bfd6991-6cd5-42b7-8869-10d05e25f45c
 - https://www.youtube.com/watch?v=27GaAUbE8LA
 ---
 Track: You Found a Clue!
@@ -1215,6 +1348,7 @@ Duration: 0:04
 Artists:
 - Keita Okamoto
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/48f00fc2-c61e-4252-bf7c-3d6a99b82874
 - https://www.youtube.com/watch?v=F_cQmGvvOD8
 ---
 Track: Battle! (The Giant of Legend)
@@ -1222,6 +1356,7 @@ Duration: 2:30
 Artists:
 - Hitomi Sato
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/1fe6a572-0482-4868-a721-dfb8f70f9564
 - https://www.youtube.com/watch?v=RTghy7gbvGM
 Referenced Tracks:
 - Battle! (Regirock/Regice/Registeel) (Pokémon Ruby / Pokémon Sapphire)
@@ -1231,6 +1366,7 @@ Duration: 1:06
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/02a2a1cb-7954-4302-8045-fe199ada6e6b
 - https://www.youtube.com/watch?v=d-kGPBy4Jtw
 Referenced Tracks:
 - Battle! (The Bird Pokémon of Legend)
@@ -1240,6 +1376,7 @@ Duration: 4:19
 Artists:
 - Go Ichinose
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/ec26bc05-3f6d-4ccf-ab9a-de49b555de63
 - https://www.youtube.com/watch?v=1qRZMVbrPLM
 ---
 Track: Staff Credits
@@ -1248,6 +1385,7 @@ Duration: 3:30
 Artists:
 - Minako Adachi
 URLs:
+- https://m.nintendo.com/shared/en-US/US/tracks/f4ba0dcb-a965-4677-b2e4-4991c4685a30
 - https://www.youtube.com/watch?v=CcTy34jldas
 Referenced Tracks:
 - Hall of Fame (Pokémon Red / Pokémon Blue)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -429,6 +429,8 @@ Content: |-
     - changed directory of [[track:frost-and-frogs-lofam5a2]] from `frost-and-frogs` to `frost-and-frogs-lofam5a2`
     - changed directory of [[track:audacity]] from `audacity-svix` to `audacity`
     - changed directories of all tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] to be suffixed `-ch1` and `-ch2` respectively; previous directories now used across [[album:deltarune-soundtrack]]
+    - changed directory of [[track:battle-frontier-brain-hoenn-version]] from `battle-frontier-brainhoenn-version` to `battle-frontier-brain-hoenn-version`
+    - changed directory of [[track:battle-frontier-brain-hoenn-version]] from `battle-frontier-brainsinnoh-version` to `battle-frontier-brain-sinnoh-version`
     - changed directory of [[track:bad-apple-lovelight]] from `bad-apple-feat-nomico` to `bad-apple-lovelight`
     - changed directory of [[track:death-mountain-theme]] from `death-mountain-the-legend-of-zelda` to `death-mountain-theme`
     - changed directory of [[track:ending-theme-the-legend-of-zelda]] from `ending-the-legend-of-zelda` to `ending-theme-the-legend-of-zelda`

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -218,7 +218,7 @@ Content: |-
     - added SoundCloud listening link for [[track:heir-seer-knight-witch]] (thanks, Lilith, Lan!)
     - added Apple Music listening links for [[album:agents-of-reality]] (thanks, Lan!)
     - added Tumblr listening link to [[track:catscratch]] (thanks, Lilith, Lan!)
-    - added Nintendo Music listening links to [[track:death-mountain-theme]], [[track:ending-theme-the-legend-of-zelda]], [[track:game-over-the-legend-of-zelda]], [[track:ganon-is-defeated]], [[track:overworld-theme-the-legend-of-zelda]], [[track:title-theme-the-legend-of-zelda]], and [[track:underworld-theme]] (thanks, ruby!)
+    - added Nintendo Music listening links across [[album:pokemon-sword-shield-super-music-collection]], and to [[track:death-mountain-theme]], [[track:ending-theme-the-legend-of-zelda]], [[track:game-over-the-legend-of-zelda]], [[track:ganon-is-defeated]], [[track:overworld-theme-the-legend-of-zelda]], [[track:title-theme-the-legend-of-zelda]], and [[track:underworld-theme]] (thanks, ruby!)
     - replaced YouTube listening link for [[track:orange-hat]] with artist's upload (thanks, Lilith, Lan!)
     - replaced YouTube listening links for [[track:solar-voyage]] and [[track:renewed-return]] with artist's uploads (thanks, wertercatt, Lan!)
     - replaced Spotify listening links for [[track:celestial]], [[album:rakka-wake-01-opening-me]], and [[album:rakka-sp1-outside-2]] with link to single, rather than track (thanks, Lan, Whisper!)
@@ -252,6 +252,7 @@ Content: |-
     <!-- album overarching presentation -->
     - restructured [[album:ophiuchus-full-suite]] into a two-halves album, representing the full suite as a single track as well as its individual parts (moved from a section in [[album:more-homestuck-fandom]]), with track artwork and revised commentary
     - restructured [[album:flyways]] similarly as [[album:ophiuchus-full-suite]]
+    - styled track sections for each disc of [[album:pokemon-sword-shield-super-music-collection]] and [[album:pokemon-scarlet-violet-super-music-collection]] to separately count track numbers (thanks, ruby!)
     <!-- album presentational tweaks -->
     - revised [[track:center-of-brilliance]] and [[track:candles-and-clockwork-alpha-version]] to present artwork assets from Bandcamp first, with alternatively sourced higher-res cuts as secondary artworks instead (thanks, Lan, Tangle!)
     - revised color of [[album:seven-seas]] to match newly added cover artwork (thanks, Jebb!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -360,6 +360,50 @@ Content: |-
     - fixed [[artist:domble]] having some credits under another name (thanks, Makin, Lan!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
+        - fixed [[track:time-for-a-breather]] being named "Take a Break"
+        - fixed [[track:pokemon-research-lab]] being named "Pokémon Laboratory"
+        - fixed [[track:pokemon-healed-pokemon-sword-shield]] being named "Recovery"
+        - fixed [[track:guide-pokemon-sword-shield]] being named "Lead the Way"
+        - fixed [[track:at-the-train-station]] being named "Wild Area Station"
+        - fixed [[track:battle-max-raid-battle]] being named "Max Raid Battle!"
+        - fixed [[track:curry-koffing-class]] being named "Curry: Koffing Class"
+        - fixed [[track:curry-wobbuffet-class]] being named "Curry: Wobbuffet Class"
+        - fixed [[track:curry-milcery-class]] being named "Curry: Milcery Class"
+        - fixed [[track:curry-copperajah-class]] being named "Curry: Copperajah Class"
+        - fixed [[track:curry-charizard-class]] being named "Curry: Charizard Class"
+        - fixed [[track:curry-dex-keep-going]] being named "Curry Dex: Do Your Best!"
+        - fixed [[track:curry-dex-complete]] being named "Curry Dex: Completed!"
+        - fixed [[track:at-the-stadium]] being named "Stadium"
+        - fixed [[track:an-old-legend]] being named "Legends of History"
+        - fixed [[track:battle-trainer-pokemon-sword-shield]] being named "Battle! (Trainer Battle)"
+        - fixed [[track:victory-trainer-pokemon-sword-shield]] being named "Victory! (Trainer Battle)"
+        - fixed [[track:gym-mission-cleared]] being named "Gym Mission Cleared!!"
+        - fixed [[track:poke-jobs]] being named "Poké Job"
+        - fixed [[track:hair-salon-pokemon-sword-shield]] being named "Salon"
+        - fixed [[track:the-ancient-mural-crumbles]] being named "Crumbling Ruins"
+        - fixed [[track:the-truth-behind-the-mural]] being named "Truth of the Ruins"
+        - fixed [[track:battle-gym-leader-piers]] being named "Battle! (Gym Leader: Piers)"
+        - fixed [[track:reaching-the-top]] being named "Arrival at the Top"
+        - fixed [[track:the-finals-begin]] being named "Final Tournament Begin!"
+        - fixed [[track:battle-finals]] being named "Battle! (Final Tournament)"
+        - fixed [[track:the-darkest-day]] being named "Darkest Day"
+        - fixed [[track:a-bizarre-situation]] being named "Abnormal Situation"
+        - fixed [[track:eternal-power]] being named "Infinite Power"
+        - fixed [[track:you-caught-eternatus]] being named "Caught an Eternatus"
+        - fixed [[track:for-a-bright-future]] being named "To Create a Bright Future"
+        - fixed [[track:battle-zacian-zamazenta]] being named "Battle! (Zacian / Zamazenta)"
+        - fixed [[track:the-amazing-avery]] being named "Super Avery"
+        - fixed [[track:obtained-an-item-but]] being named "Obtained an Item, But..."
+        - fixed [[track:victory-with-kubfu]] being named "Kubfu and Victory"
+        - fixed [[track:legends-of-legendary-pokemon]] being named "A Legend! A Legend of Legends!"
+        - fixed [[track:the-king-of-bountiful-harvests]] being named "King of Bountiful Harvests"
+        - fixed [[track:battle-glastrier-spectrier]] being named "Battle! (Glastrier / Spectrier)"
+        - fixed [[track:as-one]] being named "Unity of Rider and Horse"
+        - fixed [[track:battle-the-king-of-bountiful-harvests]] being named "Battle! (King of Bountiful Harvests)"
+        - fixed [[track:you-found-a-clue]] being named "You Found a Hint!"
+        - fixed [[track:battle-the-giant-of-legend]] being named "Battle! (Legendary Giants)"
+        - fixed [[track:gathering-at-the-tree]] being named "Gather at the Dyna Tree"
+        - fixed [[track:battle-the-bird-pokemon-of-legend]] being named "Battle! (Legendary Bird Pokémon)"
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"
         - fixed [[track:ending-theme-the-legend-of-zelda]] being named "Ending (The Legend of Zelda)"
         - fixed [[track:ganon-is-defeated]] being named "Ganon Appear/Defeat Fanfare"
@@ -422,16 +466,54 @@ Content: |-
     - fixed duration of [[track:bad-apple]] ([[artist:zun]]) to align with soundtrack release (was 3:13, now 3:15; thanks, Lan!)
     - fixed duration of [[track:bad-apple]] (feat. [[artist:nomico]]) to align with 'Lovelight' album release (was 3:13, now 5:18; thanks, Lan!)
     <h3>directory changes</h3>
-    <details><summary><b>Toggle Directorylog</b></summary>
+    <details><summary><b>Toggle Directorylog</b> (general changes)</summary>
     - changed directory of [[track:denizen-lofam4]] from `denizen` to `denizen-lofam`
     - changed directory of [[track:cloudscape-dialed-to-11]] from `cloudscape` to `cloudscape-dialed-to-11`
     - changed directory of [[track:the-respect-you-rightfully-deserve-single]] from `the-respect-you-rightfully-deserve-soundcloud` to `the-respect-you-rightfully-deserve-single`
     - changed directory of [[track:frost-and-frogs-lofam5a2]] from `frost-and-frogs` to `frost-and-frogs-lofam5a2`
     - changed directory of [[track:audacity]] from `audacity-svix` to `audacity`
     - changed directories of all tracks across [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] to be suffixed `-ch1` and `-ch2` respectively; previous directories now used across [[album:deltarune-soundtrack]]
+    - changed directory of [[track:boutique-pokemon-sword-shield]] from `boutique` to `boutique-pokemon-sword-shield`
+    - changed directory of [[track:obtained-an-item-pokemon-scarlet-violet]] from `obtained-an-item` to `obtained-an-item-pokemon-scarlet-violet`
     - changed directory of [[track:battle-frontier-brain-hoenn-version]] from `battle-frontier-brainhoenn-version` to `battle-frontier-brain-hoenn-version`
     - changed directory of [[track:battle-frontier-brain-hoenn-version]] from `battle-frontier-brainsinnoh-version` to `battle-frontier-brain-sinnoh-version`
     - changed directory of [[track:bad-apple-lovelight]] from `bad-apple-feat-nomico` to `bad-apple-lovelight`
+    </details>
+    <details><summary><b>Toggle Directorylog</b> (Nintendo Music changes)</summary>
+    - changed directory of [[track:time-for-a-breather]] from `take-a-break-pokemon-sword-shield` to `time-for-a-breather`
+    - changed directory of [[track:pokemon-research-lab]] from `pokemon-laboratory` to `pokemon-research-lab`
+    - changed directory of [[track:pokemon-healed-pokemon-sword-shield]] from `reovery-pokemon-sword-shield` to `pokemon-healed-pokemon-sword-shield`
+    - changed directory of [[track:guide-pokemon-sword-shield]] from `lead-the-way` to `guide-pokemon-sword-shield`
+    - changed directory of [[track:at-the-train-station]] from `wild-area-station` to `at-the-train-station`
+    - changed directory of [[track:battle-max-raid-battle]] from `max-raid-battle` to `battle-max-raid-battle`
+    - changed directory of [[track:curry-dex-keep-going]] from `curry-dex-do-your-best` to `curry-dex-keep-going`
+    - changed directory of [[track:curry-dex-complete]] from `curry-dex-completed` to `curry-dex-complete`
+    - changed directory of [[track:at-the-stadium]] from `stadium` to `at-the-stadium`
+    - changed directory of [[track:an-old-legend]] from `legends-of-history` to `an-old-legend`
+    - changed directory of [[track:battle-trainer-pokemon-sword-shield]] from `battle-trainer-battle-pokemon-sword-shield` to `battle-trainer-pokemon-sword-shield`
+    - changed directory of [[track:victory-trainer-pokemon-sword-shield]] from `victory-trainer-battle-pokemon-sword-shield` to `victory-trainer-pokemon-sword-shield`
+    - changed directory of [[track:poke-jobs]] from `poke-job` to `poke-jobs`
+    - changed directory of [[track:hair-salon-pokemon-sword-shield]] from `salon` to `hair-salon-pokemon-sword-shield`
+    - changed directory of [[track:the-ancient-mural-crumbles]] from `crumbling-ruins` to `the-ancient-mural-crumbles`
+    - changed directory of [[track:the-truth-behind-the-mural]] from `truth-of-the-ruins` to `the-truth-behind-the-mural`
+    - changed directory of [[track:reaching-the-top]] from `arrival-at-the-top` to `reaching-the-top`
+    - changed directory of [[track:the-finals-begin]] from `final-tournament-begin` to `the-finals-begin`
+    - changed directory of [[track:battle-finals]] from `battle-final-tournament` to `battle-finals`
+    - changed directory of [[track:the-darkest-day]] from `darkest-day` to `the-darkest-day`
+    - changed directory of [[track:a-bizarre-situation]] from `abnormal-situation` to `a-bizarre-situation`
+    - changed directory of [[track:eternal-power]] from `infinite-power` to `eternal-power`
+    - changed directory of [[track:you-caught-eternatus]] from `caught-an-eternatus` to `you-caught-eternatus`
+    - changed directory of [[track:for-a-bright-future]] from `to-create-a-bright-future` to `for-a-bright-future`
+    - changed directory of [[track:the-amazing-avery]] from `super-avery` to `the-amazing-avery`
+    - changed directory of [[track:victory-with-kubfu]] from `kubfu-and-victory` to `victory-with-kubfu`
+    - changed directory of [[track:legends-of-legendary-pokemon]] from `a-legend-a-legend-of-legends` to `legends-of-legendary-pokemon`
+    - changed directory of [[track:the-king-of-bountiful-harvests]] from `king-of-bountiful-harvests` to `the-king-of-bountiful-harvests`
+    - changed directory of [[track:as-one]] from `unity-of-rider-and-horse` to `as-one`
+    - changed directory of [[track:battle-the-king-of-bountiful-harvests]] from `battle-king-of-bountiful-harvests` to `battle-the-king-of-bountiful-harvests`
+    - changed directory of [[track:you-found-a-clue]] from `you-found-a-hint` to `you-found-a-clue`
+    - changed directory of [[track:battle-the-giant-of-legend]] from `battle-legendary-giants` to `battle-the-giant-of-legend`
+    - changed directory of [[track:gathering-at-the-tree]] from `gather-at-the-dyna-tree` to `gathering-at-the-tree`
+    - changed directory of [[track:battle-the-bird-pokemon-of-legend]] from `battle-legendary-bird-pokemon` to `battle-the-bird-pokemon-of-legend`
     - changed directory of [[track:death-mountain-theme]] from `death-mountain-the-legend-of-zelda` to `death-mountain-theme`
     - changed directory of [[track:ending-theme-the-legend-of-zelda]] from `ending-the-legend-of-zelda` to `ending-theme-the-legend-of-zelda`
     - changed directory of [[track:ganon-is-defeated]] from `ganon-appear-defeat-fanfare` to `ganon-is-defeated`


### PR DESCRIPTION
fixes titles and adds listening links from Nintendo Music, also adds per-section track counting for both Sword / Shield and Scarlet / Violet