### PR TITLE
Artwork origin details

### DIFF
--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -149,6 +149,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 1355](https://homestuck.com/story/1355)
   Tags:
   - Karkat
   - Karkat's lusus # Crabsprite
@@ -200,6 +202,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2069](https://homestuck.com/story/2069)
   Tags:
   - Karkat
   - Karkat's lusus
@@ -259,6 +263,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2017](https://homestuck.com/story/2017)
   Tags:
   - Gamzee
   - Gamzee's hive
@@ -313,6 +319,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2047](https://homestuck.com/story/2047)
   Tags:
   - Terezi
   - Scalemates
@@ -361,6 +369,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2059](https://homestuck.com/story/2059)
   Tags:
   - Karkat
   - Karkat's hive
@@ -406,6 +416,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2063](https://homestuck.com/story/2063)
   Tags:
   - Aradia (ghost)
   - Alternia
@@ -449,6 +461,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2074](https://homestuck.com/story/2074)
   Tags:
   - Nepeta
   - Nepeta's hive
@@ -493,6 +507,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2115](https://homestuck.com/story/2115)
   Tags:
   - Tavros
   - Tavros' hive
@@ -536,6 +552,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2089](https://homestuck.com/story/2089)
   Tags:
   - Gamzee
   - Gamzee's lusus
@@ -580,6 +598,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2097](https://homestuck.com/story/2097)
   Tags:
   - Kanaya
   - Kanaya's lusus
@@ -622,6 +642,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2153](https://homestuck.com/story/2153)
   Tags:
   - Sollux
 - Label: Anthology fanart
@@ -837,6 +859,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2120](https://homestuck.com/story/2120), with edits
   Tags:
   - Equius
 - Label: Anthology fanart
@@ -877,6 +901,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2181](https://homestuck.com/story/2181)
   Tags:
   - Feferi
   - Ψdon's Entente
@@ -965,6 +991,8 @@ Track Artwork:
   File Extension: jpg
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2161](https://homestuck.com/story/2161), with edits
 - Label: Anthology fanart
   Source: '[ALTERNIA/BOUND](https://alterniaart.tumblr.com)'
   Date: October 25, 2017

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -110,6 +110,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3568](https://homestuck.com/story/3568)
   Tags:
   - Aradia
   - Green Sun
@@ -176,6 +178,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:2792]]
   Tags:
   - Karkat
   - Clawsickle
@@ -242,6 +246,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:2792]]
   Tags:
   - Terezi
   - Dragon Cane
@@ -300,6 +306,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3369](https://homestuck.com/story/3369)
   Tags:
   - Terezi
   - Tavros
@@ -369,6 +377,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:2792]]
   Tags:
   - Terezi
   - Scalemates
@@ -425,6 +435,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3571](https://homestuck.com/story/3571)
   Tags:
   - Aradia
   - Dream Bubbles
@@ -467,6 +479,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:2792]]
   Tags:
   - Vriska
 - Label: Anthology fanart
@@ -518,6 +532,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2459](https://homestuck.com/story/2459)
   Tags:
   - Vriska
   - Eridan
@@ -562,6 +578,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2102](https://homestuck.com/story/2102)
   Tags:
   - Tavros
   - Tavros' lusus
@@ -619,6 +637,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2336](https://homestuck.com/story/2336)
   Tags:
   - Kanaya
   - Matriorb
@@ -667,6 +687,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3527](https://homestuck.com/story/3527)
   Tags:
   - Kanaya
   - 'cw: blood'
@@ -714,6 +736,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3331](https://homestuck.com/story/3331)
   Tags:
   - Eridan
   - Empiricist's Wand
@@ -810,6 +834,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3321](https://homestuck.com/story/3321)
   Tags:
   - Sollux
   - Eridan
@@ -848,6 +874,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:3438]]
   Tags:
   - Nepeta
   - Karkat
@@ -896,6 +924,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:3438]]
   Tags:
   - Equius
   - Equius' bots
@@ -945,6 +975,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 3444](https://homestuck.com/story/3444)
   Tags:
   - Equius
   - Gamzee
@@ -999,6 +1031,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:3438]]
   Tags:
   - Equius
   - Gamzee
@@ -1037,6 +1071,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2217](https://homestuck.com/story/2217)
   Tags:
   - Equius
 - Label: Anthology fanart
@@ -1094,6 +1130,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:3520]]
   Tags:
   - Vriska
   - Eridan
@@ -1142,6 +1180,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2592](https://homestuck.com/story/2592)
   Tags:
   - BK
   - Aradia's Soulbot
@@ -1282,6 +1322,8 @@ Track Artwork:
   Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2601](https://homestuck.com/story/2601)
   Tags:
   - Karkat
   - Victory Platform # ehhh
@@ -1350,6 +1392,8 @@ Track Artwork:
   File Extension: jpg
   Artists:
   - Homestuck
+  Origin Details: >-
+    Edit of [page 3589](https://homestuck.com/story/3589)
   Tags:
   - Aradia
   - Alternia
@@ -1386,6 +1430,8 @@ Track Artwork:
   File Extension: jpg
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2534](https://homestuck.com/story/2534)
   Tags:
   - Nepeta
   - Underlings
@@ -1426,6 +1472,8 @@ Track Artwork:
   File Extension: jpg
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2422](https://homestuck.com/story/2422)
   Tags:
   - Feferi
   - Cuttlefish
@@ -1468,6 +1516,8 @@ Track Artwork:
   File Extension: jpg
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2347](https://homestuck.com/story/2347)
   Tags:
   - Kanaya
   - Underlings
@@ -1612,6 +1662,8 @@ Track Artwork:
   File Extension: jpg
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [page 2060](https://homestuck.com/story/2060)
   Tags:
   - Karkat
   - Homes Smell Ya Later

--- a/album/hiveswap-friendsim.yaml
+++ b/album/hiveswap-friendsim.yaml
@@ -297,7 +297,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/iiywaswiwtbotsa4aatwuotdtmihcimfh)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:phil-gibson]]
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Stelsa
   - Trizza

--- a/album/hiveswap-friendsim.yaml
+++ b/album/hiveswap-friendsim.yaml
@@ -48,7 +48,7 @@ Commentary: |-
 
     Cover art by [[artist:p-pamda]]
 Wallpaper Artists:
-- Danny Cragg
+- Danny Kilgore
 Wallpaper Style: 'opacity: 0.75;'
 Wallpaper File Extension: png
 ---
@@ -63,7 +63,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/i-guess-its-called-artchop-i-didnt-name-it-but-im-down)
   Origin Details: >-
-    Uses character sprite and background art by [[artist:danny-cragg]]
+    Uses character sprite and background art by [[artist:danny-kilgore]]
   Tags:
   - Amisia
   - Alternia
@@ -84,7 +84,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/a-bunch-of-boxes-that-dont-translate-into-a-url)
   Origin Details: >-
-    Uses background art by [[artist:danny-cragg]]
+    Uses background art by [[artist:danny-kilgore]]
   Tags:
   - Alternia
 URLs:
@@ -110,7 +110,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/call-me-gor-gor)
   Origin Details: >-
-    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Tagora
   - Trizza
@@ -131,7 +131,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/tfw-another-james-roach-track)
   Origin Details: >-
-    Uses character sprite and background art by [[artist:danny-cragg]]
+    Uses character sprite and background art by [[artist:danny-kilgore]]
   Tags:
   - Kuprum
   - Folykl
@@ -189,7 +189,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/take-me-to-clown-church)
   Origin Details: >-
-    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Chahut
   - Alternia
@@ -219,7 +219,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/fortnite-funny-moments-epic-fails-episode-413)
   Origin Details: >-
-    Uses character sprite by [[artist:phil-gibson]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:phil-gibson]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Mallek
   - Trizza
@@ -420,7 +420,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/wanshis-theme-idk-man-you-name-it-im-tired)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Wanshi
   - Alternia
@@ -452,7 +452,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/graveyard-shift-play-the-route-and-then-tweet-hamesatron-about-how-good-this-title-is)
   Origin Details: >-
-    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Fozzer
   - Trizza
@@ -477,7 +477,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/clownfucker-by-james-roach-and-toby-fox)
   Origin Details: >-
-    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Marvus
   - Alternia
@@ -506,7 +506,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/this-title-is-too-long-see-description-darayas-theme)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Daraya
   - Trizza
@@ -534,7 +534,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/lmao-i-still-dont-know-if-its-nicky-or-nike-like-the-shoe-not-like-the-name-mike)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Nihkee
   - Alternia
@@ -601,7 +601,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://web.archive.org/web/20181231070207/https://soundcloud.com/jamesroachmusic/worst-end/)
   Origin Details: >-
-    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-cragg]]
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-kilgore]]
   Tags:
   - Doc Scratch
   - Trizza

--- a/album/hiveswap-friendsim.yaml
+++ b/album/hiveswap-friendsim.yaml
@@ -10,7 +10,7 @@ URLs:
 Cover Artists:
 - P-PAMda
 Default Track Cover Artists:
-- James Roach
+- James Roach (composition)
 Cover Art File Extension: png
 Color: '#d3ff8f'
 Groups:
@@ -248,10 +248,14 @@ Commentary: |-
 Track: Old Secret
 Duration: 4:26
 Track Artwork:
-- Source: >-
+- Artists:
+  - James Roach (edits)
+  Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/old-secret)
   Origin Details: >-
     Edit of [[album:hiveswap-act-1-ost]] album cover
+  Referenced Artworks:
+  - album:hiveswap-act-1-ost (edit)
   Tags:
   - Joey
   - Alternia

--- a/album/hiveswap-friendsim.yaml
+++ b/album/hiveswap-friendsim.yaml
@@ -10,7 +10,7 @@ URLs:
 Cover Artists:
 - P-PAMda
 Default Track Cover Artists:
-- Homestuck
+- James Roach
 Cover Art File Extension: png
 Color: '#d3ff8f'
 Groups:
@@ -59,9 +59,14 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 1:36
-Art Tags:
-- Amisia
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/i-guess-its-called-artchop-i-didnt-name-it-but-im-down)
+  Origin Details: >-
+    Uses character sprite and background art by [[artist:danny-cragg]]
+  Tags:
+  - Amisia
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/artchop-apparently
 - https://soundcloud.com/jamesroachmusic/i-guess-its-called-artchop-i-didnt-name-it-but-im-down
@@ -75,8 +80,13 @@ Commentary: |-
 Track: Ｍ Ｏ Ｉ Ｓ Ｔ
 Directory: moist
 Duration: 2:29
-Art Tags:
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/a-bunch-of-boxes-that-dont-translate-into-a-url)
+  Origin Details: >-
+    Uses background art by [[artist:danny-cragg]]
+  Tags:
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/-
 - https://soundcloud.com/jamesroachmusic/a-bunch-of-boxes-that-dont-translate-into-a-url
@@ -96,10 +106,15 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 3:05
-Art Tags:
-- Tagora
-- Trizza
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/call-me-gor-gor)
+  Origin Details: >-
+    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Tagora
+  - Trizza
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/call-me-gor-gor
 - https://soundcloud.com/jamesroachmusic/call-me-gor-gor
@@ -112,10 +127,15 @@ Commentary: |-
 Track: '>tfw another james roach track'
 Directory: tfw-another-james-roach-track
 Duration: 2:55
-Art Tags:
-- Kuprum
-- Folykl
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/tfw-another-james-roach-track)
+  Origin Details: >-
+    Uses character sprite and background art by [[artist:danny-cragg]]
+  Tags:
+  - Kuprum
+  - Folykl
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/tfw-another-james-roach-track
 - https://soundcloud.com/jamesroachmusic/tfw-another-james-roach-track
@@ -127,9 +147,14 @@ Commentary: |-
 ---
 Track: Piwates ',:^]
 Duration: 3:46
