### PR TITLE
Album additions: Toris Crow (Ambrosios, Chimera, Morpheus, Panoptes)!

### DIFF
--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -103,6 +103,7 @@ URLs:
 - https://toriscrow.bandcamp.com/track/featherlight
 ---
 Track: Test Track
+Main Release: 50M3 GR347 4C7 0F H3R015M
 Duration: 2:15
 URLs:
 - https://toriscrow.bandcamp.com/track/test-track
@@ -131,7 +132,7 @@ Duration: 2:15
 URLs:
 - https://toriscrow.bandcamp.com/track/test-track-piano-ver
 Referenced Tracks:
-- Test Track
+- 50M3 GR347 4C7 0F H3R015M
 ---
 Section: Bonus track
 ---

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -152,15 +152,11 @@ Commentary: |-
 
     <i>Toris Crow:</i> ([Tumblr](https://ukulelecrow.tumblr.com/post/131046583363/well-rgb-is-a-very-two-sided-coin-so-hes-about), excerpt, 10/12/2015)
 
-    > <i>"Well, RGB is a very two-sided coin, so he's about the contrast of razzle-dazzle and melancholy, high class and barely scraping by, happy and sad. He's a throwaway trinket that's been damaged beyond repair and has accepted that into his personality."</i> - [[artist:thatdappertellybloke]]
+    This is my interpretation of the description I got in reply to my ask about what RGB's music theme would be like. I will eventually have this on Bandcamp, as soon as I finish the rest of the album.
 
-    This is my interpretation of the description I got [in reply](http://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him) to my ask about what RGB's music theme would be like. I will eventually have this on Bandcamp, as soon as I finish the rest of the album.
+    <i>Toris Crow, Sarah Jolley|[[artist:sarah-jolley]]:</i> ([Tumblr](https://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him), 7/25/2015)
 
-    <i>Toris Crow:</i> ([Tumblr ask](https://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him) to [[artist:thatdappertellybloke]])
-
-    If RGB were to have a musical style to match him, what would it be? In other words, if RGB were to have a theme song what do you think it would be like? I want to compose a theme for him but I don't know where to start.
-
-    <i>thatdappertellybloke:</i> ([Tumblr answer](https://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him), 7/25/2015)
+    > <i>[[artist:toris-crow]]:</i> If RGB were to have a musical style to match him, what would it be? In other words, if RGB were to have a theme song what do you think it would be like? I want to compose a theme for him but I don't know where to start.
 
     OOooh what a fun question! Well, RGB is a very two-sided coin, so he's about the contrast of razzle-dazzle and melancholy, high class and barely scraping by, happy and sad. He's a throwaway trinket that's been damaged beyond repair and has accepted that into his personality. I think that a lot of the Professor Layton music gets the [slightly broken down](https://www.youtube.com/watch?v=Q0CQvyHflbE) and [off kilter feeling](https://www.youtube.com/watch?v=uHpmHZb8OzI) across quite well, and it has a [touch of the vaudeville](https://www.youtube.com/watch?v=iF26u4S6Ryo) to it as well. Then again he would also work well with something electro-swingy, gotta love that stuff, and of course the track I always think of as TPoH's unofficial theme is [this little beauty.](https://www.youtube.com/watch?v=Y71KOOM1mlM)
 Crediting Sources: |-

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -10,6 +10,7 @@ Cover Art File Extension: png
 Track Art File Extension: png
 Color: '#87ce55'
 Groups:
+- Toris Crow
 - Beyond
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/ambrosios))

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -151,3 +151,22 @@ Commentary: |-
     This track was written for Sarah Jolley's "The Property of Hate," a webcomic about a monster and a little girl going on an adventure. [You can check it out here.](https://jolleycomics.com/TPoH/)
 
     "The Property of Hate" belongs to Sarah Jolley and was merely inspiration for this piece.
+
+    <i>Toris Crow:</i> ([Tumblr](https://ukulelecrow.tumblr.com/post/131046583363/well-rgb-is-a-very-two-sided-coin-so-hes-about), excerpt, 10/12/2015)
+
+    > <i>"Well, RGB is a very two-sided coin, so he's about the contrast of razzle-dazzle and melancholy, high class and barely scraping by, happy and sad. He's a throwaway trinket that's been damaged beyond repair and has accepted that into his personality."</i> - [[artist:thatdappertellybloke]]
+
+    This is my interpretation of the description I got [in reply](http://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him) to my ask about what RGB's music theme would be like. I will eventually have this on Bandcamp, as soon as I finish the rest of the album.
+
+    <i>Toris Crow:</i> ([Tumblr ask](https://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him) to [[artist:thatdappertellybloke]])
+
+    If RGB were to have a musical style to match him, what would it be? In other words, if RGB were to have a theme song what do you think it would be like? I want to compose a theme for him but I don't know where to start.
+
+    <i>thatdappertellybloke:</i> ([Tumblr answer](https://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him), 7/25/2015)
+
+    OOooh what a fun question! Well, RGB is a very two-sided coin, so he's about the contrast of razzle-dazzle and melancholy, high class and barely scraping by, happy and sad. He's a throwaway trinket that's been damaged beyond repair and has accepted that into his personality. I think that a lot of the Professor Layton music gets the [slightly broken down](https://www.youtube.com/watch?v=Q0CQvyHflbE) and [off kilter feeling](https://www.youtube.com/watch?v=uHpmHZb8OzI) across quite well, and it has a [touch of the vaudeville](https://www.youtube.com/watch?v=iF26u4S6Ryo) to it as well. Then again he would also work well with something electro-swingy, gotta love that stuff, and of course the track I always think of as TPoH's unofficial theme is [this little beauty.](https://www.youtube.com/watch?v=Y71KOOM1mlM)
+
+Crediting Sources: |-
+    <i>Toris Crow:</i> ([Tumblr](https://ukulelecrow.tumblr.com/post/131046583363/well-rgb-is-a-very-two-sided-coin-so-hes-about), excerpt, 10/12/2015)
+
+    The lovely track art was made by the wonderful [[artist:wander|@ghostwandering]]!

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -1,0 +1,153 @@
+Album: Ambrosios
+Artists:
+- Toris Crow
+Date: April 10, 2016
+URLs:
+- https://toriscrow.bandcamp.com/album/ambrosios
+Cover Artists:
+- wander
+Cover Art File Extension: png
+Track Art File Extension: png
+Color: '#87ce55'
+Groups:
+- Beyond
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/ambrosios))
+
+    This is the story of a boy who died trying to save a world that was not his.
+
+Crediting Sources: |-
+    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/ambrosios))
+
+    All art by the wonderful [[artist:wander|[wander.]]]
+
+---
+Section: Main album
+---
+Track: Remember Tomorrow
+Duration: 1:26
+URLs:
+- https://toriscrow.bandcamp.com/track/remember-tomorrow
+---
+Track: Nightlife
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 1:15
+URLs:
+- https://toriscrow.bandcamp.com/track/nightlife
+---
+Track: Tribute to the 52-Hertz Whale
+Duration: 0:25
+URLs:
+- https://toriscrow.bandcamp.com/track/tribute-to-the-52-hertz-whale
+---
+Track: Elegy of Void
+Duration: 1:06
+URLs:
+- https://toriscrow.bandcamp.com/track/elegy-of-void
+---
+Track: The Starlight Harmonium
+Duration: 0:20
+URLs:
+- https://toriscrow.bandcamp.com/track/the-starlight-harmonium
+---
+Track: Heaven Won't Take Me Alive
+Duration: 0:43
+URLs:
+- https://toriscrow.bandcamp.com/track/heaven-wont-take-me-alive
+---
+Track: Fools of Time
+Duration: 1:03
+URLs:
+- https://toriscrow.bandcamp.com/track/fools-of-time
+---
+Track: Novantanove
+Duration: 1:09
+URLs:
+- https://toriscrow.bandcamp.com/track/novantanove
+---
+Track: Weakness is Free
+Duration: 0:39
+URLs:
+- https://toriscrow.bandcamp.com/track/weakness-is-free
+---
+Track: Refuge of the Fallen Soldiers
+Duration: 1:40
+URLs:
+- https://toriscrow.bandcamp.com/track/refuge-of-the-fallen-soldiers
+---
+Track: Race Against Time
+Duration: 0:46
+URLs:
+- https://toriscrow.bandcamp.com/track/race-against-time
+---
+Track: Steven's Requiem
+Duration: 0:40
+URLs:
+- https://toriscrow.bandcamp.com/track/stevens-requiem
+---
+Track: March of the Undead
+Duration: 1:09
+URLs:
+- https://toriscrow.bandcamp.com/track/march-of-the-undead
+---
+Track: Fight of Hope
+Duration: 0:32
+URLs:
+- https://toriscrow.bandcamp.com/track/fight-of-hope
+---
+Track: Featherlight
+Duration: 1:28
+URLs:
+- https://toriscrow.bandcamp.com/track/featherlight
+---
+Track: Test Track
+Duration: 2:15
+URLs:
+- https://toriscrow.bandcamp.com/track/test-track
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/test-track))
+
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:50m3-gr347-4c7-0f-h3r015m|"50M3 GR347 4C7 0F H3R015M"]]: [unofficialmspafans.bandcamp.com](https://unofficialmspafans.bandcamp.com/)
+
+---
+Track: Fight of Hope [Piano Ver.]
+Duration: 0:32
+URLs:
+- https://toriscrow.bandcamp.com/track/fight-of-hope-piano-ver
+Referenced Tracks:
+- Fight of Hope
+---
+Track: Featherlight [Piano Ver.]
+Duration: 1:41
+URLs:
+- https://toriscrow.bandcamp.com/track/featherlight-piano-ver
+Referenced Tracks:
+- Featherlight
+---
+Track: Test Track [Piano Ver.]
+Duration: 2:15
+URLs:
+- https://toriscrow.bandcamp.com/track/test-track-piano-ver
+Referenced Tracks:
+- Test Track
+---
+Section: Bonus track
+---
+Track: Hero's Waltz
+Additional Names:
+- Name: >-
+    Hero's Waltz [Bonus]
+  Annotation: >-
+    [Bandcamp](https://toriscrow.bandcamp.com/track/heros-waltz-bonus)
+Duration: 1:38
+URLs:
+- https://toriscrow.bandcamp.com/track/heros-waltz-bonus
+Cover Artists:
+- wander
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/heros-waltz-bonus))
+
+    This track was written for Sarah Jolley's "The Property of Hate," a webcomic about a monster and a little girl going on an adventure. [You can check it out here.](https://jolleycomics.com/TPoH/)
+
+    "The Property of Hate" belongs to Sarah Jolley and was merely inspiration for this piece.

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -101,13 +101,14 @@ URLs:
 - https://toriscrow.bandcamp.com/track/featherlight
 ---
 Track: Test Track
+Main Release: 50M3 GR347 4C7 0F H3R015M # Beforus
 Duration: 2:15
 URLs:
 - https://toriscrow.bandcamp.com/track/test-track
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/test-track))
 
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:50m3-gr347-4c7-0f-h3r015m|"50M3 GR347 4C7 0F H3R015M"]]: [unofficialmspafans.bandcamp.com](https://unofficialmspafans.bandcamp.com/)
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [["50M3 GR347 4C7 0F H3R015M"]]: https://unofficialmspafans.bandcamp.com/
 ---
 Track: Fight of Hope [Piano Ver.]
 Duration: 0:32

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -16,12 +16,10 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/ambrosios))
 
     This is the story of a boy who died trying to save a world that was not his.
-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/ambrosios))
 
-    All art by the wonderful [[artist:wander|[wander]]].
-
+    All art by the wonderful [[artist:wander]].
 ---
 Section: Main album
 ---
@@ -110,7 +108,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/test-track))
 
     This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:50m3-gr347-4c7-0f-h3r015m|"50M3 GR347 4C7 0F H3R015M"]]: [unofficialmspafans.bandcamp.com](https://unofficialmspafans.bandcamp.com/)
-
 ---
 Track: Fight of Hope [Piano Ver.]
 Duration: 0:32
@@ -166,8 +163,7 @@ Commentary: |-
     <i>thatdappertellybloke:</i> ([Tumblr answer](https://thatdappertellybloke.tumblr.com/post/124988459066/if-rgb-were-to-have-a-musical-style-to-match-him), 7/25/2015)
 
     OOooh what a fun question! Well, RGB is a very two-sided coin, so he's about the contrast of razzle-dazzle and melancholy, high class and barely scraping by, happy and sad. He's a throwaway trinket that's been damaged beyond repair and has accepted that into his personality. I think that a lot of the Professor Layton music gets the [slightly broken down](https://www.youtube.com/watch?v=Q0CQvyHflbE) and [off kilter feeling](https://www.youtube.com/watch?v=uHpmHZb8OzI) across quite well, and it has a [touch of the vaudeville](https://www.youtube.com/watch?v=iF26u4S6Ryo) to it as well. Then again he would also work well with something electro-swingy, gotta love that stuff, and of course the track I always think of as TPoH's unofficial theme is [this little beauty.](https://www.youtube.com/watch?v=Y71KOOM1mlM)
-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Tumblr](https://ukulelecrow.tumblr.com/post/131046583363/well-rgb-is-a-very-two-sided-coin-so-hes-about), excerpt, 10/12/2015)
 
-    The lovely track art was made by the wonderful [[artist:wander|@ghostwandering]]!
+    The lovely track art was made by the wonderful [[artist:wander]]!

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -103,7 +103,6 @@ URLs:
 - https://toriscrow.bandcamp.com/track/featherlight
 ---
 Track: Test Track
-Main Release: 50M3 GR347 4C7 0F H3R015M
 Duration: 2:15
 URLs:
 - https://toriscrow.bandcamp.com/track/test-track
@@ -132,7 +131,7 @@ Duration: 2:15
 URLs:
 - https://toriscrow.bandcamp.com/track/test-track-piano-ver
 Referenced Tracks:
-- 50M3 GR347 4C7 0F H3R015M
+- Test Track
 ---
 Section: Bonus track
 ---

--- a/album/ambrosios.yaml
+++ b/album/ambrosios.yaml
@@ -19,7 +19,7 @@ Commentary: |-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/ambrosios))
 
-    All art by the wonderful [[artist:wander|[wander.]]]
+    All art by the wonderful [[artist:wander|[wander]]].
 
 ---
 Section: Main album

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -984,10 +984,9 @@ Commentary: |-
     Listening to this track, I had the distinct image of Kurloz falling through sopor slime into the void. Not long after, the dream self between being asleep in his cocoon on Beforus and the kingdom of Prospit was an overwhelming image. It certainly called for something that looked a bit dramatic and fuzzy, the way things feel when you aren't sure if you're awake or dreaming and in that state where you can be stratled awake by the feeling you've crashed back onto the mattress, literally falling awake after just barely falling asleep.
 ---
 Track: 50M3 GR347 4C7 0F H3R015M
+Main Release: Test Track
 Additional Names:
 - Some Great Act of Heroism (quirk-free)
-Artists:
-- Toris Crow
 Duration: 2:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/50m3-gr347-4c7-0f-h3r015m

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -585,7 +585,7 @@ Commentary: |-
     <i>Toris Crow:</i>
     This piece was written for Rufioh Nitram and specifically, his clan, the Lost Weeaboos. The instrumentation was based off [["The Brave and the Bronze"]] by Yan "Nucleose" Rodriguez, with the percussion beat coming from Tavros's song [["dESPERADO ROCKET CHAIRS,"]] by Toby "Radiation" Fox. Its musical connection to Rufioh is mostly open for interpretation. This song's alternate name in [[album:chimera|my own album]] is [["La Tauromaquia,"]] meaning "bullfighting" in Spanish.
     <i>rockytoad:</i>
-    When I was figuring out what th draw for the song, I did pay attention to the song's name and also alternate name. Hearing "weeaboo" made me want to put kitty ears on Rufioh, but I scrapped that idea and instea dfocussed on the bullfighting aspect of the song first and foremost. Since Rufioh is kind of a silly character, I thught that it'd be great to gie him one of those little pony riding sticks with a bull for the head. After I finished drawing the main part of the drawing, I was still trying to figure out how to incorporate "weeaboo"-ness into it. Well, weeaboo makes me think of kitties and anime, so my mind went to Nyan Cat. Perfect, I thought, I'll add some Goold Ol' Nyan Cat rainbows, haha. And then, of course, glitter becaus anime. It came out really colorful and I'm happy with it.
+    When I was figuring out what th draw for the song, I did pay attention to the song's name and also alternate name. Hearing "weeaboo" made me want to put kitty ears on Rufioh, but I scrapped that idea and instead focussed on the bullfighting aspect of the song first and foremost. Since Rufioh is kind of a silly character, I thought that it'd be great to give him one of those little pony riding sticks with a bull for the head. After I finished drawing the main part of the drawing, I was still trying to figure out how to incorporate "weaboo"-ness into it. Well, weeaboo makes me think of kitties and anime, so my mind went to Nyan Cat. Perfect, I thought, I'll add some Goold Ol' Nyan Cat rainbows, haha. And then, of course, glitter because anime. It came out really colorful and I'm happy with it.
 ---
 Track: Life With Peace
 Artists:
@@ -984,7 +984,6 @@ Commentary: |-
     Listening to this track, I had the distinct image of Kurloz falling through sopor slime into the void. Not long after, the dream self between being asleep in his cocoon on Beforus and the kingdom of Prospit was an overwhelming image. It certainly called for something that looked a bit dramatic and fuzzy, the way things feel when you aren't sure if you're awake or dreaming and in that state where you can be stratled awake by the feeling you've crashed back onto the mattress, literally falling awake after just barely falling asleep.
 ---
 Track: 50M3 GR347 4C7 0F H3R015M
-Main Release: Test Track
 Additional Names:
 - Some Great Act of Heroism (quirk-free)
 Artists:
@@ -1000,9 +999,9 @@ Art Tags:
 - 'cw: eye horror'
 Commentary: |-
     <i>Toris Crow:</i>
-    This was written specifically as a theme fro Mituna Captor. I wrote it as a chiptune based loosely off of the Mega Man soundtrack because of Mituna's canon nickname, "Mega Man Sollux." This song was my first test for some chiptune percussion I found in the depths of my hard drive, and thus is alternatively named [[track:test-track|"Test Track"]] in [[album:ambrosios|one of my own albums.]] The actual name came from Aranea's short biography on him from Openbound, in which she states that "some great act of heroism" is what burnt out his psychic powers and shattered his mind.
+    This was written specifically as a theme for Mituna Captor. I wrote it as a chiptune based loosely off of the Mega Man soundtrack because of Mituna's canon nickname, "Mega Man Sollux." This song was my first test for some chiptune percussion I found in the depths of my hard drive, and thus is alternatively named [[track:test-track|"Test Track"]] in [[album:ambrosios|one of my own albums.]] The actual name came from Aranea's short biography on him from Openbound, in which she states that "some great act of heroism" is what burnt out his psychic powers and shattered his mind.
     <i>Gene:</i>
-    Mituna's track revolves around the event that caused him to lose his power, which is what I've chosen to depict. I decided to translate the chiptune into something visuall resembling a computer error, mirroring the "error" in Mituna's brain.
+    Mituna's track revolves around the event that caused him to lose his power, which is what I've chosen to depict. I decided to translate the chiptune into something visually resembling a computer error, mirroring the "error" in Mituna's brain.
 ---
 Track: Time's Apostate
 Artists:

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -984,9 +984,10 @@ Commentary: |-
     Listening to this track, I had the distinct image of Kurloz falling through sopor slime into the void. Not long after, the dream self between being asleep in his cocoon on Beforus and the kingdom of Prospit was an overwhelming image. It certainly called for something that looked a bit dramatic and fuzzy, the way things feel when you aren't sure if you're awake or dreaming and in that state where you can be stratled awake by the feeling you've crashed back onto the mattress, literally falling awake after just barely falling asleep.
 ---
 Track: 50M3 GR347 4C7 0F H3R015M
-Main Release: Test Track
 Additional Names:
 - Some Great Act of Heroism (quirk-free)
+Artists:
+- Toris Crow
 Duration: 2:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/50m3-gr347-4c7-0f-h3r015m

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -568,11 +568,6 @@ Commentary: |-
     I love the build up in this track! It's a lot of fun to listen to and this was a lot of fun to draw ahaha I'm not sure what else to say but the vwizard aesthetic is obvious//
 ---
 Track: The Weeaboo's Battle Cry
-Additional Names:
-- Name: >-
-    La Tauromaquia
-  Annotation: >-
-    on [Chimera](https://toriscrow.bandcamp.com/track/la-tauromaquia)
 Artists:
 - Toris Crow
 Duration: 2:49
@@ -588,7 +583,7 @@ Referenced Tracks:
 - dESPERADO ROCKET CHAIRS,
 Commentary: |-
     <i>Toris Crow:</i>
-    This piece was written for Rufioh Nitram and specifically, his clan, the Lost Weeaboos. The instrumentation was based off [["The Brave and the Bronze"]] by Yan "Nucleose" Rodriguez, with the percussion beat coming from Tavros's song [["dESPERADO ROCKET CHAIRS,"]] by Toby "Radiation" Fox. Its musical connection to Rufioh is mostly open for interpretation. This song's alternate name in my own album is "La Tauromaquia," meaning "bullfighting" in Spanish.
+    This piece was written for Rufioh Nitram and specifically, his clan, the Lost Weeaboos. The instrumentation was based off [["The Brave and the Bronze"]] by Yan "Nucleose" Rodriguez, with the percussion beat coming from Tavros's song [["dESPERADO ROCKET CHAIRS,"]] by Toby "Radiation" Fox. Its musical connection to Rufioh is mostly open for interpretation. This song's alternate name in [[album:chimera|my own album]] is [["La Tauromaquia,"]] meaning "bullfighting" in Spanish.
     <i>rockytoad:</i>
     When I was figuring out what th draw for the song, I did pay attention to the song's name and also alternate name. Hearing "weeaboo" made me want to put kitty ears on Rufioh, but I scrapped that idea and instea dfocussed on the bullfighting aspect of the song first and foremost. Since Rufioh is kind of a silly character, I thught that it'd be great to gie him one of those little pony riding sticks with a bull for the head. After I finished drawing the main part of the drawing, I was still trying to figure out how to incorporate "weeaboo"-ness into it. Well, weeaboo makes me think of kitties and anime, so my mind went to Nyan Cat. Perfect, I thought, I'll add some Goold Ol' Nyan Cat rainbows, haha. And then, of course, glitter becaus anime. It came out really colorful and I'm happy with it.
 ---
@@ -703,10 +698,6 @@ Commentary: |-
 Track: March 9f the Insuffera6le
 Additional Names:
 - March of the Insufferable (quirk-free)
-- Name: >-
-    The Pariah
-  Annotation: >-
-    on [Chimera](https://toriscrow.bandcamp.com/track/the-pariah)
 Artists:
 - Toris Crow
 Duration: 2:37
@@ -719,7 +710,7 @@ Art Tags:
 - Kankri
 Commentary: |-
     <i>Toris Crow:</i>
-    This piece was written for Kankri Vantas. It was made as a march because marches signify authority and Kankri attempts to command the respect of his fellow teammates throughout his session. The faster parts represent that his calm demeanor can be easily shattered by his short temper. I used piano and violin to connect it to the song that I had made earlier for Porrim called [["Antevo+rta."]] This song's alternate name in my own album is "The Pariah."
+    This piece was written for Kankri Vantas. It was made as a march because marches signify authority and Kankri attempts to command the respect of his fellow teammates throughout his session. The faster parts represent that his calm demeanor can be easily shattered by his short temper. I used piano and violin to connect it to the song that I had made earlier for Porrim called [["Antevo+rta."]] This song's alternate name in [[album:chimera|my own album]] is [["The Pariah."]]
     <i>ARTistotel:</i>
     The idea behind the picture was tightly tied to the piece itself, and author's description. Kankri is trying to be a leader, but all his protection falls back on the civilization long lost and destroyed - that's why it's Beforan skulls marching right after him. His leadership, his protection is aimed more at dusty pieces and bits of no longer existing Beforan society, rather than his friends in afterlife.
 ---
@@ -993,14 +984,9 @@ Commentary: |-
     Listening to this track, I had the distinct image of Kurloz falling through sopor slime into the void. Not long after, the dream self between being asleep in his cocoon on Beforus and the kingdom of Prospit was an overwhelming image. It certainly called for something that looked a bit dramatic and fuzzy, the way things feel when you aren't sure if you're awake or dreaming and in that state where you can be stratled awake by the feeling you've crashed back onto the mattress, literally falling awake after just barely falling asleep.
 ---
 Track: 50M3 GR347 4C7 0F H3R015M
+Main Release: Test Track
 Additional Names:
 - Some Great Act of Heroism (quirk-free)
-- Name: >-
-    Test Track
-  Annotation: >-
-    on [Ambrosios](https://toriscrow.bandcamp.com/track/test-track)
-Artists:
-- Toris Crow
 Duration: 2:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/50m3-gr347-4c7-0f-h3r015m
@@ -1012,7 +998,7 @@ Art Tags:
 - 'cw: eye horror'
 Commentary: |-
     <i>Toris Crow:</i>
-    This was written specifically as a theme fro Mituna Captor. I wrote it as a chiptune based loosely off of the Mega Man soundtrack because of Mituna's canon nickname, "Mega Man Sollux." This song was my first test for some chiptune percussion I found in the depths of my hard drive, and thus is alternatively named "Test Track" in one of my own albums. The actual name came from Aranea's short biography on him from Openbound, in which she states that "some great act of heroism" is what burnt out his psychic powers and shattered his mind.
+    This was written specifically as a theme fro Mituna Captor. I wrote it as a chiptune based loosely off of the Mega Man soundtrack because of Mituna's canon nickname, "Mega Man Sollux." This song was my first test for some chiptune percussion I found in the depths of my hard drive, and thus is alternatively named [[track:test-track|"Test Track"]] in [[album:ambrosios|one of my own albums.]] The actual name came from Aranea's short biography on him from Openbound, in which she states that "some great act of heroism" is what burnt out his psychic powers and shattered his mind.
     <i>Gene:</i>
     Mituna's track revolves around the event that caused him to lose his power, which is what I've chosen to depict. I decided to translate the chiptune into something visuall resembling a computer error, mirroring the "error" in Mituna's brain.
 ---
@@ -1048,10 +1034,6 @@ Track: Antevo+rta
 Directory: antevorta
 Additional Names:
 - Antevorta (quirk-free)
-- Name: >-
-    Glass Heart
-  Annotation: >-
-    on [Chimera](https://toriscrow.bandcamp.com/track/glass-heart)
 Artists:
 - Toris Crow
 Duration: 2:07
@@ -1066,7 +1048,7 @@ Art Tags:
 - Space
 Commentary: |-
     <i>Toris Crow:</i>
-    This piece was written for Porrim Maryam. The instrumentation is based off of her two themes, [[Jade Mother]] and [[Darling Dolorosa]], which both feature piano and violin. The actual meaning of the song is open for interpretation because I went mostly off of feelings when writing it. Its name comes from the goddess of childbirth and prophecy, Antevorta, whose alternate name is Porrima. This song's alternative name in my own album is "Glass Heart."
+    This piece was written for Porrim Maryam. The instrumentation is based off of her two themes, [[Jade Mother]] and [[Darling Dolorosa]], which both feature piano and violin. The actual meaning of the song is open for interpretation because I went mostly off of feelings when writing it. Its name comes from the goddess of childbirth and prophecy, Antevorta, whose alternate name is Porrima. This song's alternative name in [[album:chimera|my own album]] is [[track:glass-heart|"Glass Heart."]]
     <i>Fayghost:</i>
     This illustration stumped me. Porrim's character is more thematic than it is concrete, and such an open-ended premise left me chasing down a few false starts in the piece's design. The failure of Porrim's role as maid of space nonetheless contributed to events on a massive scale. Ignition does not mean success. Finally I found something I think captures it all without being too obvious.
 ---

--- a/album/beforus.yaml
+++ b/album/beforus.yaml
@@ -987,6 +987,8 @@ Track: 50M3 GR347 4C7 0F H3R015M
 Main Release: Test Track
 Additional Names:
 - Some Great Act of Heroism (quirk-free)
+Artists:
+- Toris Crow
 Duration: 2:15
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/50m3-gr347-4c7-0f-h3r015m

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -7,7 +7,7 @@ URLs:
 Cover Artists:
 - wander
 Cover Art File Extension: png
-Color: '#7d99b0'
+Color: '#a3c7d7'
 Groups:
 - Beyond
 Commentary: |-

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -15,12 +15,10 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/chimera))
 
     This is the story of a bird who flew to the ends of the earth and burned every bridge she encountered along the way.
-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/chimera))
 
-    All art by the wonderful [[artist:wander|[wander]]].
-
+    All art by the wonderful [[artist:wander]].
 ---
 Track: What's Left of Eternity
 Duration: 1:20
@@ -44,7 +42,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Tumblr](https://ukulelecrow.tumblr.com/post/130009062953/next-up-i-made-one-for-eva-shougoukis-aesthetic), WIP commentary, 9/27/2015)
 
     [Next up](https://ukulelecrow.tumblr.com/post/129451644068/reblog-if-you-want-me-to-try-to-compose-a-song) I made one for [eva-shougouki's](https://web.archive.org/web/0/http://eva-shougouki.tumblr.com/) aesthetic blog [fifteenth-angel](https://web.archive.org/web/0/https://fifteenth-angel.tumblr.com/). Because the blog title is "fragile like glass," I decided to make something in a bit of a higher register. Also, a lot of what you post is dark or dramatic or even emotional, so I made the song in a minor key. Feel free to tell me how you think I did!
-
 ---
 Track: The Wicked Be No More
 Duration: 2:14
@@ -70,7 +67,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/glass-heart))
 
     This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:antevorta|"Antevo+rta"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
-
 ---
 Track: Thank You for Nothing
 Duration: 1:26
@@ -86,9 +82,8 @@ URLs:
 - https://toriscrow.bandcamp.com/track/motions-of-infinity
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/motions-of-infinity))
-    
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:motions-of-infinity|the same name]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
 
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:motions-of-infinity|the same name]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
 ---
 Track: Melancholy of Demeter
 Duration: 1:48
