### PR TITLE
NLTM_ urls and a handful of aliases

### DIFF
--- a/artists.yaml
+++ b/artists.yaml
@@ -10289,6 +10289,7 @@ Dead URLs:
 - https://twitter.com/bonetail_ #active-ish; cw: medical, bruised images
 - http://dragon.reviews #used to be their tumblr, was changed to a redirect to their twitter
 - http://nltm.tumblr.com/ #old tumblr url; occupied by someone else
+- https://soundcloud.com/nolistentome
 - http://tindeck.com/users/NOLISTENTOME
 - https://nolistentome.newgrounds.com #still online, inactive
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -10283,9 +10283,9 @@ Aliases:
 - NLTM
 - NOLISTENTOME
 URLs:
-- https://www.reddit.com/user/NLTM/
 - https://nltm.bandcamp.com/
 Dead URLs:
+- https://www.reddit.com/user/NLTM/ #posts may be NSFW
 - https://twitter.com/bonetail_ #active-ish; cw: medical, bruised images
 - http://dragon.reviews #used to be their tumblr, was changed to a redirect to their twitter
 - http://nltm.tumblr.com/ #old tumblr url; occupied by someone else

--- a/artists.yaml
+++ b/artists.yaml
@@ -10278,6 +10278,19 @@ URLs:
 Artist: njeekyo
 ---
 Artist: NLTM_
+Aliases:
+- Zach Hix
+- NLTM
+- NOLISTENTOME
+URLs:
+- https://www.reddit.com/user/NLTM/
+- https://nltm.bandcamp.com/
+Dead URLs:
+- https://twitter.com/bonetail_ #active-ish; cw: medical, bruised images
+- http://dragon.reviews #used to be their tumblr, was changed to a redirect to their twitter
+- http://nltm.tumblr.com/ #old tumblr url; occupied by someone else
+- http://tindeck.com/users/NOLISTENTOME
+- https://nolistentome.newgrounds.com #still online, inactive
 ---
 Artist: No Funny Name
 ---


### PR DESCRIPTION
Spruces up the NLTM_ artist directory; including their ~~Reddit and~~ Bandcamp as a live URL~~s~~, but the rest are marked dead (twitter is marked dead cause of cw: medical, and bruised images; newgrounds is marked dead cause it's not active at all despite being an accessible link) and including a couple of aliases