-Art Tags:
-- Remele
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/piwates)
+  Origin Details: >-
+    Uses character sprite and background art by [[artist:gina-chacon]]
+  Tags:
+  - Remele
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/piwates
 - https://soundcloud.com/jamesroachmusic/piwates
@@ -142,8 +167,13 @@ Commentary: |-
 ---
 Track: it be like that sometimes
 Duration: 3:08
-Art Tags:
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/it-be-like-that-sometimes)
+  Origin Details: >-
+    Uses background art by [[artist:adrienne-garcia]]
+  Tags:
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/it-be-like-that-sometimes
 - https://soundcloud.com/jamesroachmusic/it-be-like-that-sometimes
@@ -155,10 +185,15 @@ Commentary: |-
 ---
 Track: take me to clown church
 Duration: 3:07
-Art Tags:
-- Chahut
-- Alternia
-- 'cw: blood'
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/take-me-to-clown-church)
+  Origin Details: >-
+    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Chahut
+  - Alternia
+  - 'cw: blood'
 URLs:
 - https://homestuck.bandcamp.com/track/take-me-to-clown-church
 - https://soundcloud.com/jamesroachmusic/take-me-to-clown-church
@@ -180,10 +215,15 @@ Additional Names:
   Annotation: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/fortnite-funny-moments-epic-fails-episode-413)
 Duration: 3:36
-Art Tags:
-- Mallek
-- Trizza
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/fortnite-funny-moments-epic-fails-episode-413)
+  Origin Details: >-
+    Uses character sprite by [[artist:phil-gibson]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Mallek
+  - Trizza
+  - Alternia
 Referenced Tracks:
 - track:lexxer-ascend
 - track:nuclear-james-roach
@@ -207,11 +247,16 @@ Commentary: |-
 ---
 Track: Old Secret
 Duration: 4:26
-Art Tags:
-- Joey
-- Alternia
-- Pink Moon
-- Green Moon
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/old-secret)
+  Origin Details: >-
+    Edit of [[album:hiveswap-act-1-ost]] album cover
+  Tags:
+  - Joey
+  - Alternia
+  - Pink Moon
+  - Green Moon
 URLs:
 - https://homestuck.bandcamp.com/track/old-secret
 - https://soundcloud.com/jamesroachmusic/old-secret
@@ -244,10 +289,15 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 1:11
-Art Tags:
-- Stelsa
-- Trizza
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/iiywaswiwtbotsa4aatwuotdtmihcimfh)
+  Origin Details: >-
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:phil-gibson]]
+  Tags:
+  - Stelsa
+  - Trizza
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/iiywaswiwtbotsa4aatwuotdtmihcimfh
 - https://soundcloud.com/jamesroachmusic/iiywaswiwtbotsa4aatwuotdtmihcimfh
@@ -275,9 +325,14 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 4:13
-Art Tags:
-- Marsti
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/service-car)
+  Origin Details: >-
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:angela-sham]]
+  Tags:
+  - Marsti
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/service-car
 - https://soundcloud.com/jamesroachmusic/service-car
@@ -301,9 +356,14 @@ Additional Names:
   Annotation: >-
     in-game credits, "she.png"
 Duration: 5:08
-Art Tags:
-- Karako
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/an-ascii-image-of-bowsette)
+  Origin Details: >-
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:angela-sham]]
+  Tags:
+  - Karako
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/an-ascii-image-of-bowsette
 - https://soundcloud.com/jamesroachmusic/an-ascii-image-of-bowsette
@@ -352,9 +412,14 @@ Commentary: |-
 ---
 Track: idk man you name it im tired
 Duration: 2:36
-Art Tags:
-- Wanshi
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/wanshis-theme-idk-man-you-name-it-im-tired)
+  Origin Details: >-
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Wanshi
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/idk-man-you-name-it-im-tired
 - https://soundcloud.com/jamesroachmusic/wanshis-theme-idk-man-you-name-it-im-tired
@@ -379,10 +444,15 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 5:24
-Art Tags:
-- Fozzer
-- Trizza
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/graveyard-shift-play-the-route-and-then-tweet-hamesatron-about-how-good-this-title-is)
+  Origin Details: >-
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Fozzer
+  - Trizza
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/graveyard-shift
 - >-
@@ -399,9 +469,14 @@ Artists:
 - James Roach
 - Toby Fox
 Duration: 2:52
-Art Tags:
-- Marvus
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/clownfucker-by-james-roach-and-toby-fox)
+  Origin Details: >-
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Marvus
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/clownfucker
 - https://soundcloud.com/jamesroachmusic/clownfucker-by-james-roach-and-toby-fox
@@ -423,10 +498,15 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 2:10
-Art Tags:
-- Daraya
-- Trizza
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/this-title-is-too-long-see-description-darayas-theme)
+  Origin Details: >-
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Daraya
+  - Trizza
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/this-title-was-too-long
 - https://soundcloud.com/jamesroachmusic/this-title-is-too-long-see-description-darayas-theme
@@ -446,9 +526,14 @@ Additional Names:
   Annotation: >-
     in-game credits
 Duration: 2:15
-Art Tags:
-- Nihkee
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://soundcloud.com/jamesroachmusic/lmao-i-still-dont-know-if-its-nicky-or-nike-like-the-shoe-not-like-the-name-mike)
+  Origin Details: >-
+    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Nihkee
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/turns-out-its-like-the-shoe
 - https://soundcloud.com/jamesroachmusic/lmao-i-still-dont-know-if-its-nicky-or-nike-like-the-shoe-not-like-the-name-mike
@@ -508,10 +593,15 @@ Commentary: |-
 ---
 Track: WORST END
 Duration: 2:30
-Art Tags:
-- Doc Scratch
-- Trizza
-- Alternia
+Track Artwork:
+- Source: >-
+    [SoundCloud](https://web.archive.org/web/20181231070207/https://soundcloud.com/jamesroachmusic/worst-end/)
+  Origin Details: >-
+    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-cragg]]
+  Tags:
+  - Doc Scratch
+  - Trizza
+  - Alternia
 URLs:
 - https://homestuck.bandcamp.com/track/worst-end
 - https://youtu.be/tf_EvjG7Ir8

--- a/album/hiveswap-friendsim.yaml
+++ b/album/hiveswap-friendsim.yaml
@@ -47,6 +47,18 @@ Commentary: |-
     Bonus friendship by [[artist:toby-fox]] on [[CLOWNFUCKER|"CLOWNFUCKER"]] and [[yall know i just do the music right|"yall know i just do the music right"]]
 
     Cover art by [[artist:p-pamda]]
+
+    <i>Quasar Nebula:</i> (wiki editor, 6/4/2025)
+
+    Primary artworks throughout this album are from James Roach's own SoundCloud, where he uploaded tracks as volumes of Pesterquest were released (so earlier than this album's own release). Most of them are set on the background art asset used on the main menu of Hiveswap Friendsim.
+
+    But we're not exactly sure who drew it! Current in-game credits indicate [[artist:danny-kilgore]] was the background artist for the first two volumes. However, this asset *isn't from Friendsim* - it's actually part of [[flash:hiveswap-act1]]. That game credits many artists in the role of "environment art", including [[artist:shelby-cragg]].
+
+    Danny and Shelby's crediting in Hiveswap Friendsim are nuanced. The initial release of the game (i.e. including only the first two volumes) credits Shelby as "colorist, bg painting" and Danny for "character art, illustration". Some later update revised this, crediting Shelby only under "colorists" and Danny as "character artists, background artists".
+
+    The asset also brings its own nuance, because the file from Hiveswap does *not* include the MSPA reader's crashed rocket ship! Someone must have drawn (and colored) this for Hiveswap Friendsim. Meanwhile there are also plenty of original backgrounds in the first two volumes.
+
+    We're currently leaving this background art uncredited in the relevant track artworks' origin details. A handful of the track artworks are set on backgrounds which do come from Hiveeswap Friendsim, so those take from the in-game credits, like for all character sprites.
 Wallpaper Artists:
 - Danny Kilgore
 Wallpaper Style: 'opacity: 0.75;'
@@ -63,7 +75,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/i-guess-its-called-artchop-i-didnt-name-it-but-im-down)
   Origin Details: >-
-    Uses character sprite and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:danny-kilgore]]
   Tags:
   - Amisia
   - Alternia
@@ -110,7 +122,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/call-me-gor-gor)
   Origin Details: >-
-    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:gina-chacon]]
   Tags:
   - Tagora
   - Trizza
@@ -131,7 +143,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/tfw-another-james-roach-track)
   Origin Details: >-
-    Uses character sprite and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:danny-kilgore]]
   Tags:
   - Kuprum
   - Folykl
@@ -189,7 +201,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/take-me-to-clown-church)
   Origin Details: >-
-    Uses character sprite by [[artist:gina-chacon]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:gina-chacon]]
   Tags:
   - Chahut
   - Alternia
@@ -219,7 +231,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/fortnite-funny-moments-epic-fails-episode-413)
   Origin Details: >-
-    Uses character sprite by [[artist:phil-gibson]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:phil-gibson]]
   Tags:
   - Mallek
   - Trizza
@@ -297,7 +309,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/iiywaswiwtbotsa4aatwuotdtmihcimfh)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:adrienne-garcia]]
   Tags:
   - Stelsa
   - Trizza
@@ -420,7 +432,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/wanshis-theme-idk-man-you-name-it-im-tired)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:adrienne-garcia]]
   Tags:
   - Wanshi
   - Alternia
@@ -452,7 +464,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/graveyard-shift-play-the-route-and-then-tweet-hamesatron-about-how-good-this-title-is)
   Origin Details: >-
-    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:kim-quach]]
   Tags:
   - Fozzer
   - Trizza
@@ -477,7 +489,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/clownfucker-by-james-roach-and-toby-fox)
   Origin Details: >-
-    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:kim-quach]]
   Tags:
   - Marvus
   - Alternia
@@ -506,7 +518,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/this-title-is-too-long-see-description-darayas-theme)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:adrienne-garcia]]
   Tags:
   - Daraya
   - Trizza
@@ -534,7 +546,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://soundcloud.com/jamesroachmusic/lmao-i-still-dont-know-if-its-nicky-or-nike-like-the-shoe-not-like-the-name-mike)
   Origin Details: >-
-    Uses character sprite by [[artist:adrienne-garcia]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:adrienne-garcia]]
   Tags:
   - Nihkee
   - Alternia
