### PR TITLE
Kindred Souls bonus track artwork

### DIFF
--- a/album/kindred-souls.yaml
+++ b/album/kindred-souls.yaml
@@ -2125,7 +2125,7 @@ Cover Art File Extension: jpg
 Art Tags:
 - Starwalker (original)
 - Mystery Man
-- Spamton
+- Spamton A. Spamton
 - Susie (Dark World)
 - FRIEND
 Referenced Tracks:
@@ -2141,7 +2141,7 @@ Cover Art File Extension: jpg
 Art Tags:
 - Starwalker (original)
 - Mystery Man
-- Spamton
+- Spamton A. Spamton
 - Susie (Dark World)
 - FRIEND
 Referenced Artworks:

--- a/album/kindred-souls.yaml
+++ b/album/kindred-souls.yaml
@@ -2084,10 +2084,16 @@ Directory: deltarune-tv-size-ver
 Artists:
 - ruby
 Duration: 1:22
-URLs:
-- https://unofficialmspafans.bandcamp.com/track/tv-size-ver
 Contributors:
 - Kasane Teto (vocals)
+Cover Artists:
+- Unknown Artist
+Cover Art File Extension: jpg
+Art Tags:
+- Kris (Dark World)
+- Ralsei
+Referenced Artworks:
+- track:deltarune-kindred-souls
 Referenced Tracks:
 - デルタルーン
 ---
@@ -2096,6 +2102,14 @@ Directory: deltarune-instrumental
 Artists:
 - ruby
 Duration: 5:13
+Cover Artists:
+- Unknown Artist
+Cover Art File Extension: jpg
+Art Tags:
+- Kris (Dark World)
+- Ralsei
+Referenced Artworks:
+- track:deltarune-tv-size-ver
 Referenced Tracks:
 - デルタルーン
 ---
@@ -2103,6 +2117,15 @@ Track: mus_starwalker_overworld
 Artists:
 - Levc
 Duration: 0:15
+Cover Artists:
+- Unknown Artist
+Cover Art File Extension: jpg
+Art Tags:
+- Starwalker (original)
+- Mystery Man
+- Spamton
+- Susie (Dark World)
+- FRIEND
 Referenced Tracks:
 - THE　　ORIGINAL
 ---
@@ -2110,5 +2133,16 @@ Track: mus_starwalker_battle
 Artists:
 - Levc
 Duration: 1:56
+Cover Artists:
+- Unknown Artist
+Cover Art File Extension: jpg
+Art Tags:
+- Starwalker (original)
+- Mystery Man
+- Spamton
+- Susie (Dark World)
+- FRIEND
+Referenced Artworks:
+- mus_starwalker_overworld
 Referenced Tracks:
 - THE　　ORIGINAL

--- a/album/kindred-souls.yaml
+++ b/album/kindred-souls.yaml
@@ -2118,8 +2118,9 @@ Artists:
 - Levc
 Duration: 0:15
 Cover Artists:
-- Jebb (background)
+- Jebb (Mystery Man background)
 - Makin (Starwalker)
+- ruby (Spamton A. Spamton & Garfield, Starwalker suggestion)
 Cover Art File Extension: jpg
 Art Tags:
 - Starwalker (original)

--- a/album/kindred-souls.yaml
+++ b/album/kindred-souls.yaml
@@ -2087,7 +2087,7 @@ Duration: 1:22
 Contributors:
 - Kasane Teto (vocals)
 Cover Artists:
-- Unknown Artist
+- Sanctferum (edits)
 Cover Art File Extension: jpg
 Art Tags:
 - Kris (Dark World)
@@ -2103,7 +2103,7 @@ Artists:
 - ruby
 Duration: 5:13
 Cover Artists:
-- Unknown Artist
+- Makin (edits)
 Cover Art File Extension: jpg
 Art Tags:
 - Kris (Dark World)
@@ -2118,7 +2118,8 @@ Artists:
 - Levc
 Duration: 0:15
 Cover Artists:
-- Unknown Artist
+- Jebb (background)
+- Makin (Starwalker)
 Cover Art File Extension: jpg
 Art Tags:
 - Starwalker (original)
@@ -2134,7 +2135,7 @@ Artists:
 - Levc
 Duration: 1:56
 Cover Artists:
-- Unknown Artist
+- Makin (edits)
 Cover Art File Extension: jpg
 Art Tags:
 - Starwalker (original)

--- a/art-tags/media/undertale-and-deltarune.yaml
+++ b/art-tags/media/undertale-and-deltarune.yaml
@@ -134,6 +134,7 @@ Direct Descendant Tags:
 - Knight
 - Mystery Man
 - Shadow Mantle
+- Spamton A. Spamton
 
 # Character entries
 
@@ -457,6 +458,9 @@ Extra Reading URLs:
 - https://deltarune.wiki/w/Spamton
 Direct Descendant Tags:
 - Spamton NEO
