### PR TITLE
Haunter cleanup

### DIFF
--- a/artists.yaml
+++ b/artists.yaml
@@ -5885,6 +5885,7 @@ URLs:
 - https://www.facebook.com/HaunterDubstep
 Dead URLs:
 - https://twitter.com/HaunterDubstep
+- https://haunter.bandcamp.com/ #former url of haunteruk.bandcamp.com, now bandcamp home of MKE/WI band unrelated to IKarus/Haunter/BlastProcessed
 - https://myspace.com/552379098
 - https://haunterdubstep.tumblr.com/
 - https://vault15.tumblr.com/

--- a/artists.yaml
+++ b/artists.yaml
@@ -5878,8 +5878,8 @@ URLs:
 - https://soundcloud.com/ikarusedm
 - https://soundcloud.com/blastprocessed
 - https://soundcloud.com/haunter-dubstep
-- https://www.youtube.com/user/IKarusEDM/
-- https://www.youtube.com/user/HaunterDubstep
+- https://www.youtube.com/@IKarusEDM
+- https://www.youtube.com/@HaunterDubstep/
 - https://blastprocessed.tumblr.com/
 - https://www.facebook.com/BlastProcessed/
 - https://www.facebook.com/HaunterDubstep

--- a/artists.yaml
+++ b/artists.yaml
@@ -5866,24 +5866,21 @@ Artist: hatzka
 Artist: Haunter
 Aliases:
 - HaunterDubstep
-- HaunterWI
-- hauntermke
 - BlastProcessed
 - Martyn Davies
 - IKarusEDM
+- IKarus
+- IKARUS
 URLs:
-- https://haunter.bandcamp.com/
+- https://haunteruk.bandcamp.com/
+- https://ikarusedm.bandcamp.com/
 - https://blastprocessed.bandcamp.com/
-- https://soundcloud.com/haunter-wi
 - https://soundcloud.com/ikarusedm
 - https://soundcloud.com/blastprocessed
 - https://soundcloud.com/haunter-dubstep
-- https://www.youtube.com/user/haunterWI
 - https://www.youtube.com/user/IKarusEDM/
 - https://www.youtube.com/user/HaunterDubstep
 - https://blastprocessed.tumblr.com/
-- https://twitter.com/HaunterWI
-- https://www.facebook.com/hauntermke/
 - https://www.facebook.com/BlastProcessed/
 - https://www.facebook.com/HaunterDubstep
 Dead URLs:


### PR DESCRIPTION
Cleans up Haunter's URLs and aliases, as Haunter (HaunterMKE/HaunterWI) are unrelated to Haunter/BlastProcessed/IKarus
- yeeted all of HaunterMKE and HaunterWI (aliases, urls) as these are not HaunterDubstep
- added IKarus bandcamp URL
- replaced WI/MKE Haunter bandcamp link (though, the haunteruk bandcamp used to be just haunter) with HaunterDubstep (haunteruk) bandcamp url