### PR TITLE
missing Battle Against a True Hero / Power of NEO ref

### DIFF
--- a/album/deltarune-ch2-rejected-tracks.yaml
+++ b/album/deltarune-ch2-rejected-tracks.yaml
@@ -34,6 +34,7 @@ URLs:
 - https://toby.fangamer.com/assets/interviews/9th/music/power_of_neo_unfinished_wip.mp3
 Referenced Tracks:
 - Power of "NEO"
+- Battle Against a True Hero
 Commentary: |-
     <i>Toby Fox:</i> ([CHAPTER 2 REJECTED TRACKS](https://toby.fangamer.com/interviews/chapter2_music/))
 


### PR DESCRIPTION
the unfinished, extended Power of NEO follows the same bass line as Battle Against a True Hero, this bass line can't be found in the original Power of NEO