@@ -117,7 +112,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/the-pariah))
 
     This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:march-9f-the-insuffera6le|"March 9f the Insuffera6le"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
-
 ---
 Track: La Tauromaquia
 Main Release: The Weeaboo's Battle Cry
@@ -126,9 +120,8 @@ URLs:
 - https://toriscrow.bandcamp.com/track/la-tauromaquia
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/la-tauromaquia))
-    
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:the-weeaboos-battle-cry|"The Weeaboo's Battle Cry"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
 
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:the-weeaboos-battle-cry|"The Weeaboo's Battle Cry"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
 ---
 Track: Unpredictable Weather
 Duration: 2:13

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -18,7 +18,7 @@ Commentary: |-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/chimera))
 
-    All art by the wonderful [[artist:wander|[wander.]]]
+    All art by the wonderful [[artist:wander|[wander]]].
 
 ---
 Track: What's Left of Eternity

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -9,6 +9,7 @@ Cover Artists:
 Cover Art File Extension: png
 Color: '#a3c7d7'
 Groups:
+- Toris Crow
 - Beyond
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/chimera))

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -27,6 +27,11 @@ URLs:
 - https://toriscrow.bandcamp.com/track/whats-left-of-eternity
 ---
 Track: Fifteenth Angel
+Additional Names:
+- Name: >-
+    eva-shougouki (fifteenth-angel)
+  Annotation: >-
+    Tumblr audio embed on [WIP](https://ukulelecrow.tumblr.com/post/130009062953/next-up-i-made-one-for-eva-shougoukis-aesthetic)
 Duration: 1:26
 URLs:
 - https://toriscrow.bandcamp.com/track/fifteenth-angel
@@ -34,6 +39,10 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/fifteenth-angel))
 
     This song is based off of [eva-shougouki.tumblr.com's](https://web.archive.org/web/0/http://eva-shougouki.tumblr.com/) blog [fifteenth-angel.tumblr.com](https://web.archive.org/web/0/https://fifteenth-angel.tumblr.com/).
+
+    <i>Toris Crow:</i> ([Tumblr](https://ukulelecrow.tumblr.com/post/130009062953/next-up-i-made-one-for-eva-shougoukis-aesthetic), WIP commentary, 9/27/2015)
+
+    [Next up](https://ukulelecrow.tumblr.com/post/129451644068/reblog-if-you-want-me-to-try-to-compose-a-song) I made one for [eva-shougouki's](https://web.archive.org/web/0/http://eva-shougouki.tumblr.com/) aesthetic blog [fifteenth-angel](https://web.archive.org/web/0/https://fifteenth-angel.tumblr.com/). Because the blog title is "fragile like glass," I decided to make something in a bit of a higher register. Also, a lot of what you post is dark or dramatic or even emotional, so I made the song in a minor key. Feel free to tell me how you think I did!
 
 ---
 Track: The Wicked Be No More

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -59,14 +59,14 @@ URLs:
 - https://toriscrow.bandcamp.com/track/bitter-promises
 ---
 Track: Glass Heart
-Main Release: track:antevorta
+Main Release: Antevo+rta # Beforus
 Duration: 2:07
 URLs:
 - https://toriscrow.bandcamp.com/track/glass-heart
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/glass-heart))
 
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:antevorta|"Antevo+rta"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [["Antevo+rta"]]: https://unofficialmspafans.bandcamp.com/album/beforus
 ---
 Track: Thank You for Nothing
 Duration: 1:26
@@ -74,7 +74,7 @@ URLs:
 - https://toriscrow.bandcamp.com/track/thank-you-for-nothing
 ---
 Track: Motions of Infinity
-Main Release: Motions of Infinity
+Main Release: Beforus
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:47
@@ -83,7 +83,7 @@ URLs:
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/motions-of-infinity))
 
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:motions-of-infinity|the same name]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:motions-of-infinity|the same name]]: https://unofficialmspafans.bandcamp.com/album/beforus
 ---
 Track: Melancholy of Demeter
 Duration: 1:48
