### PR TITLE
small URL additions: Glaze (SoundCloud) and WoodenToaster (Apple Music)

### DIFF
--- a/album/induction.yaml
+++ b/album/induction.yaml
@@ -669,7 +669,6 @@ Section: Remixes
 Track: Verisimilitude (Glaze Remix)
 Artists:
 - Glaze
-- WoodenToaster
 Duration: 3:53
 URLs:
 - https://svix.bandcamp.com/track/verisimilitude-glaze-remix

--- a/artists.yaml
+++ b/artists.yaml
@@ -5424,12 +5424,19 @@ URLs:
 - https://www.reddit.com/user/GlassRhino/
 ---
 Artist: Glaze
-Context Notes: |-
-    Alias of [[artist:woodentoaster]].
+Aliases:
+- WoodenToaster
 URLs:
-- https://twitter.com/GlazeArchives
-- https://open.spotify.com/artist/7J1NAfiNw9FD5T18Mx0LdR
+- https://www.youtube.com/user/WoodenToaster
 - https://soundcloud.com/glaze
+- https://open.spotify.com/artist/3J7yYhgRjwEL6S6eGpcMg9
+- https://open.spotify.com/artist/7J1NAfiNw9FD5T18Mx0LdR
+- https://music.apple.com/artist/woodentoaster/525136737
+# https://music.apple.com/artist/glaze/1356766732
+# apple music page for Glaze is borderline useless
+- https://twitter.com/WoodenToaster
+- https://twitter.com/GlazeArchives
+- https://www.facebook.com/pages/WoodenToaster/280642235307371
 ---
 Artist: glazelazer
 Dead URLs:
@@ -15517,14 +15524,6 @@ Artist: Wolfgang Amadeus Mozart
 Artist: Wolfgang Boss
 ---
 Artist: Wolfgun
----
-Artist: WoodenToaster
-URLs:
-- https://www.youtube.com/user/WoodenToaster
-- https://twitter.com/WoodenToaster
-- https://www.facebook.com/pages/WoodenToaster/280642235307371
-- https://open.spotify.com/artist/3J7yYhgRjwEL6S6eGpcMg9
-- https://music.apple.com/artist/woodentoaster/525136737
 ---
 Artist: woops
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -12475,7 +12475,6 @@ Aliases:
 URLs:
 - https://sanxion7.bandcamp.com
 - https://www.youtube.com/saxxonpike
-- https://blog.purplepa.ws
 ---
 Artist: Saori Kodama
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -5429,6 +5429,7 @@ Context Notes: |-
 URLs:
 - https://twitter.com/GlazeArchives
 - https://open.spotify.com/artist/7J1NAfiNw9FD5T18Mx0LdR
+- https://soundcloud.com/glaze
 ---
 Artist: glazelazer
 Dead URLs:
@@ -15523,6 +15524,7 @@ URLs:
 - https://twitter.com/WoodenToaster
 - https://www.facebook.com/pages/WoodenToaster/280642235307371
 - https://open.spotify.com/artist/3J7yYhgRjwEL6S6eGpcMg9
+- https://music.apple.com/artist/woodentoaster/525136737
 ---
 Artist: woops
 URLs:


### PR DESCRIPTION
Adds Glaze's SoundCloud URL and WoodenToaster's Apple Music URL.