@@ -601,7 +613,7 @@ Track Artwork:
 - Source: >-
     [SoundCloud](https://web.archive.org/web/20181231070207/https://soundcloud.com/jamesroachmusic/worst-end/)
   Origin Details: >-
-    Uses character sprite by [[artist:kim-quach]] and background art by [[artist:danny-kilgore]]
+    Uses character sprite by [[artist:kim-quach]]
   Tags:
   - Doc Scratch
   - Trizza

--- a/album/homestuck-vol-1-4.yaml
+++ b/album/homestuck-vol-1-4.yaml
@@ -244,6 +244,9 @@ Commentary: |-
 Track: Showtime Remix
 Main Release: Showtime Remix
 Duration: 2:02
+Track Artwork:
+- Tags:
+  - FreshJamz
 URLs:
 - https://homestuck.bandcamp.com/track/showtime-remix-3
 - https://youtu.be/ENWA9aNEkXk
@@ -251,7 +254,10 @@ URLs:
 Track: Aggrieve Remix
 Main Release: Aggrieve Remix
 Duration: 2:11
-Cover Art Dimensions: 350x351
+Track Artwork:
+- Dimensions: 350x351
+  Tags:
+  - FreshJamz
 URLs:
 - https://homestuck.bandcamp.com/track/aggrieve-remix-3
 - https://youtu.be/KilKZfggMOU
@@ -259,7 +265,10 @@ URLs:
 Track: Verdancy (Bassline)
 Main Release: Verdancy (Bassline)
 Duration: 0:52
-Cover Art Dimensions: 350x351
+Track Artwork:
+- Dimensions: 350x351
+  Tags:
+  - FreshJamz
 URLs:
 - https://homestuck.bandcamp.com/track/verdancy-bassline-3
 - https://youtu.be/Hhwop2K7zt0
@@ -269,6 +278,9 @@ Suffix Directory: false
 Artists:
 - rj lake
 Duration: 3:25
+Track Artwork:
+- Tags:
+  - FreshJamz
 URLs:
 - https://homestuck.bandcamp.com/track/potential-verdancy-2
 - https://youtu.be/2W9Dd4RAiHo

--- a/album/homestuck-vol-1.yaml
+++ b/album/homestuck-vol-1.yaml
@@ -62,11 +62,14 @@ Bandcamp Track ID: 2262044458
 Bandcamp Artwork ID: a2928401236
 Artists:
 - Kevin Regamey
-Art Tags:
-- John
-- John's home
-- Standing Piano
-Cover Art File Extension: gif
+Track Artwork:
+- File Extension: gif
+  Origin Details: >-
+    From [[flash:77]]
+  Tags:
+  - John
+  - John's home
+  - Standing Piano
 Duration: 2:20
 URLs:
 - https://homestuck.bandcamp.com/track/showtime-piano-refrain-3
@@ -98,9 +101,12 @@ Bandcamp Track ID: 3756188055
 Bandcamp Artwork ID: a2067313438
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Harlequinsprite
-Cover Art File Extension: gif
+Track Artwork:
+- File Extension: gif
+  Origin Details: >-
+    From [[flash:186]] (page 186)
+  Tags:
+  - Harlequinsprite
 Duration: 1:43
 URLs:
 - https://homestuck.bandcamp.com/track/harlequin-3
@@ -135,9 +141,12 @@ Bandcamp Track ID: 2219548866
 Bandcamp Artwork ID: a3851231837
 Artists:
 - Malcolm Brown
-Art Tags:
-- Dad
-Cover Art File Extension: gif
+Track Artwork:
+- File Extension: gif
+  Origin Details: >-
+    From [[flash:90]]
+  Tags:
+  - Dad
 Duration: 2:09
 MIDI Project Files:
 - Title: MIDI by IronInvoker47
@@ -169,8 +178,11 @@ Bandcamp Artwork ID: a1323568535
 Artists:
 - Michael Guy Bowman
 Duration: 1:36
-Art Tags:
-- Gate
+Track Artwork:
+- Origin Details: >-
+    From [[flash:137]] (page 137)
+  Tags:
+  - Gate
 URLs:
 - https://youtu.be/DKmXadfEnog
 Referenced Tracks:
@@ -195,11 +207,14 @@ Bandcamp Track ID: 2263998826
 Bandcamp Artwork ID: a1423086307
 Artists:
 - Andrew Huo
-Art Tags:
-- Rose
-- Rose's home
-- Violin
-Cover Art File Extension: gif
+Track Artwork:
+- File Extension: gif
+  Origin Details: >-
+    From [[flash:222]]
+  Tags:
+  - Rose
+  - Rose's home
+  - Violin
 Contributors:
 - Gabriel Nezovic (mastering)
 Duration: 1:34
@@ -223,9 +238,12 @@ Bandcamp Artwork ID: a4230425287
 Duration: 0:38
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Reckoning
-- 'Maple Valley, WA'
+Track Artwork:
+- Origin Details: >-
+    From [[flash:246]]
+  Tags:
+  - Reckoning
+  - 'Maple Valley, WA'
 URLs:
 - https://homestuck.bandcamp.com/track/sburban-countdown-3
 - https://youtu.be/C3cvihYafCs
@@ -248,11 +266,14 @@ Bandcamp Track ID: 4027745731
 Bandcamp Artwork ID: a1817699328
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Rose
-- Maplehoof
-- Knitting Needles
-Cover Art File Extension: gif
+Track Artwork:
+- File Extension: gif
+  Origin Details: >-
+    From [[flash:388]]
+  Tags:
+  - Rose
+  - Maplehoof
+  - Knitting Needles
 Duration: 2:32
 URLs:
 - https://homestuck.bandcamp.com/track/aggrieve-3
@@ -285,11 +306,14 @@ Bandcamp Artwork ID: a3157557772
 Artists:
 - Buzinkai
 - Curt Blakeslee (fanfare)
-Art Tags:
-- Underlings
-- Rabbit
-- Rag of Souls
-Cover Art File Extension: gif
+Track Artwork:
+- File Extension: gif
+  Origin Details: >-
+    From [[flash:393]]
+  Tags:
+  - Underlings
+  - Rabbit
+  - Rag of Souls
 Duration: 1:57
 URLs:
 - https://homestuck.bandcamp.com/track/showtime-imp-strife-mix-3
@@ -310,9 +334,12 @@ Bandcamp Track ID: 3935873528
 Bandcamp Artwork ID: a0663495851
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Nannasprite
-- John's nanna
+Track Artwork:
+- Origin Details: >-
+    From [[flash:418]]
+  Tags:
+  - Nannasprite
+  - John's nanna
 Duration: 1:24
 URLs:
 - https://homestuck.bandcamp.com/track/nannaquin-3
@@ -333,8 +360,11 @@ Bandcamp Track ID: 2603977158
 Bandcamp Artwork ID: a3958106753
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Skaia
+Track Artwork:
+- Origin Details: >-
+    From [[flash:422]]
+  Tags:
+  - Skaia
 Duration: 2:45
 URLs:
 - https://homestuck.bandcamp.com/track/skies-of-skaia-3
@@ -361,11 +391,14 @@ Track: Aggrieve (Violin Redux)
 Duration: 0:46
 Artists:
 - Andrew Huo
-Art Tags:
-- Rose
-- Rose's home
-- Violin
-Cover Art File Extension: jpg
+Track Artwork:
+- File Extension: jpg
+  Origin Details: >-
+    From [[flash:222]]
+  Tags:
+  - Rose
+  - Rose's home
+  - Violin
 URLs:
 - https://youtu.be/K0gpSYelM_k
 Referenced Tracks:

--- a/album/homestuck-vol-2.yaml
+++ b/album/homestuck-vol-2.yaml
@@ -50,10 +50,13 @@ Artists:
 - Michael Guy Bowman
 Contributors:
 - Joseph Aylsworth (guitar)
-Art Tags:
-- Underlings
-- John's home
-- Standing Piano
+Track Artwork:
+- Origin Details: >-
+    From [[flash:476]] (page 476)
+  Tags:
+  - Underlings
+  - John's home
+  - Standing Piano
 Duration: 2:48
 URLs:
 - https://homestuck.bandcamp.com/track/harlequin-rock-version-3
@@ -77,9 +80,12 @@ Bandcamp Track ID: 1461016644
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- John
-- Gate
+Track Artwork:
+- Origin Details: >-
+    From [[flash:644]]
+  Tags:
+  - John
+  - Gate
 Duration: 1:30
 URLs:
 - https://www.youtube.com/watch?v=Sc8wLKdRshY
@@ -97,11 +103,14 @@ Artists:
 - Kalibration
 Contributors:
 - Andrew Huo (edits)
-Art Tags:
-- Dave
-- Lil Cal
-- Ninja Sword
-- Dave's home
+Track Artwork:
+- Origin Details: >-
+    From [[flash:665]]
+  Tags:
+  - Dave
+  - Lil Cal
+  - Ninja Sword
+  - Dave's home
 Duration: 4:20
 URLs:
 - https://homestuck.bandcamp.com/track/upward-movement-dave-owns-3
@@ -132,10 +141,13 @@ Bandcamp Track ID: 1386305018
 Bandcamp Artwork ID: a2230775543
 Artists:
 - David Ko
-Art Tags:
-- WV
-- Can Town
-- Skyship Base
+Track Artwork:
+- Origin Details: >-
+    From [[flash:721]]
+  Tags:
+  - WV
+  - Can Town
+  - Skyship Base
 Duration: 1:13
 URLs:
 - https://homestuck.bandcamp.com/track/vagabounce-3
@@ -147,10 +159,13 @@ Bandcamp Artwork ID: a0030085780
 Artists:
 - Buzinkai
 - Michael Guy Bowman
-Art Tags:
-- Ruined Earth
-- Skyship Base
-- Sburb
+Track Artwork:
+- Origin Details: >-
+    From [[flash:757]]
+  Tags:
+  - Ruined Earth
+  - Skyship Base
+  - Sburb
 Duration: 2:28
 URLs:
 - https://homestuck.bandcamp.com/track/explore-3
@@ -205,10 +220,13 @@ Bandcamp Track ID: 2586232115
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- Frog Temple
-- Earth
-- Pacific Island
+Track Artwork:
+- Origin Details: >-
+    From [[flash:822]]
+  Tags:
+  - Frog Temple
+  - Earth
+  - Pacific Island
 Duration: 2:05
 Sheet Music Files:
 - Title: Tabs by Danny Wolf
@@ -227,11 +245,14 @@ Bandcamp Track ID: 817820078
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- Jack Noir
-- The Felt
-- Itchy
-- Clover
+Track Artwork:
+- Origin Details: >-
+    From [[flash:833]]
+  Tags:
+  - Jack Noir
+  - The Felt
+  - Itchy
+  - Clover
 Duration: 2:34
 URLs:
 - https://www.youtube.com/watch?v=L55OrtyUMko
@@ -242,9 +263,12 @@ Bandcamp Track ID: 1959163980
 Bandcamp Artwork ID: a3335808007
 Artists:
 - Gabriel Nezovic
-Art Tags:
-- FreshJamz
-- Music Note
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
+  - Music Note
 Duration: 2:02
 URLs:
 - https://homestuck.bandcamp.com/track/showtime-remix-3
@@ -255,9 +279,12 @@ Sampled Tracks:
 Track: Aggrieve Remix
 Bandcamp Track ID: 460953025
 Bandcamp Artwork ID: a0892476453
-Art Tags:
-- FreshJamz
-- Music Note
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
+  - Music Note
 Artists:
 - Gabriel Nezovic
 Duration: 2:11
@@ -272,9 +299,12 @@ Sampled Tracks:
 Track: Verdancy (Bassline)
 Bandcamp Track ID: 351330356
 Bandcamp Artwork ID: a4135527921
-Art Tags:
-- FreshJamz
-- Music Note
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
+  - Music Note
 Artists:
 - Kalibration
 Duration: 0:52
@@ -287,9 +317,12 @@ Bandcamp Track ID: 198684116
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- FreshJamz
-- Music Note
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
+  - Music Note
 Duration: 1:30
 URLs:
 - https://www.youtube.com/watch?v=DauXhvk7p6o

--- a/album/homestuck-vol-3.yaml
+++ b/album/homestuck-vol-3.yaml
@@ -50,11 +50,14 @@ Bandcamp Track ID: 3986700048
 Bandcamp Artwork ID: a4234662821
 Artists:
 - Curt Blakeslee
-Art Tags:
-- Dave
-- Lil Cal
-- Dave's home
-- 'Houston, TX'
+Track Artwork:
+- Origin Details: >-
+    From [[flash:836]]
+  Tags:
+  - Dave
+  - Lil Cal
+  - Dave's home
+  - 'Houston, TX'
 Duration: 2:32
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
@@ -79,8 +82,11 @@ Bandcamp Track ID: 2425809880
 Bandcamp Artwork ID: a3132382386
 Artists:
 - Malcolm Brown
-Art Tags:
-- John
+Track Artwork:
+- Origin Details: >-
+    From [[flash:843]]
+  Tags:
+  - John
 Duration: 2:47
 URLs:
 - https://homestuck.bandcamp.com/track/harleboss-3
@@ -101,11 +107,14 @@ Bandcamp Track ID: 3987633265
 Bandcamp Artwork ID: a3547713527
 Artists:
 - Curt Blakeslee
-Art Tags:
-- Dave
-- Dave's bro
-- Unbreakable Katana
-- Smuppets
+Track Artwork:
+- Origin Details: >-
+    From [[flash:871]]
+  Tags:
+  - Dave
+  - Dave's bro
+  - Unbreakable Katana
+  - Smuppets
 Duration: 2:27
 URLs:
 - https://homestuck.bandcamp.com/track/beatdown-round-2-3
@@ -124,10 +133,13 @@ Bandcamp Track ID: 669270917
 Bandcamp Artwork ID: a3935691051
 Artists:
 - David Ko
-Art Tags:
-- Jade
-- Jade's grandpa
-- Jade's home
+Track Artwork:
+- Origin Details: >-
+    From [[flash:918]]
+  Tags:
+  - Jade
+  - Jade's grandpa
+  - Jade's home
 Duration: 1:47
 MIDI Project Files:
 - Title: MIDI by Unknown
@@ -142,10 +154,13 @@ Bandcamp Track ID: 3908511167
 Bandcamp Artwork ID: a3617756702
 Artists:
 - David Ko
-Art Tags:
-- Jade
-- Jade's grandpa
-- Jade's home
+Track Artwork:
+- Origin Details: >-
+    From [[flash:918]]
+  Tags:
+  - Jade
+  - Jade's grandpa
+  - Jade's home
 Duration: 2:03
 URLs:
 - https://homestuck.bandcamp.com/track/dissension-remix-3
@@ -158,8 +173,11 @@ Bandcamp Track ID: 1479138878
 Bandcamp Artwork ID: a2527183767
 Artists:
 - Nick Smalley
-Art Tags:
-- FreshJamz
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
 Duration: 1:06
 URLs:
 - https://homestuck.bandcamp.com/track/ohgodwhat-3
@@ -188,8 +206,11 @@ Bandcamp Track ID: 3363108771
 Bandcamp Artwork ID: a1893067780
 Artists:
 - Michael Guy Bowman
-Art Tags:
-- FreshJamz
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
 Duration: 1:05
 URLs:
 - https://homestuck.bandcamp.com/track/ohgodwhat-remix-3
@@ -216,8 +237,11 @@ Additional Names:
 - RS5 (as [[track:rs5-trancestep-mix|remixed]] on [[album:exile]])
 Artists:
 - BurnedKirby
-Art Tags:
-- FreshJamz
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
 Duration: 1:36
 URLs:
 - https://homestuck.bandcamp.com/track/rediscover-fusion-3
@@ -234,8 +258,11 @@ Bandcamp Track ID: 597158703
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- FreshJamz
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
 Duration: 2:05
 URLs:
 - https://www.youtube.com/watch?v=fBOrrAq_Qv0
@@ -248,8 +275,11 @@ Bandcamp Track ID: 1439898196
 Bandcamp Artwork ID: a3323517644
 Artists:
 - Gabriel Nezovic
-Art Tags:
-- FreshJamz
+Track Artwork:
+- Origin Details: >-
+    From [[flash:830]]
+  Tags:
+  - FreshJamz
 Duration: 2:00
 URLs:
 - https://homestuck.bandcamp.com/track/explore-remix-3
@@ -264,11 +294,14 @@ Bandcamp Track ID: 1067169216
 Bandcamp Artwork ID: a1438126688
 Artists:
 - Michael Guy Bowman
-Art Tags:
-- Rose
-- Rose's mom
-- Rose's home
-- 'Rainbow Falls, NY'
+Track Artwork:
+- Origin Details: >-
+    From [[flash:938]]
+  Tags:
+  - Rose
+  - Rose's mom
+  - Rose's home
+  - 'Rainbow Falls, NY'
 Duration: 1:15
 URLs:
 - https://homestuck.bandcamp.com/track/chorale-for-jaspers-3
@@ -297,8 +330,11 @@ Artists:
 - Michael Guy Bowman
 Contributors:
 - Tavia Morra (vocals)
-Art Tags:
-- John
+Track Artwork:
+- Origin Details: >-
+    From [[flash:pony]]
+  Tags:
+  - John
 Duration: 1:03
 URLs:
 - https://homestuck.bandcamp.com/track/pony-chorale-3

--- a/album/homestuck-vol-3.yaml
+++ b/album/homestuck-vol-3.yaml
@@ -178,6 +178,7 @@ Track Artwork:
     From [[flash:830]]
   Tags:
   - FreshJamz
+  - Music Note
 Duration: 1:06
 URLs:
 - https://homestuck.bandcamp.com/track/ohgodwhat-3
@@ -211,6 +212,7 @@ Track Artwork:
     From [[flash:830]]
   Tags:
   - FreshJamz
+  - Music Note
 Duration: 1:05
 URLs:
 - https://homestuck.bandcamp.com/track/ohgodwhat-remix-3
@@ -242,6 +244,7 @@ Track Artwork:
     From [[flash:830]]
   Tags:
   - FreshJamz
+  - Music Note
 Duration: 1:36
 URLs:
 - https://homestuck.bandcamp.com/track/rediscover-fusion-3
@@ -263,6 +266,7 @@ Track Artwork:
     From [[flash:830]]
   Tags:
   - FreshJamz
+  - Music Note
 Duration: 2:05
 URLs:
 - https://www.youtube.com/watch?v=fBOrrAq_Qv0
@@ -280,6 +284,7 @@ Track Artwork:
     From [[flash:830]]
   Tags:
   - FreshJamz
+  - Music Note
 Duration: 2:00
 URLs:
 - https://homestuck.bandcamp.com/track/explore-remix-3

--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -85,9 +85,12 @@ Bandcamp Artwork ID: a1037485303
 Duration: 0:43
 Artists:
 - Malcolm Brown
-Art Tags:
-- John
-- Bing Crosby
+Track Artwork:
+- Origin Details: >-
+    From [[flash:948]]
+  Tags:
+  - John
+  - Bing Crosby
 URLs:
 - https://homestuck.bandcamp.com/track/revelawesome-3
 - https://youtu.be/yeIEkiIjw5c
@@ -109,8 +112,11 @@ Bandcamp Track ID: 3244936029
 Bandcamp Artwork ID: a1376950896
 Artists:
 - Mark J. Hadley
-Art Tags:
-- John
+Track Artwork:
+- Origin Details: >-
+    From [[flash:979]]
+  Tags:
+  - John
 Duration: 1:38
 URLs:
 - https://homestuck.bandcamp.com/track/hardlyquin-3
@@ -127,10 +133,13 @@ Bandcamp Track ID: 2132301583
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- Becquerel
-- Frog Temple
-- Pacific Island
+Track Artwork:
+- Origin Details: >-
+    From [[flash:980]]
+  Tags:
+  - Becquerel
+  - Frog Temple
+  - Pacific Island
 Duration: 2:59
 URLs:
 - https://www.youtube.com/watch?v=-hYsvaMPOus
@@ -149,11 +158,14 @@ Bandcamp Artwork ID: a3912682986
 Artists:
 - Andrew Huo
 - Toby Fox
-Art Tags:
-- Jade
-- Becquerel
-- Frog Temple
-- Pacific Island
+Track Artwork:
+- Origin Details: >-
+    From [[flash:980]]
+  Tags:
+  - Jade
+  - Becquerel
+  - Frog Temple
+  - Pacific Island
 Duration: 1:36
 URLs:
 - https://homestuck.bandcamp.com/track/carefree-victory-3
@@ -186,11 +198,14 @@ Bandcamp Track ID: 2053237285
 # No longer available, can't be embedded
 Artists:
 - Bill Bolin
-Art Tags:
-- Jade
-- Jade's home
-- Eclectic Bass
-- Prospit
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1026]]
+  Tags:
+  - Jade
+  - Jade's home
+  - Eclectic Bass
+  - Prospit
 Duration: 1:20
 URLs:
 - https://www.youtube.com/watch?v=iPf-CBzZLWg