@@ -104,24 +104,24 @@ URLs:
 - https://toriscrow.bandcamp.com/track/flight
 ---
 Track: The Pariah
-Main Release: March 9f the Insuffera6le
+Main Release: March 9f the Insuffera6le # Beforus
 Duration: 2:37
 URLs:
 - https://toriscrow.bandcamp.com/track/the-pariah
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/the-pariah))
 
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:march-9f-the-insuffera6le|"March 9f the Insuffera6le"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [["March 9f the Insuffera6le"]]: https://unofficialmspafans.bandcamp.com/album/beforus
 ---
 Track: La Tauromaquia
-Main Release: The Weeaboo's Battle Cry
+Main Release: The Weeaboo's Battle Cry # Beforus
 Duration: 2:49
 URLs:
 - https://toriscrow.bandcamp.com/track/la-tauromaquia
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/la-tauromaquia))
 
-    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:the-weeaboos-battle-cry|"The Weeaboo's Battle Cry"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [["The Weeaboo's Battle Cry"]]: https://unofficialmspafans.bandcamp.com/album/beforus
 ---
 Track: Unpredictable Weather
 Duration: 2:13

--- a/album/chimera.yaml
+++ b/album/chimera.yaml
@@ -1,0 +1,153 @@
+Album: Chimera
+Artists:
+- Toris Crow
+Date: September 4, 2016
+URLs:
+- https://toriscrow.bandcamp.com/album/chimera
+Cover Artists:
+- wander
+Cover Art File Extension: png
+Color: '#7d99b0'
+Groups:
+- Beyond
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/chimera))
+
+    This is the story of a bird who flew to the ends of the earth and burned every bridge she encountered along the way.
+
+Crediting Sources: |-
+    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/chimera))
+
+    All art by the wonderful [[artist:wander|[wander.]]]
+
+---
+Track: What's Left of Eternity
+Duration: 1:20
+URLs:
+- https://toriscrow.bandcamp.com/track/whats-left-of-eternity
+---
+Track: Fifteenth Angel
+Duration: 1:26
+URLs:
+- https://toriscrow.bandcamp.com/track/fifteenth-angel
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/fifteenth-angel))
+
+    This song is based off of [eva-shougouki.tumblr.com's](https://web.archive.org/web/0/http://eva-shougouki.tumblr.com/) blog [fifteenth-angel.tumblr.com](https://web.archive.org/web/0/https://fifteenth-angel.tumblr.com/).
+
+---
+Track: The Wicked Be No More
+Duration: 2:14
+URLs:
+- https://toriscrow.bandcamp.com/track/the-wicked-be-no-more
+---
+Track: Forgotten God
+Duration: 2:17
+URLs:
+- https://toriscrow.bandcamp.com/track/forgotten-god
+---
+Track: Bitter Promises
+Duration: 1:26
+URLs:
+- https://toriscrow.bandcamp.com/track/bitter-promises
+---
+Track: Glass Heart
+Main Release: track:antevorta
+Duration: 2:07
+URLs:
+- https://toriscrow.bandcamp.com/track/glass-heart
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/glass-heart))
+
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:antevorta|"Antevo+rta"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+
+---
+Track: Thank You for Nothing
+Duration: 1:26
+URLs:
+- https://toriscrow.bandcamp.com/track/thank-you-for-nothing
+---
+Track: Motions of Infinity
+Main Release: Motions of Infinity
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 1:47
+URLs:
+- https://toriscrow.bandcamp.com/track/motions-of-infinity
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/motions-of-infinity))
+    
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:motions-of-infinity|the same name]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+
+---
+Track: Melancholy of Demeter
+Duration: 1:48
+URLs:
+- https://toriscrow.bandcamp.com/track/melancholy-of-demeter
+---
+Track: The Moonlight Harmonium
+Duration: 0:34
+URLs:
+- https://toriscrow.bandcamp.com/track/the-moonlight-harmonium
+Referenced Tracks:
+- The Starlight Harmonium
+---
+Track: Flight
+Suffix Directory: true
+Duration: 1:43
+URLs:
+- https://toriscrow.bandcamp.com/track/flight
+---
+Track: The Pariah
+Main Release: March 9f the Insuffera6le
+Duration: 2:37
+URLs:
+- https://toriscrow.bandcamp.com/track/the-pariah
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/the-pariah))
+
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:march-9f-the-insuffera6le|"March 9f the Insuffera6le"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+
+---
+Track: La Tauromaquia
+Main Release: The Weeaboo's Battle Cry
+Duration: 2:49
+URLs:
+- https://toriscrow.bandcamp.com/track/la-tauromaquia
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/la-tauromaquia))
+    
+    This track can also be found in [[album:beforus|the Beforus Album]] here under [[track:the-weeaboos-battle-cry|"The Weeaboo's Battle Cry"]]: [unofficialmspafans.bandcamp.com/album/beforus](https://unofficialmspafans.bandcamp.com/album/beforus)
+
+---
+Track: Unpredictable Weather
+Duration: 2:13
+URLs:
+- https://toriscrow.bandcamp.com/track/unpredictable-weather
+---
+Track: Fool's Paradise
+Duration: 2:19
+URLs:
+- https://toriscrow.bandcamp.com/track/fools-paradise
+---
+Track: Winter Solstice
+Duration: 2:00
+URLs:
+- https://toriscrow.bandcamp.com/track/winter-solstice
+---
+Track: Winter Solstice [Piano Ver.]
+Duration: 1:32
+URLs:
+- https://toriscrow.bandcamp.com/track/winter-solstice-piano-ver
+Referenced Tracks:
+- Winter Solstice
+---
+Track: Would You Like to Dance?
+Duration: 1:53
+URLs:
+- https://toriscrow.bandcamp.com/track/would-you-like-to-dance
+---
+Track: The End of Forever
+Duration: 2:22
+URLs:
+- https://toriscrow.bandcamp.com/track/the-end-of-forever

--- a/album/morpheus.yaml
+++ b/album/morpheus.yaml
@@ -16,12 +16,10 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/morpheus))
 
     This is the story of an immortal who hid behind mayhem and misconception until the day he met his match.