+---
+Tag: Spamton A. Spamton
+Color: '#FFFFFF'
 ---
 Tag: Spamton NEO
 Color: '#BF4385'

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -197,7 +197,7 @@ Content: |-
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
-    - added missing track artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello, Makin!)
+    - added missing track artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello, Makin, ruby!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
     - added revised artwork ([[date:3/13/2013]]) to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
     - added SoundCloud artwork to [[track:dave-striders-cool-mixtape]] (thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -197,7 +197,7 @@ Content: |-
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
-    - added artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello!)
+    - added artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello, Makin!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
     - added revised artwork ([[date:3/13/2013]]) to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
     - added SoundCloud artwork to [[track:dave-striders-cool-mixtape]] (thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -197,6 +197,7 @@ Content: |-
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
+    - added artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
     - added revised artwork ([[date:3/13/2013]]) to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
     - added SoundCloud artwork to [[track:dave-striders-cool-mixtape]] (thanks, Lan!)
@@ -297,6 +298,7 @@ Content: |-
     - removed dead link in commentary for [[track:threxecute]] (thanks, Lilith!)
     - removed dead Bandcamp listening links across [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed dead Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
+    - removed nonexistent Bandcamp link for [[track:deltarune-tv-size-ver]] (thanks, Lilith!)
     - removed dead SoundCloud listening link for [[track:bloodsucker-brawl]] (thanks, Lan!)
     - removed Deezer listening links for [[track:pale-rain]] and [[track:celestial]], and reordered links for [[track:pale-rain]] to fit wiki standard (thanks, Lan!)
     <h3>data fixes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -78,7 +78,7 @@ Content: |-
     - fixed external links not getting processed by the wiki if they follow some unrelated "[" on the same line
     - fixed broken background CSS for albums [[album:coloUrs-and-mayhem-universe-a]], [[album:coloUrs-and-mayhem-universe-b]], and [[album:the-homestuck-strife-project-vol-1]]
     <h3>album additions</h3>
-    - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus <<Jebb:album presentation help>>, <<Makin:URLs & artwork crediting help>>, <<Monckat:duration fix>>!)
+    - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus <<Jebb:album presentation help>>, <<Lilith:URL fix, bonus track artwork data>>, <<Cello:bonus track artwork help>>, <<Makin:URLs & bonus track artwork crediting help>>, <<Monckat:track duration fix>>!)
         - added [[album:kindred-souls]]!
     - added latest release from [[group:studio-june]]! (thanks, <<Lilith:album data, presentation, research>>, plus <<ruby:References Beyond Homestuck help>>, <<articulatelyComposed:artwork crediting help>>!)
         - added [[album:friendsim-2-volume-2]]!
@@ -197,7 +197,6 @@ Content: |-
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
-    - added missing track artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello, Makin, ruby!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
     - added revised artwork ([[date:3/13/2013]]) to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
     - added SoundCloud artwork to [[track:dave-striders-cool-mixtape]] (thanks, Lan!)
@@ -298,7 +297,6 @@ Content: |-
     - removed dead link in commentary for [[track:threxecute]] (thanks, Lilith!)
     - removed dead Bandcamp listening links across [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed dead Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
-    - removed nonexistent Bandcamp link for [[track:deltarune-tv-size-ver]] (thanks, Lilith!)
     - removed dead SoundCloud listening link for [[track:bloodsucker-brawl]] (thanks, Lan!)
     - removed Deezer listening links for [[track:pale-rain]] and [[track:celestial]], and reordered links for [[track:pale-rain]] to fit wiki standard (thanks, Lan!)
     <h3>data fixes</h3>

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -78,7 +78,7 @@ Content: |-
     - fixed external links not getting processed by the wiki if they follow some unrelated "[" on the same line
     - fixed broken background CSS for albums [[album:coloUrs-and-mayhem-universe-a]], [[album:coloUrs-and-mayhem-universe-b]], and [[album:the-homestuck-strife-project-vol-1]]
     <h3>album additions</h3>
-    - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus Jebb, Makin, <<Monckat:duration fix>>!)
+    - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus <<Jebb:album presentation help>>, <<Makin:URLs & artwork crediting help>>, <<Monckat:duration fix>>!)
         - added [[album:kindred-souls]]!
     - added latest release from [[group:studio-june]]! (thanks, <<Lilith:album data, presentation, research>>, plus <<ruby:References Beyond Homestuck help>>, <<articulatelyComposed:artwork crediting help>>!)
         - added [[album:friendsim-2-volume-2]]!

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -197,7 +197,7 @@ Content: |-
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
-    - added artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello, Makin!)
+    - added missing track artwork to [[track:deltarune-tv-size-ver]], [[track:deltarune-instrumental]], [[track:mus-starwalker-overworld]], and [[track:mus-starwalker-battle]] (thanks, Lilith, Cello, Makin!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
     - added revised artwork ([[date:3/13/2013]]) to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
     - added SoundCloud artwork to [[track:dave-striders-cool-mixtape]] (thanks, Lan!)


### PR DESCRIPTION
adds fields (cover artist is marked ~~as Unknown Artist for now~~ no longer the case; thanks Makin, and ruby!) supporting bonus track artwork for
- デルタルーン (TV Size ver.)
- デルタルーン (Instrumental)
- mus_starwalker_overworld
- mus_starwalker_battle

also removes nonexistent bandcamp URL for the tv size ver of DELTARUNE

merge with: [hsmusic-media#161](https://github.com/hsmusic/hsmusic-media/pull/161)