### PR TITLE
Trolls Who Can Eat Trolls Are The Luckiest Trolls art tag fix 

### DIFF
--- a/album/fondly-regard-illustration.yaml
+++ b/album/fondly-regard-illustration.yaml
@@ -1041,7 +1041,7 @@ Track: Trolls Who Can Eat Trolls Are the Luckiest Trolls
 Cover Artists:
 - Jas
 Art Tags:
-- Joey
+- Chixie
 - Dammek
 - Xefros
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -497,6 +497,7 @@ Content: |-
     - added [[tag:green-moon]] and [[tag:pink-moon]] tags to [[album:friendsim-2-volume-1]] (thanks, Lilith!)
     - added [[tag:sbahj]] tag to track artwork for [[track:im-a-member-of-the-midnight-crew-soapstone]] (thanks, Lan!)
     - added [[tag:spamton]] tag to [[track:sburban-keygen-working-2009-no-virus]] (thanks, Meulanie, Lilith!)
+    - fixed [[track:trolls-who-can-eat-trolls-are-the-luckiest-trolls]] being tagged with [[tag:joey]] instead of [[tag:chixie]] (thanks, Lilith!)
     - added [[tag:michael-guy-bowman]] tag to [[album:comfortable-bugs]] and [[album:look-on-my-works-ye-mighty-and-despair]] (thanks, Lan!)
     - added blood warning to [[track:cobalt-corsair]] (thanks, Lan!)
     <!-- additional file fixes -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -497,7 +497,7 @@ Content: |-
     - added [[tag:green-moon]] and [[tag:pink-moon]] tags to [[album:friendsim-2-volume-1]] (thanks, Lilith!)
     - added [[tag:sbahj]] tag to track artwork for [[track:im-a-member-of-the-midnight-crew-soapstone]] (thanks, Lan!)
     - added [[tag:spamton]] tag to [[track:sburban-keygen-working-2009-no-virus]] (thanks, Meulanie, Lilith!)
-    - fixed [[track:trolls-who-can-eat-trolls-are-the-luckiest-trolls]] being tagged with [[tag:joey]] instead of [[tag:chixie]] (thanks, Lilith!)
+    - fixed [[track:trolls-who-can-eat-trolls-are-the-luckiest-trolls]] being tagged with [[tag:joey]] instead of [[tag:chixie]] (thanks, Lilith, Jebb, Makin!)
     - added [[tag:michael-guy-bowman]] tag to [[album:comfortable-bugs]] and [[album:look-on-my-works-ye-mighty-and-despair]] (thanks, Lan!)
     - added blood warning to [[track:cobalt-corsair]] (thanks, Lan!)
     <!-- additional file fixes -->


### PR DESCRIPTION
Fixes erroneous Joey tag on Trolls Who Can Eat Trolls Are The Luckiest Trolls, replacing it with a Chixie tag instead.

Not only that, the booklet commentary (excerpt here) even says Chixie!

> The artwork here by Jas really spoke to me, because I always love the idea of the characters performing music together in Homestuck related media, and **Chixie** is my favourite Friendsim character.