-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/morpheus))
 
-    All art by the wonderful [[artist:wander|[wander]]].
-
+    All art by the wonderful [[artist:wander]].
 ---
 Track: Faustian Bargain
 Duration: 2:15

--- a/album/morpheus.yaml
+++ b/album/morpheus.yaml
@@ -1,0 +1,130 @@
+Album: Morpheus
+Artists:
+- Toris Crow
+Date: December 30, 2016
+URLs:
+- https://toriscrow.bandcamp.com/album/morpheus
+Cover Artists:
+- wander
+Cover Art File Extension: png
+Cover Art Dimensions: 1725x1678
+Color: '#f34c4b'
+Groups:
+- Beyond
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/morpheus))
+
+    This is the story of an immortal who hid behind mayhem and misconception until the day he met his match.
+
+Crediting Sources: |-
+    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/morpheus))
+
+    All art by the wonderful [[artist:wander|[wander.]]]
+
+---
+Track: Faustian Bargain
+Duration: 2:15
+URLs:
+- https://toriscrow.bandcamp.com/track/faustian-bargain
+---
+Track: Sleep Paralysis
+Duration: 2:19
+URLs:
+- https://toriscrow.bandcamp.com/track/sleep-paralysis
+---
+Track: God is Dead
+Duration: 2:16
+URLs:
+- https://toriscrow.bandcamp.com/track/god-is-dead
+---
+Track: Hero from Another World
+Duration: 2:07
+URLs:
+- https://toriscrow.bandcamp.com/track/hero-from-another-world
+---
+Track: Pray for Rain, Darling
+Duration: 2:06
+URLs:
+- https://toriscrow.bandcamp.com/track/pray-for-rain-darling
+---
+Track: Thunderstorm
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 2:28
+URLs:
+- https://toriscrow.bandcamp.com/track/thunderstorm
+---
+Track: Overture
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 2:30
+URLs:
+- https://toriscrow.bandcamp.com/track/overture
+---
+Track: The Performer
+Duration: 1:42
+URLs:
+- https://toriscrow.bandcamp.com/track/the-performer
+---
+Track: Lost and Found
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 2:26
+URLs:
+- https://toriscrow.bandcamp.com/track/lost-and-found
+---
+Track: Goodbye Doesn't Mean Forever
+Duration: 1:24
+URLs:
+- https://toriscrow.bandcamp.com/track/goodbye-doesnt-mean-forever
+---
+Track: Marigold
+Suffix Directory: true
+Duration: 2:12
+URLs:
+- https://toriscrow.bandcamp.com/track/marigold
+---
+Track: Lavender
+Suffix Directory: true
+Duration: 2:37
+URLs:
+- https://toriscrow.bandcamp.com/track/lavender
+---
+Track: Steven's Theme
+Duration: 1:55
+URLs:
+- https://toriscrow.bandcamp.com/track/stevens-theme
+---
+Track: Boss Battle
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 1:17
+URLs:
+- https://toriscrow.bandcamp.com/track/boss-battle
+---
+Track: Four-Leaf Clover
+Duration: 1:41
+URLs:
+- https://toriscrow.bandcamp.com/track/four-leaf-clover
+---
+Track: Apologies
+Suffix Directory: true
+Duration: 2:12
+URLs:
+- https://toriscrow.bandcamp.com/track/apologies
+---
+Track: Guardian of the Light
+Duration: 1:54
+URLs:
+- https://toriscrow.bandcamp.com/track/guardian-of-the-light
+---
+Track: The Preacher
+Duration: 4:11
+URLs:
+- https://toriscrow.bandcamp.com/track/the-preacher
+---
+Track: Runaway
+Suffix Directory: true
+Duration: 1:54
+URLs:
+- https://toriscrow.bandcamp.com/track/runaway