@@ -206,9 +221,12 @@ Artists:
 - Bill Bolin
 Contributors:
 - Toby Fox (goat bleat)
-Art Tags:
-- Dave
-- Ninja Sword
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1070]]
+  Tags:
+  - Dave
+  - Ninja Sword
 Duration: 2:28
 URLs:
 - https://www.youtube.com/watch?v=YGHRAAP8uGQ
@@ -221,10 +239,13 @@ Bandcamp Track ID: 406749243
 Bandcamp Artwork ID: a2135812319
 Artists:
 - Malcolm Brown
-Art Tags:
-- Skaia
-- Pacific Island
-- Prospit
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1073]]
+  Tags:
+  - Skaia
+  - Pacific Island
+  - Prospit
 Duration: 3:08
 URLs:
 - https://homestuck.bandcamp.com/track/ballad-of-awakening-3
@@ -253,6 +274,8 @@ Track Artwork:
 - Directory: original
   Artists:
   - Homestuck
+  Origin Details: >-
+    From [[flash:1149]]
   Tags:
   - Rose
   - 'Rainbow Falls, NY'
@@ -327,6 +350,9 @@ Bandcamp Track ID: 2409406453
 Bandcamp Artwork ID: a3319645886
 Artists:
 - rj lake
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1267]] (page 1267)
 Duration: 6:29
 URLs:
 - https://homestuck.bandcamp.com/track/three-in-the-morning-rjs-i-can-barely-sleep-in-this-casino-remix-3
@@ -344,8 +370,11 @@ Artists:
 - Clark Powell
 Contributors:
 - Michael Vallejo (percussion)
-Art Tags:
-- LoWaS
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1358]]
+  Tags:
+  - LoWaS
 Duration: 2:37
 URLs:
 - https://homestuck.bandcamp.com/track/doctor-3
@@ -520,9 +549,12 @@ Bandcamp Track ID: 2416684563
 Bandcamp Artwork ID: a1905387711
 Artists:
 - Buzinkai
-Art Tags:
-- Rose
-- LoLaR
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1407]] (page 1407)
+  Tags:
+  - Rose
+  - LoLaR
 Duration: 1:24
 URLs:
 - https://homestuck.bandcamp.com/track/endless-climb-3
@@ -547,9 +579,12 @@ Bandcamp Track ID: 2522844322
 Bandcamp Artwork ID: a3484540854
 Artists:
 - Toby Fox
-Art Tags:
-- Dave
-- LoHaC
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1641]]
+  Tags:
+  - Dave
+  - LoHaC
 Duration: 1:10
 URLs:
 - https://homestuck.bandcamp.com/track/atomyk-ebonpyre-3
@@ -577,9 +612,12 @@ Bandcamp Track ID: 3965975565
 Bandcamp Artwork ID: a1410739956
 Artists:
 - Toby Fox
-Art Tags:
-- Jack Noir
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [[flash:1668]]
+  Tags:
+  - Jack Noir
+  - 'cw: blood'
 Duration: 2:24
 URLs:
 - https://homestuck.bandcamp.com/track/black-3

--- a/album/homestuck-vol-6.yaml
+++ b/album/homestuck-vol-6.yaml
@@ -99,9 +99,12 @@ Track: Frost
 Suffix Directory: true
 Artists:
 - Solatrus
-Art Tags:
-- Jade
-- LoFaF
+Track Artwork:
+- Origin Details: >-
+    From [[flash:2988]]
+  Tags:
+  - Jade
+  - LoFaF
 Duration: 5:05
 URLs:
 - https://homestuck.bandcamp.com/track/frost-3
@@ -168,9 +171,12 @@ Track: Courser
 Artists:
 - Seth Peelle
 - Alex Rosetti
