### PR TITLE
Trollcops references wrong "Under The Hot"

### DIFF
--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -265,7 +265,7 @@ Track Artwork:
   - 'cw: hanging'
 Referenced Tracks:
 - Trollcops (Radio Play)
-- Under The Hat
+- track:under-the-hat-lofam
 Sheet Music Files:
 - Title: Sheet music by Erik Scheele (original composer)
   Files:
@@ -1399,7 +1399,7 @@ Track Artwork:
   - Alternia
   - 'cw: cops'
 Referenced Tracks:
-- Under The Hat
+- track:under-the-hat-lofam
 Lyrics: |-
     (Alternia: One of the roughest beats in the universe. It's a tough job to keep it safe, and an even tougher job to find people who'll keep it that way. She's a gal with a knack for justice and has the force under her thumb. He's a guy who just joined the APD and finding his bearings is about as easy as feeding a Gyclops his cough syrup. And together, they are Trollcops.)
 


### PR DESCRIPTION
https://hsmusic.wiki/track/trollcops-radio-play/ and https://hsmusic.wiki/track/trollcops reference tag the wrong "Under The Hat" (It's linked to [the one from _One Year Older_](https://hsmusic.wiki/track/under-the-hat/) which came out a year *after* it, instead of [the _Land of Fans and Music_ one](https://hsmusic.wiki/track/under-the-hat-lofam/))

This fixes that.