--- a/album/morpheus.yaml
+++ b/album/morpheus.yaml
@@ -19,7 +19,7 @@ Commentary: |-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/morpheus))
 
-    All art by the wonderful [[artist:wander|[wander.]]]
+    All art by the wonderful [[artist:wander|[wander]]].
 
 ---
 Track: Faustian Bargain

--- a/album/morpheus.yaml
+++ b/album/morpheus.yaml
@@ -10,6 +10,7 @@ Cover Art File Extension: png
 Cover Art Dimensions: 1725x1678
 Color: '#f34c4b'
 Groups:
+- Toris Crow
 - Beyond
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/morpheus))

--- a/album/panoptes.yaml
+++ b/album/panoptes.yaml
@@ -1,0 +1,115 @@
+Album: Panoptes
+Artists:
+- Toris Crow
+Date: February 27, 2019
+URLs:
+- https://toriscrow.bandcamp.com/album/panoptes
+Cover Artists:
+- wander
+Cover Art File Extension: png
+Cover Art Dimensions: 1725x1678
+Color: '#a677b7'
+Groups:
+- Beyond
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/panoptes))
+
+    You dream of a mysterious bartender with many eyes. He knows what you are looking for. You watch as he polishes the glass in his hand, pensively; yet the glass is already spotless. Where did he come from? What does he want?
+
+Crediting Sources: |-
+    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/panoptes))
+
+    Album art by [[artist:wander|[wander.]]]
+
+---
+Track: Under an Ocean
+Duration: 1:40
+URLs:
+- https://toriscrow.bandcamp.com/track/under-an-ocean
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/under-an-ocean))
+
+    This track was written for Sarah Jolley's webcomic "The Property of Hate." [You can check it out here.](https://jolleycomics.com/TPoH/)
+
+---
+Track: Autumn Fires
+Duration: 0:49
+URLs:
+- https://toriscrow.bandcamp.com/track/autumn-fires
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/autumn-fires))
+
+    This track was used in JP Reuter's comedy short film "The Curious Mystery of the Mysterious Curiosity." You can watch it here: [www.youtube.com/watch?v=kU30uYqpP5I](https://www.youtube.com/watch?v=kU30uYqpP5I)
+
+---
+Track: Winter Solstice
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 2:33
+URLs:
+- https://toriscrow.bandcamp.com/track/winter-solstice-2
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/winter-solstice-2))
+
+    This is actually the Winter Solstice I wrote in 2016. It is a several year tradition for me to start or write a piece on December 21st and call it "Winter Solstice."
+
+---
+Track: Surrendering Salvation
+Duration: 2:15
+URLs:
+- https://toriscrow.bandcamp.com/track/surrendering-salvation
+---
+Track: Circadian Rhythm
+Duration: 1:20
+URLs:
+- https://toriscrow.bandcamp.com/track/circadian-rhythm
+---
+Track: The Albatross and the Raven
+Duration: 2:15
+URLs:
+- https://toriscrow.bandcamp.com/track/the-albatross-and-the-raven
+---
+Track: Pink Flowers
+Duration: 2:06
+URLs:
+- https://toriscrow.bandcamp.com/track/pink-flowers
+Commentary: |-
+    <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/pink-flowers))
+
+    This track was written for Sarah Jolley's webcomic "The Property of Hate." [You can check it out here.](https://jolleycomics.com/TPoH/)
+
+---
+Track: The Foolish God
+Duration: 2:27
+URLs:
+- https://toriscrow.bandcamp.com/track/the-foolish-god
+---
+Track: Fog and Frost
+Duration: 1:30
+URLs:
+- https://toriscrow.bandcamp.com/track/fog-and-frost
+---
+Track: A Thorn With Every Rose
+Artists:
+- Toris Crow
+- Michael Rosie
+Duration: 2:09
+URLs:
+- https://toriscrow.bandcamp.com/track/a-thorn-with-every-rose
+Crediting Sources: |-
+    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/track/a-thorn-with-every-rose)
+
+    Made in collaboration with [[artist:michael-rosie]].
+
+---
+Track: Guardians
+Suffix Directory: true
+Always Reference By Directory: true
+Duration: 1:06
+URLs:
+- https://toriscrow.bandcamp.com/track/guardians
+---
+Track: The Starship Oblivion
+Duration: 1:30
+URLs:
+- https://toriscrow.bandcamp.com/track/the-starship-oblivion