-Art Tags:
-- Becquerel
-- Reckoning
+Track Artwork:
+- Origin Details: >-
+    From [[flash:2927]]
+  Tags:
+  - Becquerel
+  - Reckoning
 Duration: 4:37
 URLs:
 - https://homestuck.bandcamp.com/track/courser-2
@@ -186,8 +192,11 @@ MIDI Project Files:
 Track: Umbral Ultimatum
 Artists:
 - Toby Fox
-Art Tags:
-- Jade
+Track Artwork:
+- Origin Details: >-
+    From [[flash:2927]]
+  Tags:
+  - Jade
 Duration: 3:33
 URLs:
 - https://homestuck.bandcamp.com/track/umbral-ultimatum-2
@@ -217,8 +226,11 @@ MIDI Project Files:
 Track: GameBro (Original 1990 Mix)
 Artists:
 - Erik Scheele
-Art Tags:
-- GameBro
+Track Artwork:
+- Origin Details: >-
+    From [page 1832](https://homestuck.com/story/1832)
+  Tags:
+  - GameBro
 Duration: 3:24
 URLs:
 - https://homestuck.bandcamp.com/track/gamebro-original-1990-mix-2
@@ -341,10 +353,13 @@ Commentary: |-
 Track: Tribal Ebonpyre
 Artists:
 - Erik Scheele
-Art Tags:
-- Dave
-- Crocodiles (consort)
-- LoHaC
+Track Artwork:
+- Origin Details: >-
+    From [page 2773](https://homestuck.com/story/2773)
+  Tags:
+  - Dave
+  - Crocodiles (consort)
+  - LoHaC
 Duration: 1:48
 URLs:
 - https://homestuck.bandcamp.com/track/tribal-ebonpyre-2
@@ -370,11 +385,14 @@ Commentary: |-
 Track: I Don't Want to Miss a Thing
 Artists:
 - Michael Guy Bowman
-Art Tags:
-- John
-- Ben Affleck
-- Bruce Willis
-- Liv Tyler
+Track Artwork:
+- Origin Details: >-
+    From [page 223](https://homestuck.com/story/223)
+  Tags:
+  - John
+  - Ben Affleck
+  - Bruce Willis
+  - Liv Tyler
 Duration: 3:57
 URLs:
 - https://homestuck.bandcamp.com/track/i-dont-want-to-miss-a-thing-2
@@ -488,8 +506,11 @@ Artists:
 - Toby Fox
 Contributors:
 - Tensei (guitar)
-Art Tags:
-- Vriska
+Track Artwork:
+- Origin Details: >-
+    From [page 2976](https://homestuck.com/story/2976)
+  Tags:
+  - Vriska
 Duration: 2:47
 URLs:
 - https://homestuck.bandcamp.com/track/megalovania-2
@@ -544,10 +565,13 @@ Commentary: |-
 Track: Walk-Stab-Walk (R&E)
 Artists:
 - Erik Scheele
-Art Tags:
-- Jack Noir
-- Karkat
-- LoPaH
+Track Artwork:
+- Origin Details: >-
+    From [page 2298](https://homestuck.com/story/2298)
+  Tags:
+  - Jack Noir
+  - Karkat
+  - LoPaH
 Duration: 3:29
 URLs:
 - https://homestuck.bandcamp.com/track/walk-stab-walk-r-e-2
@@ -568,12 +592,15 @@ Commentary: |-
 Track: Gaia Queen
 Artists:
 - Toby Fox
-Art Tags:
-- Jade
-- Dave
-- Riflekind
-- Echidna
-- LoFaF
+Track Artwork:
+- Origin Details: >-
+    From [[flash:3001]]
+  Tags:
+  - Jade
+  - Dave
+  - Riflekind
+  - Echidna
+  - LoFaF
 Duration: 3:06
 URLs:
 - https://homestuck.bandcamp.com/track/gaia-queen-2
@@ -589,9 +616,12 @@ Lyrics: |-
 Track: Elevatorstuck
 Artists:
 - Tensei
-Art Tags:
-- Dave
-- LoHaC
+Track Artwork:
+- Origin Details: >-
+    From [page 2780](https://homestuck.com/story/2780)
+  Tags:
+  - Dave
+  - LoHaC
 Duration: 2:09
 URLs:
 - https://homestuck.bandcamp.com/track/elevatorstuck-2
@@ -617,13 +647,16 @@ Track: Wacky Antics
 Artists:
 - David Ko
 - Toby Fox
-Art Tags:
-- WV
-- AR
-- Serenity
-- Eggy-Looking Base
-- Frog Temple
-- Ruined Earth
+Track Artwork:
+- Origin Details: >-
+    From [page 1503](https://homestuck.com/story/1503)
+  Tags:
+  - WV
+  - AR
+  - Serenity
+  - Eggy-Looking Base
+  - Frog Temple
+  - Ruined Earth
 Duration: 2:05
 URLs:
 - https://homestuck.bandcamp.com/track/wacky-antics-2
@@ -634,9 +667,12 @@ Referenced Tracks:
 Track: Horschestra
 Artists:
 - Alex Rosetti
-Art Tags:
-- HB
-- Horses
+Track Artwork:
+- Origin Details: >-
+    From [page 1334](https://homestuck.com/story/1334)
+  Tags:
+  - HB
+  - Horses
 Duration: 4:13
 URLs:
 - https://homestuck.bandcamp.com/track/horschestra-2
@@ -645,10 +681,13 @@ URLs:
 Track: Heir Transparent
 Artists:
 - rj lake
-Art Tags:
-- John
-- Skaia
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [[flash:3087]]
+  Tags:
+  - John
+  - Skaia
+  - 'cw: blood'
 Duration: 4:01
 URLs:
 - https://homestuck.bandcamp.com/track/heir-transparent-2
@@ -659,8 +698,11 @@ Referenced Tracks:
 Track: Boy Skylark (Brief)
 Artists:
 - rj lake
-Art Tags:
-- John
+Track Artwork:
+- Origin Details: >-
+    From [page 3075](https://homestuck.com/story/3075)
+  Tags:
+  - John
 Duration: 2:46
 URLs:
 - https://homestuck.bandcamp.com/track/boy-skylark-brief-2
@@ -674,10 +716,13 @@ Track: Squidissension
 Artists:
 - Mark J. Hadley
 Duration: 2:44
-Art Tags:
-- Jade
-- Squiddles
-- Dream Bubbles
+Track Artwork:
+- Origin Details: >-
+    From [[flash:2848]]
+  Tags:
+  - Jade
+  - Squiddles
+  - Dream Bubbles
 URLs:
 - https://homestuck.bandcamp.com/track/squidissension-2
 - https://youtu.be/zJ7y3sWT7l0
@@ -695,10 +740,13 @@ Additional Names:
   Annotation: earlier MSPA credit
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Gamzee
-- Jade's home
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 3219](https://homestuck.com/story/3219)
+  Tags:
+  - Gamzee
+  - Jade's home
+  - 'cw: blood'
 Duration: 2:32
 URLs:
 - https://homestuck.bandcamp.com/track/blackest-heart-2
@@ -716,12 +764,15 @@ Additional Names:
   Annotation: earlier MSPA credit, see also [[Nic Cage Romance]]
 Artists:
 - Toby Fox
-Art Tags:
-- Vriska
-- Nicolas Cage
-- John Cusack
-- Meg Ryan
-- Trolls' Meteor
+Track Artwork:
+- Origin Details: >-
+    From [page 3060](https://homestuck.com/story/3060)
+  Tags:
+  - Vriska
+  - Nicolas Cage
+  - John Cusack
+  - Meg Ryan
+  - Trolls' Meteor
 Duration: 2:45
 URLs:
 - https://homestuck.bandcamp.com/track/nic-cage-song-2
@@ -810,14 +861,17 @@ Lyrics: |-
 Track: Phrenic Phever
 Artists:
 - Clark Powell
-Art Tags:
-- Karkat
-- Gamzee
-- Ness (EarthBound)
-- Paula (EarthBound)
-- Jeff (EarthBound)
-- Poo (EarthBound)
-- Trolls' Meteor
+Track Artwork:
+- Origin Details: >-
+    From [[flash:2792]]
+  Tags:
+  - Karkat
+  - Gamzee
+  - Ness (EarthBound)
+  - Paula (EarthBound)
+  - Jeff (EarthBound)
+  - Poo (EarthBound)
+  - Trolls' Meteor
 Duration: 3:18
 URLs:
 - https://homestuck.bandcamp.com/track/phrenic-phever-2
@@ -828,8 +882,11 @@ Referenced Tracks:
 Track: 3 In The Morning (Pianokind)
 Artists:
 - Erik Scheele
-Art Tags:
-- Snowman
+Track Artwork:
+- Origin Details: >-
+    From [page 2555](https://homestuck.com/story/2555)
+  Tags:
+  - Snowman
 Duration: 4:13
 URLs:
 - https://homestuck.bandcamp.com/track/3-in-the-morning-pianokind-2
@@ -861,11 +918,14 @@ Commentary: |-
 Track: A Tender Moment
 Artists:
 - Toby Fox
-Art Tags:
-- Jade
-- Jadesprite
-- Fenestrology
-- Jade's home
+Track Artwork:
+- Origin Details: >-
+    From [page 3243](https://homestuck.com/story/3243)
+  Tags:
+  - Jade
+  - Jadesprite
+  - Fenestrology
+  - Jade's home
 Duration: 2:17
 URLs:
 - https://homestuck.bandcamp.com/track/a-tender-moment-2
@@ -880,8 +940,11 @@ MIDI Project Files:
 Track: Crystalanthology
 Artists:
 - Solatrus
-Art Tags:
-- Vriska
+Track Artwork:
+- Origin Details: >-
+    From [page 3130](https://homestuck.com/story/3130)
+  Tags:
+  - Vriska
 Duration: 4:44
 URLs:
 - https://homestuck.bandcamp.com/track/crystalanthology-2

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -248,12 +248,15 @@ Duration: 1:08
 URLs:
 - https://homestuck.bandcamp.com/track/firefly-2
 - https://youtu.be/KC9v0nOnDK8
-Cover Artists:
-- Homestuck
-Cover Art File Extension: gif
-Art Tags:
-- John
-- LoWaS
+Track Artwork:
+- File Extension: gif
+  Artists:
+  - Homestuck
+  Origin Details: >-
+    From [page 3078](https://homestuck.com/story/3078)
+  Tags:
+  - John
+  - LoWaS
 Commentary: |-
     <i>Buzinkai:</i> (via [[media:misc/commentary-collection.txt|early commentary collection]])
 
@@ -266,16 +269,19 @@ Duration: 3:59
 URLs:
 - https://homestuck.bandcamp.com/track/whistling-jackhammer-2
 - https://youtu.be/a9ExRM4xlw8
-Cover Artists:
-- Homestuck
-Cover Art File Extension: gif
-Art Tags:
-- Dirk
-- Sawtooth
-- Imperial Drones
-- Unbreakable Katana
-- Flooded Earth
-- 'Houston, TX'
+Track Artwork:
+- File Extension: gif
+  Artists:
+  - Homestuck
+  Origin Details: >-
+    From [page 4970](https://homestuck.com/story/4970)
+  Tags:
+  - Dirk
+  - Sawtooth
+  - Imperial Drones
+  - Unbreakable Katana
+  - Flooded Earth
+  - 'Houston, TX'
 Sheet Music Files:
 - Title: Sheet music by dcheng334
   Files:
@@ -1380,13 +1386,16 @@ Duration: 3:05
 URLs:
 - https://homestuck.bandcamp.com/track/break-shot-2
 - https://youtu.be/E07s837gHWE
-Cover Artists:
-- Homestuck
-Cover Art File Extension: jpg
-Art Tags:
-- Lord English
-- AH
-- Green Sun
+Track Artwork:
+- File Extension: jpg
+  Artists:
+  - Homestuck
+  Origin Details: >-
+    From [page 4683](https://homestuck.com/story/4683)
+  Tags:
+  - Lord English
+  - AH
+  - Green Sun
 ---
 Track: Portrait
 Artists:
@@ -1435,12 +1444,15 @@ Duration: 2:36
 URLs:
 - https://homestuck.bandcamp.com/track/negative-aperture-2
 - https://youtu.be/x15fE5XGk1g
-Cover Artists:
-- Homestuck
-Cover Art File Extension: gif
-Art Tags:
-- Sawtooth
-- Flooded Earth
+Track Artwork:
+- File Extension: gif
+  Artists:
+  - Homestuck
+  Origin Details: >-
+    From [page 4968](https://homestuck.com/story/4968)
+  Tags:
+  - Sawtooth
+  - Flooded Earth
 ---
 Track: Sweet Dreams, Timaeus
 Artists:
@@ -1470,12 +1482,15 @@ Duration: 3:10
 URLs:
 - https://homestuck.bandcamp.com/track/red-miles-2
 - https://youtu.be/_7ulwTrNnTE
-Cover Artists:
-- Homestuck
-Art Tags:
-- Red Miles
-- Roxy's home
-- 'Rainbow Falls, NY'
+Track Artwork:
+- Artists:
+  - Homestuck
+  Origin Details: >-
+    From [page 5039](https://homestuck.com/story/5039)
+  Tags:
+  - Red Miles
+  - Roxy's home
+  - 'Rainbow Falls, NY'
 Sheet Music Files:
 - Title: Piano score by Purple1222119
   Files:
@@ -1518,12 +1533,15 @@ Duration: 4:12
 URLs:
 - https://homestuck.bandcamp.com/track/the-changing-game-2
 - https://youtu.be/a7UeOYYKrxg
-Cover Artists:
-- Homestuck
-Art Tags:
-- Battleship Condescension
-- Jane's home
-- 'Maple Valley, WA'
+Track Artwork:
+- Artists:
+  - Homestuck
+  Origin Details: >-
+    From [page 4665](https://homestuck.com/story/4665)
+  Tags:
+  - Battleship Condescension
+  - Jane's home
+  - 'Maple Valley, WA'
 ---
 Track: Requited
 Artists:
@@ -1999,11 +2017,14 @@ Duration: 2:47
 URLs:
 - https://www.youtube.com/watch?v=om3VC6ru4yk
 - https://youtu.be/om3VC6ru4yk
-Cover Artists:
-- Homestuck
-Cover Art File Extension: jpg
-Art Tags:
-- Nicolas Cage
+Track Artwork:
+- File Extension: jpg
+  Artists:
+  - Homestuck
+  Origin Details: >-
+    From [[flash:darkcage]]
+  Tags:
+  - Nicolas Cage
 Referenced Tracks:
 - Crustacean
 - Hardlyquin

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -88,8 +88,11 @@ Commentary: |-
 Track: Three in the Morning
 Artists:
 - Clark Powell
-Art Tags:
-- Snowman
+Track Artwork:
+- Origin Details: >-
+    From [page 1267](https://homestuck.com/story/1267)
+  Tags:
+  - Snowman
 Duration: 2:49
 URLs:
 - https://homestuck.bandcamp.com/track/three-in-the-morning-3
@@ -116,8 +119,11 @@ MIDI Project Files:
 Track: Blue Noir
 Artists:
 - David Ko
-Art Tags:
-- DD
+Track Artwork:
+- Origin Details: >-
+    From [extras 28](https://homestuck.com/extras/28)
+  Tags:
+  - DD
 Duration: 0:55
 URLs:
 - https://homestuck.bandcamp.com/track/blue-noir-2
@@ -128,10 +134,13 @@ Referenced Tracks:
 Track: Dead Shuffle
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Felt Mansion
-- Pink Moon
-- Alternia
+Track Artwork:
+- Origin Details: >-
+    From [page 1246](https://homestuck.com/story/1246)
+  Tags:
+  - Felt Mansion
+  - Pink Moon
+  - Alternia
 Duration: 2:17
 URLs:
 - https://homestuck.bandcamp.com/track/dead-shuffle-2
@@ -144,11 +153,14 @@ Commentary: |-
 Track: Hearts Flush
 Artists:
 - Mark J. Hadley
-Art Tags:
-- CD
-- DD
-- Trace
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1226](https://homestuck.com/story/1226)
+  Tags:
+  - CD
+  - DD
+  - Trace
+  - Felt Mansion
 Duration: 2:12
 URLs:
 - https://homestuck.bandcamp.com/track/hearts-flush-2
@@ -161,25 +173,28 @@ Commentary: |-
 Track: Knives and Ivory
 Artists:
 - Kevin Regamey
-Art Tags:
-- Jack Noir
-- Bing Crosby
-- Itchy
-- Doze
-- Trace
-- Clover
-- Fin
-- Die
-- Crowbar
-- Stitch
-- Sawbuck
-- Matchsticks
-- Eggs
-- Biscuits
-- Quarters
-- Cans
-- Bladekind
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1163](https://homestuck.com/story/1163)
+  Tags:
+  - Jack Noir
+  - Bing Crosby
+  - Itchy
+  - Doze
+  - Trace
+  - Clover
+  - Fin
+  - Die
+  - Crowbar
+  - Stitch
+  - Sawbuck
+  - Matchsticks
+  - Eggs
+  - Biscuits
+  - Quarters
+  - Cans
+  - Bladekind
+  - Felt Mansion
 Duration: 1:10
 URLs:
 - https://homestuck.bandcamp.com/track/knives-and-ivory-2
@@ -188,12 +203,15 @@ URLs:
 Track: Liquid Negrocity
 Artists:
 - Toby Fox
-Art Tags:
-- Jack Noir
-- DD
-- CD
-- HB
-- Wasps
+Track Artwork:
+- Origin Details: >-
+    From [extras 29](https://homestuck.com/extras/29)
+  Tags:
+  - Jack Noir
+  - DD
+  - CD
+  - HB
+  - Wasps
 Duration: 2:10
 URLs:
 - https://homestuck.bandcamp.com/track/liquid-negrocity-2
@@ -216,9 +234,12 @@ MIDI Project Files:
 Track: Hollow Suit
 Artists:
 - Alex Rosetti
-Art Tags:
-- Stitch
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1253](https://homestuck.com/story/1253)
+  Tags:
+  - Stitch
+  - Felt Mansion
 Duration: 2:24
 URLs:
 - https://homestuck.bandcamp.com/track/hollow-suit-2
@@ -235,15 +256,18 @@ Commentary: |-
 Track: Ante Matter
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Itchy
-- Doze
-- Trace
-- Die
-- Crowbar
-- Matchsticks
-- Eggs
-- Biscuits
+Track Artwork:
+- Origin Details: >-
+    From [page 1188](https://homestuck.com/story/1188)
+  Tags:
+  - Itchy
+  - Doze
+  - Trace
+  - Die
+  - Crowbar
+  - Matchsticks
+  - Eggs
+  - Biscuits
 Duration: 2:33
 URLs:
 - https://homestuck.bandcamp.com/track/ante-matter-2
@@ -256,10 +280,13 @@ Commentary: |-
 Track: The Ballad of Jack Noir
 Artists:
 - Toby Fox
-Art Tags:
-- Jack Noir
-- Clocks
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1158](https://homestuck.com/story/1158)
+  Tags:
+  - Jack Noir
+  - Clocks
+  - Felt Mansion
 Duration: 1:48
 URLs:
 - https://homestuck.bandcamp.com/track/the-ballad-of-jack-noir-2
@@ -276,11 +303,14 @@ Artists:
 - Michael Guy Bowman
 Contributors:
 - Fenris (saxophone)
-Art Tags:
-- CD
-- Doze
-- Clocks
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1179](https://homestuck.com/story/1179)
+  Tags:
+  - CD
+  - Doze
+  - Clocks
+  - Felt Mansion
 Duration: 2:59
 URLs:
 - https://homestuck.bandcamp.com/track/lunar-eclipse-2
@@ -302,12 +332,15 @@ Track: Hauntjam
 Artists:
 - Andrew Huo
 - Michael Guy Bowman
-Art Tags:
-- DD
-- Trace
-- Clocks
-- Felt Mansion
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 1203](https://homestuck.com/story/1203)
+  Tags:
+  - DD
+  - Trace
+  - Clocks
+  - Felt Mansion
+  - 'cw: blood'
 Duration: 2:16
 URLs:
 - https://homestuck.bandcamp.com/track/hauntjam-2
@@ -344,8 +377,11 @@ Additional Names:
 - jazzjazzjazzthejazzatronjazzer (early name)
 Artists:
 - rj lake
-Art Tags:
-- DD
+Track Artwork:
+- Origin Details: >-
+    From [[flash:833]]
+  Tags:
+  - DD
 Duration: 2:56
 URLs:
 - https://homestuck.bandcamp.com/track/carbon-nadsat-cuestick-genius-2
@@ -358,8 +394,11 @@ Commentary: |-
 Track: Ace of Trump
 Artists:
 - Hilary Troiano
-Art Tags:
-- Die
+Track Artwork:
+- Origin Details: >-
+    From [page 1210](https://homestuck.com/story/1210)
+  Tags:
+  - Die
 Duration: 6:29
 URLs:
 - https://homestuck.bandcamp.com/track/ace-of-trump-2
@@ -396,8 +435,11 @@ Commentary: |-
 Track: Moonshine
 Artists:
 - Alex Rosetti
-Art Tags:
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1154](https://homestuck.com/story/1154)
+  Tags:
+  - Felt Mansion
 Duration: 2:39
 URLs:
 - https://homestuck.bandcamp.com/track/moonshine-2
@@ -425,8 +467,11 @@ Commentary: |-
 Track: Tall, Dark and Loathsome
 Artists:
 - Clark Powell
-Art Tags:
-- Jack Noir
+Track Artwork:
+- Origin Details: >-
+    From [page 1188](https://homestuck.com/story/1188)
+  Tags:
+  - Jack Noir
 Duration: 1:33
 URLs:
 - https://homestuck.bandcamp.com/track/tall-dark-and-loathsome-2
@@ -439,8 +484,11 @@ Sheet Music Files:
 Track: Joker's Wild
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Itchy
+Track Artwork:
+- Origin Details: >-
+    From [page 1210](https://homestuck.com/story/1210)
+  Tags:
+  - Itchy
 Duration: 2:16
 URLs:
 - https://homestuck.bandcamp.com/track/jokers-wild-2
@@ -455,8 +503,11 @@ Commentary: |-
 Track: Livin' It Up
 Artists:
 - Gabriel Nezovic
-Art Tags:
-- Die
+Track Artwork:
+- Origin Details: >-
+    From [page 1211](https://homestuck.com/story/1211)
+  Tags:
+  - Die
 Duration: 2:00
 URLs:
 - https://homestuck.bandcamp.com/track/livin-it-up-2
@@ -466,11 +517,14 @@ Track: Hauntjelly
 Artists:
 - Andrew Huo
 - artist:ian-taylor
-Art Tags:
-- DD
-- Fin
-- Clocks
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1230](https://homestuck.com/story/1230)
+  Tags:
+  - DD
+  - Fin
+  - Clocks
+  - Felt Mansion
 Duration: 2:02
 URLs:
 - https://homestuck.bandcamp.com/track/hauntjelly-2
@@ -484,6 +538,9 @@ Track: Nightlife (Extended)
 Suffix Directory: true
 Main Release: track:nightlife-extended
 Duration: 2:34
+Track Artwork:
+- Origin Details: >-
+    From [[flash:833]]
 URLs:
 - https://www.youtube.com/watch?v=L55OrtyUMko
 - https://archive.org/details/exile-pinkushion/04%20Nightlife.mp3

--- a/album/strife.yaml
+++ b/album/strife.yaml
@@ -47,8 +47,11 @@ Commentary: |-
 Section: Main album
 ---
 Track: Stormspirit
-Art Tags:
-- LoWaS
+Track Artwork:
+- Origin Details: >-
+    From [[flash:3087]]
+  Tags:
+  - LoWaS
 Duration: 0:46
 URLs:
 - https://tenseimusic.bandcamp.com/track/stormspirit
@@ -60,8 +63,11 @@ Sheet Music Files:
   - 'Stormspirit - Clawtooth.pdf'
 ---
 Track: Heir Conditioning
-Art Tags:
-- John
+Track Artwork:
+- Origin Details: >-
+    From [page 3497](https://homestuck.com/story/3497)
+  Tags:
+  - John
 Duration: 3:53
 URLs:
 - https://tenseimusic.bandcamp.com/track/heir-conditioning
@@ -81,8 +87,11 @@ Sheet Music Files:
   - 'Heir Conditioning - Danny Wolf (piano score).pdf'
 ---
 Track: Dance of Thorns
-Art Tags:
-- Rose
+Track Artwork:
+- Origin Details: >-
+    From [page 3043](https://homestuck.com/story/3043)
+  Tags:
+  - Rose
 Duration: 4:01
 URLs:
 - https://tenseimusic.bandcamp.com/track/dance-of-thorns
@@ -112,10 +121,13 @@ MIDI Project Files:
   - 'Dance of Thorns - Twix Stix.mid'
 ---
 Track: Time on My Side
-Art Tags:
-- Dave
-- Caledscratch
-- LoHaC
+Track Artwork:
+- Origin Details: >-
+    From [page 3095](https://homestuck.com/story/3095)
+  Tags:
+  - Dave
+  - Caledscratch
+  - LoHaC
 Duration: 3:28
 URLs:
 - https://tenseimusic.bandcamp.com/track/time-on-my-side
@@ -165,9 +177,12 @@ Commentary: |-
     That aside, obviously stuff from The Prodigy's Fat of the Land album bears some resemblance as well, especially with the cheesy bassline. I know that a few Prodigy songs have been used in the otherwise kinda shitty Charlie's Angels movies whenever shit was about to go down, and that's really the kind of vibe I was going for as well.
 ---
 Track: Atomic Bonsai
-Art Tags:
-- Jade
-- Rockets
+Track Artwork:
+- Origin Details: >-
+    From [page 3309](https://homestuck.com/story/3309)
+  Tags:
+  - Jade
+  - Rockets
 Duration: 4:20
 URLs:
 - https://tenseimusic.bandcamp.com/track/atomic-bonsai
@@ -183,13 +198,16 @@ MIDI Project Files:
   - 'Atomic Bonsai - Tensei.mid'
 ---
 Track: Knife's Edge
-Art Tags:
-- Jack Noir
-- Davesprite
-- Dave's bro
-- Lil Cal
-- Unbreakable Katana
-- LoWaS
+Track Artwork:
+- Origin Details: >-
+    From [page 2893](https://homestuck.com/story/2893)
+  Tags:
+  - Jack Noir
+  - Davesprite
+  - Dave's bro
+  - Lil Cal
+  - Unbreakable Katana
+  - LoWaS
 Duration: 4:05
 URLs:
 - https://tenseimusic.bandcamp.com/track/knifes-edge

--- a/album/the-felt.yaml
+++ b/album/the-felt.yaml
@@ -67,9 +67,12 @@ Commentary: |-
 Track: Jade Dragon
 Artists:
 - rj lake
-Art Tags:
-- Snowman
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1305](https://homestuck.com/story/1305)
+  Tags:
+  - Snowman
+  - Felt Mansion
 Duration: 3:27
 URLs:
 - https://homestuck.bandcamp.com/track/jade-dragon-2
@@ -80,9 +83,12 @@ Referenced Tracks:
 Track: Swing of the Clock
 Artists:
 - Solatrus
-Art Tags:
-- Felt Mansion
-- Clocks
+Track Artwork:
+- Origin Details: >-
+    From [page 1252](https://homestuck.com/story/1252)
+  Tags:
+  - Felt Mansion
+  - Clocks
 Duration: 5:58
 URLs:
 - https://homestuck.bandcamp.com/track/swing-of-the-clock-2
@@ -149,11 +155,14 @@ Commentary: |-
 Track: Rhapsody in Green
 Artists:
 - Clark Powell
-Art Tags:
-- Crowbar
-- Stitch
-- Sawbuck
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1265](https://homestuck.com/story/1265)
+  Tags:
+  - Crowbar
+  - Stitch
+  - Sawbuck
+  - Felt Mansion
 Duration: 3:54
 URLs:
 - https://homestuck.bandcamp.com/track/rhapsody-in-green-2
@@ -162,10 +171,13 @@ URLs:
 Track: Humphrey's Lullaby
 Artists:
 - Toby Fox
-Art Tags:
-- DD
-- Stitch
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1260](https://homestuck.com/story/1260)
+  Tags:
+  - DD
+  - Stitch
+  - Felt Mansion
 Duration: 2:06
 URLs:
 - https://homestuck.bandcamp.com/track/humphreys-lullaby-2
@@ -174,10 +186,13 @@ URLs:
 Track: Clockwork Reversal
 Artists:
 - Thomas Ferkol
-Art Tags:
-- Clocks
-- Felt Mansion
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 1228](https://homestuck.com/story/1228)
+  Tags:
+  - Clocks
+  - Felt Mansion
+  - 'cw: blood'
 Duration: 1:41
 URLs:
 - https://homestuck.bandcamp.com/track/clockwork-reversal-2
@@ -197,11 +212,14 @@ Additional Names:
     early name
 Artists:
 - Solatrus
-Art Tags:
-- Jack Noir
-- Itchy
-- Clocks
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1187](https://homestuck.com/story/1187)
+  Tags:
+  - Jack Noir
+  - Itchy
+  - Clocks
+  - Felt Mansion
 Duration: 4:57
 URLs:
 - https://homestuck.bandcamp.com/track/chartreuse-rewind-2
@@ -242,10 +260,13 @@ Commentary: |-
 Track: The Broken Clock
 Artists:
 - Erik Scheele
-Art Tags:
-- Clover
-- Clocks
-- Magic 8 Ball
+Track Artwork:
+- Origin Details: >-
+    From [page 1324](https://homestuck.com/story/1324)
+  Tags:
+  - Clover
+  - Clocks
+  - Magic 8 Ball
 Duration: 3:10
 URLs:
 - https://homestuck.bandcamp.com/track/the-broken-clock-2
@@ -261,10 +282,13 @@ MIDI Project Files:
 Track: Apocryphal Antithesis
 Artists:
 - Clark Powell
-Art Tags:
-- Felt Mansion
-- Itchy
-- Doze
+Track Artwork:
+- Origin Details: >-
+    From [page 1184](https://homestuck.com/story/1184)
+  Tags:
+  - Felt Mansion
+  - Itchy
+  - Doze
 Duration: 2:51
 URLs:
 - https://homestuck.bandcamp.com/track/apocryphal-antithesis-2
@@ -275,10 +299,13 @@ Referenced Tracks:
 Track: Trails
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Clocks
-- Felt Mansion
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 1198](https://homestuck.com/story/1198)
+  Tags:
+  - Clocks
+  - Felt Mansion
+  - 'cw: blood'
 Duration: 2:29
 URLs:
 - https://homestuck.bandcamp.com/track/trails-2
@@ -291,10 +318,13 @@ Commentary: |-
 Track: Baroqueback Bowtier (Scratch's Lament)
 Artists:
 - Clark Powell
-Art Tags:
-- CD
-- Stitch
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1301](https://homestuck.com/story/1301)
+  Tags:
+  - CD
+  - Stitch
+  - Felt Mansion
 Duration: 4:06
 URLs:
 - https://homestuck.bandcamp.com/track/baroqueback-bowtier-scratchs-lament-2
@@ -310,10 +340,13 @@ Sheet Music Files:
 Track: Scratch
 Artists:
 - David Ko
-Art Tags:
-- Doc Scratch
-- Battlefield
-- Scratch's apartment
+Track Artwork:
+- Origin Details: >-
+    From [page 2253](https://homestuck.com/story/2253)
+  Tags:
+  - Doc Scratch
+  - Battlefield
+  - Scratch's apartment
 Duration: 3:10
 URLs:
 - https://homestuck.bandcamp.com/track/scratch-2
@@ -345,10 +378,13 @@ Commentary: |-
 Track: Omelette Sandwich
 Artists:
 - Mark J. Hadley
-Art Tags:
-- Eggs
-- Biscuits
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1225](https://homestuck.com/story/1225)
+  Tags:
+  - Eggs
+  - Biscuits
+  - Felt Mansion
 Duration: 3:32
 URLs:
 - https://homestuck.bandcamp.com/track/omelette-sandwich-2
@@ -365,10 +401,13 @@ Commentary: |-
 Track: Temporal Piano
 Artists:
 - Erik Scheele
-Art Tags:
-- Clocks
-- Felt Mansion
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 1286](https://homestuck.com/story/1286)
+  Tags:
+  - Clocks
+  - Felt Mansion
+  - 'cw: blood'
 Duration: 3:49
 URLs:
 - https://homestuck.bandcamp.com/track/temporal-piano-2
@@ -377,13 +416,16 @@ URLs:
 Track: Time Paradox
 Artists:
 - Thomas Ferkol
-Art Tags:
-- Die
-- Itchy
-- Jack Noir
-- Felt Mansion
-- 'cw: blood'
-- 'cw: corpse'
+Track Artwork:
+- Origin Details: >-
+    From [page 1212](https://homestuck.com/story/1212)
+  Tags:
+  - Die
+  - Itchy
+  - Jack Noir
+  - Felt Mansion
+  - 'cw: blood'
+  - 'cw: corpse'
 Duration: 3:06
 URLs:
 - https://homestuck.bandcamp.com/track/time-paradox-2
@@ -402,9 +444,12 @@ Commentary: |-
 Track: Eldritch
 Artists:
 - Alex Rosetti
-Art Tags:
-- Clocks
-- Felt Mansion
+Track Artwork:
+- Origin Details: >-
+    From [page 1158](https://homestuck.com/story/1158)
+  Tags:
+  - Clocks
+  - Felt Mansion
 Duration: 2:02
 URLs:
 - https://homestuck.bandcamp.com/track/eldritch-2
@@ -417,11 +462,14 @@ Sheet Music Files:
 Track: English
 Artists:
 - Toby Fox
-Art Tags:
-- DD
-- Stitch
-- Felt Mansion
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 1261](https://homestuck.com/story/1261)
+  Tags:
+  - DD
+  - Stitch
+  - Felt Mansion
+  - 'cw: blood'
 Duration: 3:30
 URLs:
 - https://homestuck.bandcamp.com/track/english-2
@@ -438,14 +486,17 @@ MIDI Project Files:
 Track: Variations
 Artists:
 - rj lake
-Art Tags:
-- HB
-- Clover
-- Eggs
-- Biscuits
-- Clocks
-- Felt Mansion
-- 'cw: blood'
+Track Artwork:
+- Origin Details: >-
+    From [page 1307](https://homestuck.com/story/1307)
+  Tags:
+  - HB
+  - Clover
+  - Eggs
+  - Biscuits
+  - Clocks
+  - Felt Mansion
+  - 'cw: blood'
 Duration: 6:03
 URLs:
 - https://homestuck.bandcamp.com/track/variations-2

--- a/album/unreleased-tracks.yaml
+++ b/album/unreleased-tracks.yaml
@@ -345,6 +345,19 @@ URLs:
 Referenced Tracks:
 - not a creature was stirring
 ---
+Track: I Don't Want to Miss a Thing (Boner Mix)
+Artists:
+- Toby Fox
+Duration: 0:31
+URLs:
+- https://media.hsmusic.wiki/misc/archive/I Don't Want to Miss a Thing (Boner Mix).mp3
+Sampled Tracks:
+- I Don't Want to Miss a Thing
+Commentary: |-
+    <i>Quasar Nebula:</i> (wiki editor, 6/4/2025)
+
+    Unofficial name, taken from the Homestuck Sound Test. We also don't *know* this edit is by Toby Fox, but like... probably.
+---
 Track: Darling Dolorosa
 Artists:
 - Toby Fox

--- a/artists.yaml
+++ b/artists.yaml
@@ -3260,17 +3260,23 @@ URLs:
 ---
 Artist: Danny Brown
 ---
-Artist: Danny Cragg
-Aliases:
-- Amber Rogers
-URLs:
-- https://twitter.com/recentlydanny
-Dead URLs:
-- http://www.neo-kosmos.com/
----
 Artist: Danny Elfman
 ---
 Artist: Danny Jacob
+---
+Artist: Danny Kilgore
+Aliases:
+- Amber Cragg
+- Amber Rogers
+- Danny Cragg
+URLs:
+- https://dannykilgore.tumblr.com
+- https://bsky.app/profile/freshnewboy.bsky.social
+- https://freshnewboy.itch.io
+Dead URLs:
+- http://www.neo-kosmos.com/
+- https://twitter.com/recentlydanny
+- https://linktr.ee/dannycragg
 ---
 Artist: Dante Basco
 URLs:

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -986,6 +986,39 @@ URLs:
 Featured Tracks:
 - Frustracean
 ---
+Flash: '[S] Cage: Reveal plan.'
+Page: darkcage
+Date: December 23, 2011
+Cover Art File Extension: png
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=7063s
+Featured Tracks:
+- Frustracean
+Commentary: |-
+    <i>Andrew Hussie:</i> ([Tumblr](https://homestuck.net/official/tumblr/#boner), 12/23/2011)
+
+    <b>boner</b>
+
+    (at the end of the flash, did you click the upper right corner?)
+
+    I asked [[artist:toby-fox|Toby]] to make the song ([[Frustracean]]), mimicking the [[flash:979|John breakdown]] song. And he did that.
+
+    But for some reason he put 5 minutes of silence at the end, followed by this bizarre Cage boner clip. So I’m like, ok what the fuck am I supposed to do with this thing.
+
+    So that’s what I did with this thing.
+
+    <i>Andrew Hussie:</i> ([Tumblr](https://homestuck.net/official/tumblr/#dark-cage-wallpaper-saved-at-low-quality), 12/23/2011)
+
+    <b>Dark Cage wallpaper, saved at low quality.</b>
+
+    <img src="media/misc/archive/darkcage.jpg" width="421" inline>
+
+    Y/W.
+
+    <i>Quasar Nebula:</i> (wiki editor, 6/4/2025)
+
+    Not exactly a separate flash, since it's just embedded within [[flash:4373|the previous one]], but this secret page really exists!
+---
 Flash: '[S] END OF ACT 6 INTERMISSION 1'
 Page: '4390'
 Date: December 29, 2011
@@ -1112,11 +1145,20 @@ Featured Tracks:
 ---
 Flash: '[S] Terry: Fast forward to Liv.'
 Page: '5027'
-Date: June 12, 2012
+Date: June 5, 2012
 URLs:
 - https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8488s
 Featured Tracks:
 - I Don't Want to Miss a Thing
+---
+Flash: '[S] Wait, what am I supposed to do with this bunny again?'
+Page: darkcage2
+Date: June 5, 2012
+Cover Art File Extension: png
+URLs:
+- https://www.youtube.com/watch?v=AEIOQN3YmNc&t=8645s
+Featured Tracks:
+- I Don't Want to Miss a Thing (Boner Mix)
 ---
 Flash: '[S] Dirk: Synchronize.'
 Page: '5238'

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -1682,7 +1682,7 @@ Contributors:
 - Angela Sham (art)
 - Callan Bencich (art)
 - Chaz Canterbury (art)
-- Danny Cragg (art)
+- Danny Kilgore (art)
 - HONE (art)
 - Jonathan Griffiths (art)
 - Jos Venti (art)
@@ -1858,7 +1858,7 @@ Contributors:
 - Cohen Edenfield (additional contributions)
 - Dagmar (animation, cutscene art, prop illustration, animation cleanup)
 - Dan Hernbrott (additional engineering)
-- Danny Cragg (animation)
+- Danny Kilgore (animation)
 - Delfina Isla (additional art)
 - Drake Stillman (additional contributions)
 - Elly Beck (additional art)
@@ -1939,7 +1939,7 @@ List Terminology: Volumes in this game
 Directory: fs-vol1
 Contributors:
 - 'Andrew Hussie (writing: Ardata, Diemen)'
-- 'Danny Cragg (art: characters, backgrounds, endings)'
+- 'Danny Kilgore (art: characters, backgrounds, endings)'
 - 'Shelby Cragg (art: colorist)'
 - David Turnbull (programming)
 Date: April 13, 2018
@@ -1952,7 +1952,7 @@ Directory: fs-vol2
 Contributors:
 - 'Aysha U. Farah (writing: Amisia)'
 - 'Unknown Artist (writing: Cirava)'
-- 'Danny Cragg (art: characters, backgrounds, endings)'
+- 'Danny Kilgore (art: characters, backgrounds, endings)'
 - 'Shelby Cragg (art: colorist)'
 - David Turnbull (programming)
 Date: April 27, 2018
@@ -2001,7 +2001,7 @@ Directory: fs-vol6
 Contributors:
 - 'Magdalena Clark (writing: Elwurd)'
 - 'Aysha U. Farah (writing: Kuprum & Folykl)'
-- 'Danny Cragg (art: characters, backgrounds, endings)'
+- 'Danny Kilgore (art: characters, backgrounds, endings)'
 - Mint Chipleaf (programming)
 Date: June 22, 2018
 Featured Tracks:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -3337,7 +3337,7 @@ Content: |-
         - added full lists of featured tracks to [[flash:psycholonials]] flashes (instead of just the tracks corresponding to each chapter's album)
         - fixed [[track:your-universe]] being credited to "Marcus Citrine" rather than [[artist:marcus-carline]] (who also wrote [[track:the-leaving]] from [[album:beyond-canon]]!)
         - credited cover and wallpaper art for [[album:hiveswap-act-1-ost]] and cover art for [[album:hiveswap-act-2-ost]] to [[artist:mallory-dyer]]
-        - credited wallpaper art for [[album:hiveswap-friendsim]] to [[artist:danny-cragg]], for [[album:the-felt]] to [[artist:molly-gur]], and for [[album:the-wanderers]] to [[artist:lauren-ross]]
+        - credited wallpaper art for [[album:hiveswap-friendsim]] to [[artist:danny-kilgore]], for [[album:the-felt]] to [[artist:molly-gur]], and for [[album:the-wanderers]] to [[artist:lauren-ross]]
         - (all artworks above were previously credited to the catch-all [[artist:homestuck]])
     <h3>bug fixes</h3>
     - fixed artist pages no longer sorting tracks according to their original release date (e.g. on [[artist:tempest2k]], tracks from [[album:inhospitable-delisted]] were being sorted according to the album rerelease in 2021, rather than the original track releases in 2017)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -54,6 +54,7 @@ Content: |-
     - added [[album:cognitive-coalescence]] by [[artist:witchs-cadence]] (thanks, Lilith, Lan!)
     <h3>other additions</h3>
     <!-- flash additions -->
+    - added [[flash:darkcage]] and [[flash:darkcage2]] secret pages (thanks, Tangle!)
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
     <!-- track additions -->
     - added [[track:vitality-home]] to [[album:home]]! (thanks, Lan, Lilith!)
@@ -82,6 +83,8 @@ Content: |-
     <!-- name fixes (single-lines) -->
     - fixed [[track:riches-to-ruins-movements-pt-ii]] ([[album:pesterquest-soundtrack]]) missing an "in-game credits" annotation on one of its additional names (thanks, Surge!)
     - fixed [[track:danger-on-the-dance-floor-mid-boss]] being named "Danger on the Dance Floor (Mid-Boss)" (to align with soundtrack release; thanks, ruby!)
+    <!-- general data fixes -->
+    - fixed date for [[flash:5027]] (was [[date:6/12/2012]], now [[date:6/5/2012]])
     <!-- art tag fixes -->
     - added [[tag:music-note]] tag to [[track:ohgodwhat]], [[track:ohgodwhat-remix]], [[track:rediscover-fusion]], [[track:rediscover-fusion-remix]], and [[track:explore-remix]] (thanks, Jackie!)
     - added [[tag:freshjamz]] tag to [[track:showtime-remix]], [[track:aggrieve-remix]], [[track:verdancy-bassline]], and [[track:potential-verdancy]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -71,6 +71,7 @@ Content: |-
     - fixed [[track:trial-truth-pt-2]] not referencing [[track:the-truth-inhibitor]] (Inhibitor; thanks, Lilith!)
     - fixed [[track:ikari-instrumental]] not referencing [[track:ikari]] (vocal version; thanks, Lilith!)
     - fixed [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] not referencing [[track:penumbra-phantasm]] (thanks, ruby, Makin, Jebb, Interrobang, Witch's Cadence, Monckat, Red Rax, Rainy, Meulanie, Jackie, Lan!)
+    - fixed [[track:old-secret]] artwork ([[album:hiveswap-friendsim]]) not referencing [[album:hiveswap-act-1-ost]] album cover (thanks, Jackie!)
     <!-- name fixes (subsections) -->
     - fixed some tracks' names not aligning with the Nintendo Music app: (thanks, ruby!)
         - fixed [[track:death-mountain-theme]] being named "Death Mountain (The Legend of Zelda)"

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -83,6 +83,8 @@ Content: |-
     - fixed [[track:riches-to-ruins-movements-pt-ii]] ([[album:pesterquest-soundtrack]]) missing an "in-game credits" annotation on one of its additional names (thanks, Surge!)
     - fixed [[track:danger-on-the-dance-floor-mid-boss]] being named "Danger on the Dance Floor (Mid-Boss)" (to align with soundtrack release; thanks, ruby!)
     <!-- art tag fixes -->
+    - added [[tag:music-note]] tag to [[track:ohgodwhat]], [[track:ohgodwhat-remix]], [[track:rediscover-fusion]], [[track:rediscover-fusion-remix]], and [[track:explore-remix]] (thanks, Jackie!)
+    - added [[tag:freshjamz]] tag to [[track:showtime-remix]], [[track:aggrieve-remix]], [[track:verdancy-bassline]], and [[track:potential-verdancy]] (thanks, Lilith!)
     - removed [[tag:john]] tag from [[album:the-baby-is-june]] (and [[album:the-baby-is-june-instrumental|instrumental]]), [[track:planet-healer-press-play]] ([[album:s-press-play]]), and [[track:urban-jungle]] (thanks, Lan!)
     <!-- commentary fixes -->
     - fixed Bandcamp credits blurb for [[album:jailbreak-vol-1]] listing [[artist:melodiousdiscord]] instead of [[artist:rebecca-harding]] (thanks, Lilith!)


### PR DESCRIPTION
For Hiveswap Friendsim and the Homestuck panels across the official discography.

Also darkcage flashes and some tag fixes.

Merge with hsmusic/hsmusic-media#142.