### PR TITLE
Albums addition: Palokrai I & Palokrai II

### DIFF
--- a/album/lofam.yaml
+++ b/album/lofam.yaml
@@ -946,14 +946,17 @@ Commentary: |-
     Originally this picture didn't have Rose in it at all. It was just a generic silhouette standing, holding a star on a specibus card. That was kinda lame, and didn't really fit the feel of the song. I think I improved it.
 ---
 Track: Maibasojen
-Artists:
-- Isoraķatheð Zorethan F.
+Suffix Directory: true
+Always Reference By Directory: true
+Main Release: Maibasojen
 Duration: 3:13
 URLs:
 - https://homestuckgaiden.bandcamp.com/track/maibasojen
 - https://youtu.be/-P9FdBPpY04
 Cover Artists:
 - Isoraķatheð Zorethan F.
+Referenced Artworks:
+- Maibasojen
 Commentary: |-
     <i>Isoraķatheð Zorethan F.:</i> (booklet commentary)
 

--- a/album/lofam.yaml
+++ b/album/lofam.yaml
@@ -974,7 +974,7 @@ Commentary: |-
 
     [1] Sometimes the B, S and J are flopped around each other because the name has never really been fixed; pronunciation is IPA except that &lt;j> is /ʔ/.
 
-    [2] The entire album is called Palokrai and is cut into two parts. The reference to the alphabet was not planned out at first; instead the first few pieces I wrote just happened to avoid each other by first letter and I thought to continue that down that road until it ends. Letters are picked without decision. As described later, M is picked 3rd from the end. Looking at the album art of the others, it appears that the box at the bottom is to ensure that the presence of the box and the colour together uniquely determine which song in the album it is.
+    [2] The entire album is called Palokrai and is cut into [[album:palokrai-i|two]] [[album:palokrai-ii|parts]]. The reference to the alphabet was not planned out at first; instead the first few pieces I wrote just happened to avoid each other by first letter and I thought to continue that down that road until it ends. Letters are picked without decision. As described later, M is picked 3rd from the end. Looking at the album art of the others, it appears that the box at the bottom is to ensure that the presence of the box and the colour together uniquely determine which song in the album it is.
 
     I *believe* that every piece has a four-syllable name, and if it won't fit on one line in the default font then it's split into two visually. There is however never a space in the name.
 

--- a/album/palokrai-i.yaml
+++ b/album/palokrai-i.yaml
@@ -26,7 +26,7 @@ Commentary: |-
 
     [[album:palokrai-ii]] will have 13 songs as well, and should be available next June.
 
-    I'll like to thank H/S in general and [[group:official|its constituent musicians]] for getting me to do this in the first place. I would have never gone this far to do so.
+    I'll like to thank H/S in general and its constituent musicians for getting me to do this in the first place. I would have never gone this far to do so.
 
     {1} As funny as this looks, this isn't a semi-open interval. It's a square mouth followed by a parenthesis.
 
@@ -35,6 +35,14 @@ Commentary: |-
     Inspired by H/S<br>
     Made possible by MuseScore and my unending bathroom composing sessions<br>
     Creation secured by the Pseudoans and their Invention Double Reacharound.
+
+    <i>Quasar Nebula:</i> (wiki editor, 9/16/2025)
+
+    This album is dated on Bandcamp with a custom release date of 12/23/2010. According to the internal data which Bandcamp makes available in any JavaScript console (`TralbumData.current.publish_date`), the album was actually first published twenty days earlier: 12/03/2010.
+
+    Tracks across this album have custom release dates, which are visible on the track pages on Bandcamp, and reflected here, too. There are some asterisks: see [[track:istojabego]], [[track:cforenso-ii]], [[track:cforenso-iii]]. Also, the final track, [[track:vejisto]], has a notable publish_date, 12/23/2010 - the same as the album's custom release date. (The track is also custom release dated 12/23/2010, and its written lyrics are expressly set on that particular date.)
+
+    All together, this suggests that the album initially had only twelve of its thirteen (main) tracks, and [[track:cforenso-ii]] and [[track:cforenso-iii]] were at the end of the album, the same as bonus tracks typically are. But the tracks still don't self-describe as "bonus tracks", so we're still describing them as just "hidden tracks" here. It's also possible that the album really was published on 12/23/2010 and Bandcamp's internal wires work some way we're not aware, hypothetically e.g. publish_date always recording the earliest publish date, even though an album was un- and later re-published. (That's speculation. We have no record to tell either way, for this album.)
 ---
 Section: Main album
 ---
