### PR TITLE
Jupiter (Jebb) addition

### DIFF
--- a/album/fondly-regard-illustration.yaml
+++ b/album/fondly-regard-illustration.yaml
@@ -709,7 +709,7 @@ URLs:
 Referenced Tracks:
 - Atomyk Ebonpyre
 - Beatdown (Strider Style)
-# - Jupiter (unreleased)
+- track:jupiter-jebb
 - track:silly-billy-hit-single
 - Davesprite
 - Hokus Pokus

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -2448,6 +2448,10 @@ Commentary: |-
 
     This track has the same duration as the later version. By that alone, it's ostensibly possible that this track was included on Shenanigans: MSPA's [Bandcamp release](https://web.archive.org/web/20130409111336/http://sparksd2145.bandcamp.com/). But it doesn't seem likely, since the updated version is from [[date:6/20/2012]], predating the Bandcamp release by three months. [The download from skaia.net](http://dl.skaia.net/albums), aligning with Bandcamp's track list, affirms the updated version is what got included there.
 ---
+Track: Jupiter
+Directory: jupiter-jebb
+Always Reference By Directory: true
+---
 Track: Karkalicious
 Artists:
 - Superspecks!

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -532,7 +532,7 @@ Content: |-
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:the-worlds-heel]] not referencing [[track:production-line-of-the-holy-clown]] (thanks, Gryotharian, Lilith!)
     - fixed [[track:duodenary]] not referencing [[track:six-by-six]] (thanks, Lilith, Rainy!)
-    - fixed [[track:coulrocide]] not referencing [[track:jupiter-jebb]] (thanks, Jebb!)
+    - fixed [[track:coulrocide]] not referencing [[track:jupiter-jebb]] (thanks, Jebb, Lilith!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
         - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]] (original single)
         - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]] (original single)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -532,6 +532,7 @@ Content: |-
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:the-worlds-heel]] not referencing [[track:production-line-of-the-holy-clown]] (thanks, Gryotharian, Lilith!)
     - fixed [[track:duodenary]] not referencing [[track:six-by-six]] (thanks, Lilith, Rainy!)
+    - fixed [[track:coulrocide]] not referencing [[track:jupiter-jebb]] (thanks, Jebb!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
         - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]] (original single)
         - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]] (original single)


### PR DESCRIPTION
Adds Jebb's unreleased Jupiter as a referenced track to Coulrocide (here we go again!)