--- a/album/panoptes.yaml
+++ b/album/panoptes.yaml
@@ -10,6 +10,7 @@ Cover Art File Extension: png
 Cover Art Dimensions: 1725x1678
 Color: '#a677b7'
 Groups:
+- Toris Crow
 - Beyond
 Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/panoptes))

--- a/album/panoptes.yaml
+++ b/album/panoptes.yaml
@@ -16,12 +16,10 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/album/panoptes))
 
     You dream of a mysterious bartender with many eyes. He knows what you are looking for. You watch as he polishes the glass in his hand, pensively; yet the glass is already spotless. Where did he come from? What does he want?
-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/panoptes))
 
-    Album art by [[artist:wander|[wander]]].
-
+    Album art by [[artist:wander]].
 ---
 Track: Under an Ocean
 Duration: 1:40
@@ -31,7 +29,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/under-an-ocean))
 
     This track was written for Sarah Jolley's webcomic "The Property of Hate." [You can check it out here.](https://jolleycomics.com/TPoH/)
-
 ---
 Track: Autumn Fires
 Duration: 0:49
@@ -41,7 +38,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/autumn-fires))
 
     This track was used in JP Reuter's comedy short film "The Curious Mystery of the Mysterious Curiosity." You can watch it here: [www.youtube.com/watch?v=kU30uYqpP5I](https://www.youtube.com/watch?v=kU30uYqpP5I)
