### PR TITLE
Reference addition/fix: Homestuck Anthem in Frog Hunt

### DIFF
--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -520,6 +520,8 @@ Art Tags:
 - Frogs
 - Queen's Ring
 - LoFaF
+Referenced Tracks:
+- Homestuck Anthem
 Commentary: |-
     <i>Michael Guy Bowman, drpepperfan|[[artist:michael-guy-bowman]]:</i> (composer, [Tumblr](https://web.archive.org/web/20120118163148/http://iambowman.tumblr.com/), around 1/17/2012)
 
@@ -544,6 +546,11 @@ Commentary: |-
     <i>Tavia Morra:</i> (track artist, [Tumblr](https://seeyoutmorra.tumblr.com/post/12054861967/homestuck-volume-8-track-art), excerpt, 10/28/2011)
 
     Frog Hunt was, like [[Calamity]], one of the more challenging pieces since I opted for a much cleaner (And much more Disney) look for the piece. I totally saw Jade and Dave on the frog hunt, dressing for the part as adventurers and explorers. Jade, in her excitement, may have dragged Dave through a couple of bushes and thorned plants.
+Referencing Sources: |-
+    <i>Michael Guy Bowman:</i> (Bowmantown Discord, 12/1/2024)
+
+    Relistening to "Frog Hunt" and suddenly I hear [[track:homestuck-anthem|"Homestuck Anthem"]]<br>
+    I completely forgot there's a little reference to it at 3:01
 ---
 Track: Terraform
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -326,7 +326,7 @@ Content: |-
     - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)
-    - fixed [[track:frog-hunt]] not referencing [[track:homestuck-anthem]] (thanks, Celeste, Bowman, Lilith!)
+    - fixed [[track:frog-hunt]] not referencing [[track:homestuck-anthem]] (thanks, Bowman, Celeste, Lilith!)
     - fixed [[track:a-common-occurrance-every-night-to-be-exact]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:rise-of-the-denizens]] not sampling [[track:upward-movement-dave-owns]] in addition to referencing it, and referencing [[track:cascade]] instead of sampling [[track:savior-of-the-dreaming-dead-cascade-cut]] (thanks, Makin, Lan!)
     - fixed [[track:bowstutzlogic]] not sampling [[track:your-bed]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -326,6 +326,7 @@ Content: |-
     - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)
+    - fixed [[track:frog-hunt]] not referencing [[track:homestuck-anthem]] (thanks, Celeste, Bowman, Lilith!)
     - fixed [[track:a-common-occurrance-every-night-to-be-exact]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:rise-of-the-denizens]] not sampling [[track:upward-movement-dave-owns]] in addition to referencing it, and referencing [[track:cascade]] instead of sampling [[track:savior-of-the-dreaming-dead-cascade-cut]] (thanks, Makin, Lan!)
     - fixed [[track:bowstutzlogic]] not sampling [[track:your-bed]] (thanks, Lilith!)


### PR DESCRIPTION
Thanks, Bowman and Celeste!

adds homestuck anthem to frog hunt as a referenced track
and adds referencing source from Bowmantown Discord