@@ -44,7 +52,7 @@ Duration: 2:13
 URLs:
 - https://isoraqathedh.bandcamp.com/track/akdoyvonren
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/akdoyvonren))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/akdoyvonren))
 
     The first and foremost piece has two versions; this is the second of them.
 
@@ -59,8 +67,15 @@ URLs:
 Track: Istojabeȝo
 Directory: istojabego
 Duration: 1:14
+Has Date: false
 URLs:
 - https://isoraqathedh.bandcamp.com/track/istojabe-o
+Commentary: |-
+    <i>Quasar Nebula:</i> (wiki editor, 9/16/2025)
+
+    Most of Palokrai's tracks have custom release dates on Bandcamp, which we represent here, despite the tracks within the albums themselves actually being released all or almost all at once. This track is missing a custom release date! However, its lime label fits [[track:maibasojen-lofam|the numbering system]] used across Palokrai: 3.03.02 places it after 3.02.02 ([[track:baptikonyen|the previous track]]) and before 3.04.02 ([[track:saltovahr|the next track]]).
+
+    Unfortunately, since the custom track dates on Bandcamp are the *only* source for these track dates (the numbering system does *not* represent specific dates, and the album was prepared on Bandcamp mostly after its tracks were created), the date used for this track is arbitrary. So... this track has no date at all. Eep!
 ---
 Track: Saltovahr
 Date First Released: July 24, 2010
@@ -80,7 +95,7 @@ Duration: 2:01
 URLs:
 - https://isoraqathedh.bandcamp.com/track/zerehanda
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/zerehanda))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/zerehanda))
 
     The very first using the pentatonic scale. I guess that should be poignant because I'm Chinese be begin with!
 ---
@@ -96,7 +111,7 @@ Duration: 3:13
 URLs:
 - https://isoraqathedh.bandcamp.com/track/quensindara
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/quensindara))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/quensindara))
 
     This is a three-in-one medley consisting of Quistrodose, Quenzeyodu and Quelesósta.
 ---
@@ -124,17 +139,23 @@ Duration: 2:09
 URLs:
 - https://isoraqathedh.bandcamp.com/track/cforenso
 ---
-Section: Bonus tracks
+Section: Hidden tracks
 ---
 Track: Cforenso II
+Date First Released: December 2, 2010
 Duration: 2:09
 Cover Art File Extension: jpg
 Referenced Artworks:
 - Cforenso
 Referenced Tracks:
 - Cforenso
+Commentary: |-
+    <i>Quasar Nebula:</i> (wiki editor, 9/16/2025)
+
+    Since these two tracks are hidden on Bandcamp and only available as part of the album download, they don't have custom on-site track release dates. However, the artwork for [[track:cforenso]] indicates multiple parts to Cforenso itself, so we're going out on a limb and reusing the date for that track, here.
 ---
 Track: Cforenso III
+Date First Released: December 2, 2010
 Duration: 4:17
 Cover Art File Extension: jpg
 Referenced Artworks:
@@ -143,6 +164,10 @@ Referenced Artworks:
 Referenced Tracks:
 - Cforenso
 - Cforenso II
+Commentary: |-
+    <i>Quasar Nebula:</i> (wiki editor, 9/16/2025)
+
+    See [[track:cforenso-ii]]! Since the artwork for [[track:cforenso]] indicates multiple parts to Cforenso itself, so we're reusing the date for that track, here.
 ---
 Section: Main album, continued
 ---
@@ -150,12 +175,8 @@ Track: Vejisto
 Duration: 6:02
 URLs:
 - https://isoraqathedh.bandcamp.com/track/vejisto
-Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/vejisto))
-
-    This is the first time I added any lyrics. Don't get to excited though -- I haven't sang any.
-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp lyrics blurb](https://isoraqathedh.bandcamp.com/track/vejisto))
+Lyrics: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([artist's lyrics](https://isoraqathedh.bandcamp.com/track/vejisto))
 
     Intro
 
@@ -201,3 +222,7 @@ Commentary: |-
     December 24th, he's gonna have some fun.
 
     Outro
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/vejisto))
+
+    This is the first time I added any lyrics. Don't get to excited though -- I haven't sang any.

--- a/album/palokrai-i.yaml
+++ b/album/palokrai-i.yaml
@@ -58,7 +58,6 @@ URLs:
 ---
 Track: Istojabeȝo
 Directory: istojabego
-Date First Released: December 23, 2010
 Duration: 1:14
 URLs:
 - https://isoraqathedh.bandcamp.com/track/istojabe-o
@@ -86,7 +85,7 @@ Commentary: |-
     The very first using the pentatonic scale. I guess that should be poignant because I'm Chinese be begin with!
 ---
 Track: Kastoronda
-Date First Released: 
+Date First Released: August 25, 2010
 Duration: 1:37
 URLs:
 - https://isoraqathedh.bandcamp.com/track/kastoronda
@@ -180,11 +179,11 @@ Commentary: |-
     The pile of paperwork goes far beyond his ability,<br>
     He cannot take no more, he leaves without fanfare.
 
-    [[Chorus\]]
+    \[[Chorus]]
 
     Solo
 
-    [[Chorus\]]
+    \[[Chorus]]
 
     4 December 24th, December 24th,<br>
     He trudges up the same old giant office building,<br>

--- a/album/palokrai-i.yaml
+++ b/album/palokrai-i.yaml
@@ -1,0 +1,204 @@
+Album: Palokrai I
+Date: December 23, 2010
+Artists:
+- Isoraķatheð Zorethan F.
+Color: '#f14e54'
+URLs:
+- https://isoraqathedh.bandcamp.com/album/palokrai-i
+Cover Artists:
+- Isoraķatheð Zorethan F.
+Default Track Cover Artists:
+- Isoraķatheð Zorethan F.
+Cover Art File Extension: png
+Track Art File Extension: png
+Groups:
+- Fandom
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/album/palokrai-i))
+
+    This album is the first in a most likely large amount of albums.
+
+    At first, I didn't think that I was capable of doing any music. But after so much time spent on Homestuck (hereby termed H/S) and hearing their own highly lucrative music (still unable to buy them despite having the money :[) {1} I thought, for the first time, that music may be something I can do.
+
+    And in six months this happened.
+
+    Palokrai, like a lot of things I do, will be in two. This is the first. Its serial number, No. 3.{01 ~ 13}.01, indicates its content, songs one to thirteen.
+
+    [[album:palokrai-ii]] will have 13 songs as well, and should be available next June.
+
+    I'll like to thank H/S in general and its constituent musicians for getting me to do this in the first place. I would have never gone this far to do so.
+
+    {1} As funny as this looks, this isn't a semi-open interval. It's a square mouth followed by a parenthesis.
+
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp credits blurb](https://isoraqathedh.bandcamp.com/album/palokrai-i))
+
+    Inspired by H/S<br>
+    Made possible by MuseScore and my unending bathroom composing sessions<br>
+    Creation secured by the Pseudoans and their Invention Double Reacharound.
+---
+Section: Main album
+---
+Track: Akdoyvonren
+Date First Released: June 6, 2010
+Duration: 2:13
+URLs:
+- https://isoraqathedh.bandcamp.com/track/akdoyvonren
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/akdoyvonren))
+
+    The first and foremost piece has two versions; this is the second of them.
+
+    UCN/Index: No. 3.01.04.
+---
+Track: Baptikonyen
+Date First Released: June 7, 2010
+Duration: 1:14
+URLs:
+- https://isoraqathedh.bandcamp.com/track/baptikonyen
+---
+Track: Istojabeȝo
+Directory: istojabego
+Date First Released: December 23, 2010
+Duration: 1:14
+URLs:
+- https://isoraqathedh.bandcamp.com/track/istojabe-o
+---
+Track: Saltovahr
+Date First Released: July 24, 2010
+Duration: 2:09
+URLs:
+- https://isoraqathedh.bandcamp.com/track/saltovahr
+---
+Track: Xastorojo
+Date First Released: August 5, 2010
+Duration: 3:11
+URLs:
+- https://isoraqathedh.bandcamp.com/track/xastorojo
+---
+Track: Zerehanda
+Date First Released: August 26, 2010
+Duration: 2:01
+URLs:
+- https://isoraqathedh.bandcamp.com/track/zerehanda
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/zerehanda))
+
+    The very first using the pentatonic scale. I guess that should be poignant because I'm Chinese be begin with!
+---
+Track: Kastoronda
+Date First Released: 
+Duration: 1:37
+URLs:
+- https://isoraqathedh.bandcamp.com/track/kastoronda
+---
+Track: Quensindara
+Date First Released: October 4, 2010
+Duration: 3:13
+URLs:
+- https://isoraqathedh.bandcamp.com/track/quensindara
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/quensindara))
+
+    This is a three-in-one medley consisting of Quistrodose, Quenzeyodu and Quelesósta.
+---
+Track: Degrutos
+Date First Released: September 19, 2010
+Duration: 1:33
+URLs:
+- https://isoraqathedh.bandcamp.com/track/degrutos
+---
+Track: Galsordokan
+Date First Released: October 8, 2010
+Duration: 3:13
+URLs:
+- https://isoraqathedh.bandcamp.com/track/galsordokan
+---
+Track: Tikijona
+Date First Released: November 13, 2010
+Duration: 3:49
+URLs:
+- https://isoraqathedh.bandcamp.com/track/tikijona
+---
+Track: Cforenso
+Date First Released: December 2, 2010
+Duration: 2:09
+URLs:
+- https://isoraqathedh.bandcamp.com/track/cforenso
+---
+Section: Bonus tracks
+---
+Track: Cforenso II
+Duration: 2:09
+Cover Art File Extension: jpg
+Referenced Artworks:
+- Cforenso
+Referenced Tracks:
+- Cforenso
+---
+Track: Cforenso III
+Duration: 4:17
+Cover Art File Extension: jpg
+Referenced Artworks:
+- Cforenso
+- Cforenso II
+Referenced Tracks:
+- Cforenso
+- Cforenso II
+---
+Section: Main album, continued
+---
+Track: Vejisto
+Duration: 6:02
+URLs:
+- https://isoraqathedh.bandcamp.com/track/vejisto
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/vejisto))
+
+    This is the first time I added any lyrics. Don't get to excited though -- I haven't sang any.
+
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp lyrics blurb](https://isoraqathedh.bandcamp.com/track/vejisto))
+
+    Intro
+
+    1 December 23rd, December 23rd,<br>
+    There was a man inside a giant office building<br>
+    Outside a light snow begins falling from the inky pitch black sky,<br>
+    December 23rd, it's cold as cold can be.
+
+    2 December 23rd, December 23rd,<br>
+    It was a cold uncaring world out in the outside,<br>
+    Inside was the same old coldness, yet another different kind,<br>
+    December 23rd, what a life to be there.
+
+    Chorus Where is the fairness of this world when you can't ever enjoy yourself,<br>
+    Why can't they ever understand your prediactment,<br>
+    Your collegues went off to everywhere leaving you all alone,<br>
+    December 23rd, how it burns in your heart.
+
+    3 December 23rd, 11:59,<br>
+    He's tired and there's still much to do,<br>
+    The pile of paperwork goes far beyond his ability,<br>
+    He cannot take no more, he leaves without fanfare.
+
+    [[Chorus\]]
+
+    Solo
+
+    [[Chorus\]]
+
+    4 December 24th, December 24th,<br>
+    He trudges up the same old giant office building,<br>
+    When he got there he found that all his work had disappeared,<br>
+    Replaced with a small note, with these words written down.
+
+    5 My dear subordinate, I knew that you worked hard,<br>
+    I've decided that you need a break that you deserve,<br>
+    So I done all the work for you and now you can go home right now,<br>
+    Don't worry about pay, you get it to. Yours, Boss.
+
+    6 December 24th, December 24,<br>
+    Maybe the world is not so cruel after all,<br>
+    He thought as he drives home for his holiday has now begun,<br>
+    December 24th, he's gonna have some fun.
+
+    Outro

--- a/album/palokrai-i.yaml
+++ b/album/palokrai-i.yaml
@@ -26,7 +26,7 @@ Commentary: |-
 
     [[album:palokrai-ii]] will have 13 songs as well, and should be available next June.
 
-    I'll like to thank H/S in general and its constituent musicians for getting me to do this in the first place. I would have never gone this far to do so.
+    I'll like to thank H/S in general and [[group:official|its constituent musicians]] for getting me to do this in the first place. I would have never gone this far to do so.
 
     {1} As funny as this looks, this isn't a semi-open interval. It's a square mouth followed by a parenthesis.
 

--- a/album/palokrai-ii.yaml
+++ b/album/palokrai-ii.yaml
@@ -1,0 +1,122 @@
+Album: Palokrai II
+Date: August 15, 2011
+Artists:
+- Isoraķatheð Zorethan F.
+Color: '#6480f5'
+URLs:
+- https://isoraqathedh.bandcamp.com/album/palokrai-ii
+Cover Artists:
+- Isoraķatheð Zorethan F.
+Default Track Cover Artists:
+- Isoraķatheð Zorethan F.
+Cover Art File Extension: png
+Track Art File Extension: png
+Groups:
+- Fandom
+---
+Section: Main album
+---
+Track: Nlekudoyan
+Date First Released: December 12, 2010
+Duration: 2:10
+URLs:
+- https://isoraqathedh.bandcamp.com/track/nlekudoyan
+---
+Track: Paħilono
+Directory: pahilono
+Date First Released: December 17, 2010
+Duration: 1:37
+URLs:
+- https://isoraqathedh.bandcamp.com/track/pa-ilono
+---
+Track: Rahonida
+Date First Released: December 20, 2010
+Duration: 2:17
+URLs:
+- https://isoraqathedh.bandcamp.com/track/rahonida
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/rahonida))
+
+    First of the R-J-L Trilogy of Chiptunes.
+
+    It's pretty disorientating to stick your toe in something that you have never done before, but as one has to do it sometime, why not now?
+---
+Track: Jeltagnoya
+Date First Released: December 26, 2011
+Duration: 2:19
+URLs:
+- https://isoraqathedh.bandcamp.com/track/jeltagnoya
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/jeltagnoya))
+
+    Or, how not to vary tempo.
+
+    Very experimental indeed, this piece varies tempo more than actual variation. The first part is sort of regular, the second, equal in composition but entirely unrecognizable, has a BPM swinging wildly between 10 and 800. Not kidding. Nominally: 320.
+---
+Track: Lellasuve
+Date First Released: December 30, 2011
+Duration: 3:32
+URLs:
+- https://isoraqathedh.bandcamp.com/track/lellasuve
+---
+Track: Hiltastordžen
+Directory: hiltastordzen
+Date First Released: January 7, 2011
+Duration: 3:21
+URLs:
+- https://isoraqathedh.bandcamp.com/track/hiltastord-en
+---
+Track: Yalafura
+Date First Released: January 29, 2011
+Duration: 2:03
+URLs:
+- https://isoraqathedh.bandcamp.com/track/yalafura
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/yalafura))
+
+    Sorry, no Chinese New Year special. This isn't even completely done, as there seems to be a bit of a problem with songs that start with Y. So stay tuned for more.
+---
+Track: Feleynstitšro
+Directory: feleynstitsro
+Date First Released: August 2, 2012
+Duration: 2:31
+URLs:
+- https://isoraqathedh.bandcamp.com/track/feleynstit-ro
+---
+Track: Opokraiso
+Date First Released: February 26, 2011
+Duration: 2:41
+URLs:
+- https://isoraqathedh.bandcamp.com/track/opokraiso
+---
+Track: Maibasojen
+Additional Names:
+- Maisabojen (composer suggestion)
+- Mausajoben (composer suggestion)
+- M (composer suggestion)
+Date First Released: March 5, 2011
+Duration: 3:13
+URLs:
+- https://isoraqathedh.bandcamp.com/track/maibasojen
+Commentary: |-
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/maibasojen))
+
+    The unspellable track! You can call it "Maisabojen", "Maibasojen", "Mausajoben" or just "M".
+---
+Track: Entergaonta
+Date First Released: March 26, 2011
+Duration: 1:24
+URLs:
+- https://isoraqathedh.bandcamp.com/track/entergaonta
+---
+Track: Ukiyondaj
+Date First Released: June 18, 2011
+Duration: 3:32
+URLs:
+- https://isoraqathedh.bandcamp.com/track/ukiyondaj
+---
+Track: Winonaido
+Date First Released: August 12, 2011
+Duration: 2:09
+URLs:
+- https://isoraqathedh.bandcamp.com/track/winonaido