-
 ---
 Track: Winter Solstice
 Suffix Directory: true
@@ -53,7 +49,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/winter-solstice-2))
 
     This is actually the Winter Solstice I wrote in 2016. It is a several year tradition for me to start or write a piece on December 21st and call it "Winter Solstice."
-
 ---
 Track: Surrendering Salvation
 Duration: 2:15
@@ -78,7 +73,6 @@ Commentary: |-
     <i>Toris Crow:</i> ([Bandcamp about blurb](https://toriscrow.bandcamp.com/track/pink-flowers))
 
     This track was written for Sarah Jolley's webcomic "The Property of Hate." [You can check it out here.](https://jolleycomics.com/TPoH/)
-
 ---
 Track: The Foolish God
 Duration: 2:27
@@ -98,10 +92,9 @@ Duration: 2:09
 URLs:
 - https://toriscrow.bandcamp.com/track/a-thorn-with-every-rose
 Crediting Sources: |-
-    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/track/a-thorn-with-every-rose)
+    <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/track/a-thorn-with-every-rose))
 
     Made in collaboration with [[artist:michael-rosie]].
-
 ---
 Track: Guardians
 Suffix Directory: true

--- a/album/panoptes.yaml
+++ b/album/panoptes.yaml
@@ -19,7 +19,7 @@ Commentary: |-
 Crediting Sources: |-
     <i>Toris Crow:</i> ([Bandcamp credits blurb](https://toriscrow.bandcamp.com/album/panoptes))
 
-    Album art by [[artist:wander|[wander.]]]
+    Album art by [[artist:wander|[wander]]].
 
 ---
 Track: Under an Ocean

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -880,13 +880,6 @@ Duration: 0:24
 URLs:
 - https://www.youtube.com/watch?v=cIvkdbhBnnc
 ---
-Track: Featherlight
-Artists:
-- Toris Crow
-Duration: 1:28
-URLs:
-- https://toriscrow.bandcamp.com/track/featherlight
----
 Track: findher
 Artists:
 - Toby Fox

--- a/artists.yaml
+++ b/artists.yaml
@@ -14948,6 +14948,10 @@ Artist: Tha Trademarc
 ---
 Artist: Thaehan
 ---
+Artist: thatdappertellybloke
+URLs:
+- https://thatdappertellybloke.tumblr.com/
+---
 Artist: The8BitDrummer
 ---
 Artist: TheAdvertiseme

--- a/artists.yaml
+++ b/artists.yaml
@@ -13006,6 +13006,14 @@ Artist: Sarah Fu
 URLs:
 - https://sarahfu.tumblr.com/
 ---
+Artist: Sarah Jolley
+Aliases:
+- modmad
+- thatdappertellybloke
+URLs:
+- https://modmad.tumblr.com
+- https://jolleycomics.com
+---
 Artist: Sarah Stiles
 ---
 Artist: Sarah Zedig
@@ -14949,10 +14957,6 @@ Artist: Tetsuya Shibata
 Artist: Tha Trademarc
 ---
 Artist: Thaehan
----
-Artist: thatdappertellybloke
-URLs:
-- https://thatdappertellybloke.tumblr.com/
 ---
 Artist: The8BitDrummer
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -6119,26 +6119,28 @@ Artist: hatzka
 Artist: Haunter
 Aliases:
 - HaunterDubstep
+- HaunterWI
+- hauntermke
 - BlastProcessed
 - Martyn Davies
 - IKarusEDM
-- IKarus
-- IKARUS
 URLs:
-- https://haunteruk.bandcamp.com/
-- https://ikarusedm.bandcamp.com/
+- https://haunter.bandcamp.com/
 - https://blastprocessed.bandcamp.com/
+- https://soundcloud.com/haunter-wi
 - https://soundcloud.com/ikarusedm
 - https://soundcloud.com/blastprocessed
 - https://soundcloud.com/haunter-dubstep
-- https://www.youtube.com/@IKarusEDM
-- https://www.youtube.com/@HaunterDubstep/
+- https://www.youtube.com/user/haunterWI
+- https://www.youtube.com/user/IKarusEDM/
+- https://www.youtube.com/user/HaunterDubstep
 - https://blastprocessed.tumblr.com/
+- https://twitter.com/HaunterWI
+- https://www.facebook.com/hauntermke/
 - https://www.facebook.com/BlastProcessed/
 - https://www.facebook.com/HaunterDubstep
 Dead URLs:
 - https://twitter.com/HaunterDubstep
-- https://haunter.bandcamp.com/ #former url of haunteruk.bandcamp.com, now bandcamp home of MKE/WI band unrelated to IKarus/Haunter/BlastProcessed
 - https://myspace.com/552379098
 - https://haunterdubstep.tumblr.com/
 - https://vault15.tumblr.com/

--- a/artists.yaml
+++ b/artists.yaml
@@ -4950,6 +4950,8 @@ URLs:
 - http://www.youtube.com/jessevalentinemusic
 - https://open.spotify.com/artist/4c7ssQj66cEGMq6viiJdTZ
 ---
+Artist: F. C. Ambrose
+---
 Artist: F-ZERO
 ---
 Artist: Fable Bae
@@ -9766,6 +9768,8 @@ Artist: Michael Rosen
 URLs:
 - https://www.michaelrosen.co.uk/
 - https://www.youtube.com/channel/UC7D-mXO4kk-XWvH6lBXdrPw
+---
+Artist: Michael Rosie
 ---
 Artist: Michael Salvatori
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -4950,8 +4950,6 @@ URLs:
 - http://www.youtube.com/jessevalentinemusic
 - https://open.spotify.com/artist/4c7ssQj66cEGMq6viiJdTZ
 ---
-Artist: F. C. Ambrose
----
 Artist: F-ZERO
 ---
 Artist: Fable Bae
@@ -15953,6 +15951,12 @@ Artist: Walter Donovan
 Artist: Walter Murphy
 ---
 Artist: Walter Rollins
+---
+Artist: wander
+Aliases:
+- F. C. Ambrose
+URLs:
+- https://ghostwandering.tumblr.com/
 ---
 Artist: Wario Land
 ---

--- a/groups.yaml
+++ b/groups.yaml
@@ -916,6 +916,16 @@ Series:
   - 'Pokémon Sword & Pokémon Shield + Expansion Pass: Super Music Collection' # effectively 11/8/2019, via https://www.pokemon.com/us/pokemon-news/a-special-letter-and-song-from-undertale-game-creator-toby-fox
   - 'Pokémon Scarlet & Pokémon Violet + The Hidden Treasure of Area Zero: Super Music Collection'
 ---
+Group: Toris Crow
+Closely Linked Artists:
+- Toris Crow
+URLs:
+- https://toriscrow.bandcamp.com/
+Description: |-
+    A small bird with a taste for music.
+    <hr class="split">
+    [Description via Bandcamp.](https://toriscrow.bandcamp.com/)
+---
 Group: what is lost in the mines?
 Closely Linked Artists:
 - WHATISLOSTINTHEMINES

--- a/groups.yaml
+++ b/groups.yaml
@@ -922,8 +922,10 @@ Closely Linked Artists:
 URLs:
 - https://toriscrow.bandcamp.com/
 Description: |-
-    A small bird with a taste for music.
+    <i>"A small bird with a taste for music."</i>
+
     <hr class="split">
+
     [Description via Bandcamp.](https://toriscrow.bandcamp.com/)
 ---
 Group: what is lost in the mines?

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -430,7 +430,6 @@ Content: |-
     <!-- tracks newly marked as a secondary release -->
     - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:rectify-lofam2]] ([[album:lofam2]]) newly as a secondary release (thanks, Lan!)
-    - marked [[track:50m3-gr347-4c7-0f-h3r015m]] ([[album:beforus]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
     - marked [[track:frost-and-frogs-lofam5a2]] ([[album:lofam5a2]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:fallen-down]] ([[album:i-miss-you-earthbound-2012]] newly as a secondary release (thanks, ruby!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -430,6 +430,7 @@ Content: |-
     <!-- tracks newly marked as a secondary release -->
     - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:rectify-lofam2]] ([[album:lofam2]]) newly as a secondary release (thanks, Lan!)
+    - marked [[track:50m3-gr347-4c7-0f-h3r015m]] ([[album:beforus]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
     - marked [[track:frost-and-frogs-lofam5a2]] ([[album:lofam5a2]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:fallen-down]] ([[album:i-miss-you-earthbound-2012]] newly as a secondary release (thanks, ruby!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -209,7 +209,7 @@ Content: |-
         - added [[album:the-earthen-scar]], [[album:the-liminal-descent]], [[album:the-divine-deception]], and [[album:the-earthen-scar-revisited]]!
         - added [[album:vespers]] and [[album:grigori]]!
         - added [[album:corpseflower-cycle]], [[album:elementail]], [[album:the-carpet-merchant-of-konstantiniyya]], and [[album:dear-children]]!
-    - added releases by [[group:toris-crow]]! (thanks, Lilith!)
+    - added releases by [[group:toris-crow]]! (thanks, <<Lilith:album data, presentation, research>>, <<Lan:additional data, presentation, research>>!)
         - added [[album:ambrosios]]!
         - added [[album:chimera]]!
         - added [[album:morpheus]]!

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -209,7 +209,7 @@ Content: |-
         - added [[album:the-earthen-scar]], [[album:the-liminal-descent]], [[album:the-divine-deception]], and [[album:the-earthen-scar-revisited]]!
         - added [[album:vespers]] and [[album:grigori]]!
         - added [[album:corpseflower-cycle]], [[album:elementail]], [[album:the-carpet-merchant-of-konstantiniyya]], and [[album:dear-children]]!
-    - added releases by [[artist:toris-crow]]! (thanks, Lilith!)
+    - added releases by [[group:toris-crow]]! (thanks, Lilith!)
         - added [[album:ambrosios]]!
         - added [[album:chimera]]!
         - added [[album:morpheus]]!
@@ -246,6 +246,7 @@ Content: |-
     - added [[group:raid]] group (thanks, <<Lilith:data, description>>!)
     - added [[group:svix]] group (thanks, <<Lilith:data, description>>!)
     - added [[group:thomas-ferkol]] group (thanks, <<Jebb:data, description feedback>>, <<Lan:description>>, <<Makin:description feedback>>, <<Grace:description feedback>>!)
+    - added [[group:toris-crow]] group (thanks, Lilith!)
     - added [[group:act-omega]] group (thanks, <<Whisper:data, description>>!)
     - added [[group:cheezquest]] group (thanks, <<Jebb:data, description>>, <<Lan:description>>!)
     - added [[group:sbargv2]] group (thanks, <<wertercatt:data, description>>!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -209,6 +209,11 @@ Content: |-
         - added [[album:the-earthen-scar]], [[album:the-liminal-descent]], [[album:the-divine-deception]], and [[album:the-earthen-scar-revisited]]!
         - added [[album:vespers]] and [[album:grigori]]!
         - added [[album:corpseflower-cycle]], [[album:elementail]], [[album:the-carpet-merchant-of-konstantiniyya]], and [[album:dear-children]]!
+    - added releases by [[artist:toris-crow]]! (thanks, Lilith!)
+        - added [[album:ambrosios]]!
+        - added [[album:chimera]]!
+        - added [[album:morpheus]]!
+        - added [[album:panoptes]]!
     - added special release soundtracks and other additional releases from [[group:undertale-and-deltarune]]! (thanks, ruby, bit, Lan, Tangle!)
         - added [[album:undertale-soundtrack-cd]]!
         - added [[album:undertale-collectors-edition-soundtrack]]!
@@ -424,6 +429,7 @@ Content: |-
     <!-- tracks newly marked as a secondary release -->
     - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:rectify-lofam2]] ([[album:lofam2]]) newly as a secondary release (thanks, Lan!)
+    - marked [[track:50m3-gr347-4c7-0f-h3r015m]] ([[album:beforus]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
     - marked [[track:frost-and-frogs-lofam5a2]] ([[album:lofam5a2]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:fallen-down]] ([[album:i-miss-you-earthbound-2012]] newly as a secondary release (thanks, ruby!)
@@ -433,6 +439,7 @@ Content: |-
         - moved [[track:mysterious-shrine]], [[track:absolutely-overfamiliar-shrine]], [[track:bonetrousle-trailer-version]], and [[track:before-the-story]] to [[album:undertale-collectors-edition-soundtrack]]
         - moved [[track:dating-start-fm-version]], [[track:bereavement]], and [[track:dog-dating]] to [[album:undertale-soundtrack-cd]]
         - moved [[track:mad-mew-mew]] to single release
+    - moved [[track:featherlight]] from [[album:references-beyond-homestuck]] to [[album:ambrosios]] (thanks, Lilith!)
     - moved [[track:bad-apple-lovelight]] (feat. [[artist:nomico]]) from "Music from video games" to "Other music originating outside Homestuck" (thanks, Lan, bit!)
     <!-- track section/placement changes (not fixes) -->
     - moved [[track:the-respect-you-rightfully-deserve-single]] from [[album:more-homestuck-fandom]] to [[album:the-respect-you-rightfully-deserve|single release]] (thanks, Lilith!)


### PR DESCRIPTION
### Adds all four of Toris Crow's Beyond albums:
- [Ambrosios, April 10, 2016](https://toriscrow.bandcamp.com/album/ambrosios)
- [Chimera, September 4, 2016](https://toriscrow.bandcamp.com/album/chimera)
- [Morpheus, December 30, 2016](https://toriscrow.bandcamp.com/album/morpheus)
- [Panoptes, February 27, 2019](https://toriscrow.bandcamp.com/album/panoptes)
----
### other additions/changes:
- added Toris Crow (group of crows is called a murder)
- moved Featherlight from References Beyond Homestuck to Ambrosios, its home album
- marked 50M3 GR347 4C7 0F H3R015M newly as a rerelease, per Ambrosios' release date (April 10) compared to Beforus (April 12) ~~(10/2025 edit: nevermind this one, could cause complications now that I think about it)~~ (11/2025 edit: this is getting ridiculous, I reverted these un-changes... why?)

Goes with: https://github.com/hsmusic/hsmusic-media/pull/141