--- a/album/palokrai-ii.yaml
+++ b/album/palokrai-ii.yaml
@@ -35,7 +35,7 @@ Duration: 2:17
 URLs:
 - https://isoraqathedh.bandcamp.com/track/rahonida
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/rahonida))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/rahonida))
 
     First of the R-J-L Trilogy of Chiptunes.
 
@@ -47,7 +47,7 @@ Duration: 2:19
 URLs:
 - https://isoraqathedh.bandcamp.com/track/jeltagnoya
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/jeltagnoya))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/jeltagnoya))
 
     Or, how not to vary tempo.
 
@@ -72,7 +72,7 @@ Duration: 2:03
 URLs:
 - https://isoraqathedh.bandcamp.com/track/yalafura
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/yalafura))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/yalafura))
 
     Sorry, no Chinese New Year special. This isn't even completely done, as there seems to be a bit of a problem with songs that start with Y. So stay tuned for more.
 ---
@@ -91,15 +91,15 @@ URLs:
 ---
 Track: Maibasojen
 Additional Names:
-- Maisabojen (composer suggestion)
-- Mausajoben (composer suggestion)
-- M (composer suggestion)
+- Maisabojen (artist's suggestion)
+- Mausajoben (artist's suggestion)
+- M (artist's suggestion)
 Date First Released: March 5, 2011
 Duration: 3:13
 URLs:
 - https://isoraqathedh.bandcamp.com/track/maibasojen
 Commentary: |-
-    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp blurb](https://isoraqathedh.bandcamp.com/track/maibasojen))
+    <i>Isoraķatheð Zorethan F.:</i> ([Bandcamp about blurb](https://isoraqathedh.bandcamp.com/track/maibasojen))
 
     The unspellable track! You can call it "Maisabojen", "Maibasojen", "Mausajoben" or just "M".
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -6444,7 +6444,7 @@ Artist: Isoraķatheð Zorethan F.
 Directory: isorakathed-zorethan-f
 URLs:
 - https://isoraqathedh.bandcamp.com/
-- https://twitter.com/isoraqathedh
+- https://bsky.app/profile/isoraqathedh.com
 - https://isoraqathedh.tumblr.com
 - https://isoraqathedh.github.io
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -6443,6 +6443,7 @@ Aliases:
 Artist: Isoraķatheð Zorethan F.
 Directory: isorakathed-zorethan-f
 URLs:
+- https://isoraqathedh.bandcamp.com/
 - https://twitter.com/isoraqathedh
 - https://isoraqathedh.tumblr.com
 - https://isoraqathedh.github.io

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -142,9 +142,9 @@ Content: |-
         - added [[album:cyberdemon]]!
         - added [[album:sun-in-sedona]]!
         - added [[album:waiting-for-the-night-svix-mix]]!
+    - added [[album:palokrai-i]] and [[album:palokrai-ii]] by [[artist:isorakathed-zorethan-f]]! (thanks, Lilith!)
     - added [[album:so-i-herd-you-liek-homestuck]] by [[artist:sidewalkbanana]] (thanks, Lilith!)
     - added [[album:centauromachy]] and [[album:sbargrist]] by [[artist:curricle]]! (thanks, Jebb!)
-    - added [[album:palokrai-i]] and [[album:palokrai-ii]] by [[artist:isorakathed-zorethan-f]]! (thanks, Lilith!)
     - added [[album:some-artifacts-may-occur]] by [[artist:shinokabe]] (thanks, Lilith, Lan!)
     - added [[album:vaporstuck]] by [[artist:the-hypergiants-asmr]] (thanks, Lilith!)
     - added [[album:janestuck-volume-100]] and [[album:janestuck-volume-2]]! (thanks, Lilith, Jackie!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -144,6 +144,7 @@ Content: |-
         - added [[album:waiting-for-the-night-svix-mix]]!
     - added [[album:so-i-herd-you-liek-homestuck]] by [[artist:sidewalkbanana]] (thanks, Lilith!)
     - added [[album:centauromachy]] and [[album:sbargrist]] by [[artist:curricle]]! (thanks, Jebb!)
+    - added [[album:palokrai-i]] and [[album:palokrai-ii]] by [[artist:isorakathed-zorethan-f]]! (thanks, Lilith!)
     - added [[album:some-artifacts-may-occur]] by [[artist:shinokabe]] (thanks, Lilith, Lan!)
     - added [[album:vaporstuck]] by [[artist:the-hypergiants-asmr]] (thanks, Lilith!)
     - added [[album:janestuck-volume-100]] and [[album:janestuck-volume-2]]! (thanks, Lilith, Jackie!)
@@ -278,6 +279,7 @@ Content: |-
     - moved stuff from commentary into crediting and referencing sources in [[track:showtime-svix-mix]], [[track:versus-hardmode-remix]], [[track:the-showdown-single-version]], [[track:adventurous-ascent-single-version]], [[track:the-showdown-album-version]], [[track:adventurous-ascent-lofam5a2-version]], [[track:infinite-cataclysm]], [[track:vivid-spectrum]], [[track:old-world]], and [[track:losing-heart]] (thanks, Tangle, Lanolin!)
     - removed a bunch of commentary from [[track:adventurous-ascent-lofam5a2-version]] that was just duplicated from the LOFAM5A2 album booklet
     <!-- tracks newly marked as a secondary release -->
+    - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
     - marked [[track:frost-and-frogs-lofam5a2]] ([[album:lofam5a2]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:fallen-down]] ([[album:i-miss-you-earthbound-2012]] newly as a secondary release (thanks, ruby!)
@@ -524,6 +526,7 @@ Content: |-
     - removed dead YouTube listening links for [[track:destiny-ablaze]], [[track:id-purpose]], and [[track:prelude-ablaze]] (thanks, Lan!)
     <h3>directory changes</h3>
     <details><summary><b>Toggle Directorylog</b> (general changes)</summary>
+    - changed directory of [[track:maibasojen-lofam]] from `maibasojen` to `maibasojen-lofam`
     - changed directory of [[track:denizen-lofam4]] from `denizen` to `denizen-lofam`
     - changed directory of [[track:cloudscape-dialed-to-11]] from `cloudscape` to `cloudscape-dialed-to-11`
     - changed directory of [[track:the-respect-you-rightfully-deserve-single]] from `the-respect-you-rightfully-deserve-soundcloud` to `the-respect-you-rightfully-deserve-single`


### PR DESCRIPTION
Adds the original home of Maisabojen, Palokrai II, as well as the predecessor album, Palokrai I, both from Isoraķatheð Zorethan F.

Also changes the directory name of `maibasojen` (LOFAM) to `maibasojen-lofam`, marked as rerelease

adds Bandcamp URL to Isoraķatheð Zorethan F.

Merge with media: [#159](https://github.com/hsmusic/hsmusic-media/pull/159)