### PR TITLE
updated official discography Bandcamp URLs (no longer compilations!!! (except for coloUrs and mayhem))

### DIFF
--- a/album/act-7.yaml
+++ b/album/act-7.yaml
@@ -5,7 +5,7 @@ Artists:
 Date: April 13, 2016
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-9-10-with-s-collide-and-act-7
+- https://homestuck.bandcamp.com/album/act-7
 - https://www.youtube.com/watch?v=FPsMeamXcE8
 Cover Artists:
 - Homestuck
@@ -45,7 +45,7 @@ Art Tags:
 - Earth
 Duration: 9:00
 URLs:
-- https://homestuck.bandcamp.com/track/overture-canon-edit-2
+- https://homestuck.bandcamp.com/track/overture-canon-edit
 - https://www.youtube.com/watch?v=FPsMeamXcE8
 Referenced Tracks:
 - I - Overture

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -4,7 +4,7 @@ Artists:
 Date: July 18, 2010
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/alterniabound-with-alternia
+- https://homestuck.bandcamp.com/album/alternia
 - https://www.youtube.com/playlist?list=PLYhdhHfN2xDpqsbieSVEmK_OYNgAYgZEZ
 Cover Artists:
 - Cindy Dominguez
@@ -123,7 +123,7 @@ Commentary: |-
 
     The first official Hivebent album, by the incorrigible [[artist:toby-fox|Toby "Radiation" Fox]]. It's an album about our dear Alternian trolls and their silly and/or terrifying trolly adventures!
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20100722172449/https://homestuck.bandcamp.com/album/alternia))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/alternia))
 
     Includes PDF booklet with musician commentary and bonus artwork, plus larger version of album cover.
 
@@ -142,7 +142,7 @@ Section: Main album
 Track: Crustacean
 Duration: 1:31
 URLs:
-- https://homestuck.bandcamp.com/track/crustacean-2
+- https://homestuck.bandcamp.com/track/crustacean
 - https://youtu.be/U5CGEwHZoss
 Track Artwork:
 - Label: Official art
@@ -195,7 +195,7 @@ Commentary: |-
 Track: Showdown
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/showdown-2
+- https://homestuck.bandcamp.com/track/showdown
 - https://youtu.be/5mdkmTXDG2I
 Track Artwork:
 - Label: Official art
@@ -256,7 +256,7 @@ Additional Names:
 - Miracles (quirk-free)
 Duration: 2:31
 URLs:
-- https://homestuck.bandcamp.com/track/miracles-2
+- https://homestuck.bandcamp.com/track/miracles
 - https://youtu.be/ztovKMiiolU
 Track Artwork:
 - Label: Official art
@@ -312,7 +312,7 @@ Commentary: |-
 Track: The Lemonsnout Turnabout
 Duration: 2:23
 URLs:
-- https://homestuck.bandcamp.com/track/the-lemonsnout-turnabout-2
+- https://homestuck.bandcamp.com/track/the-lemonsnout-turnabout
 - https://youtu.be/pvgyx0w8B1E
 Track Artwork:
 - Label: Official art
@@ -362,7 +362,7 @@ Commentary: |-
 Track: Phaze and Blood
 Duration: 1:38
 URLs:
-- https://homestuck.bandcamp.com/track/phaze-and-blood-2
+- https://homestuck.bandcamp.com/track/phaze-and-blood
 - https://youtu.be/fNsqqoGNLpE
 Track Artwork:
 - Label: Official art
@@ -409,7 +409,7 @@ Additional Names:
 - Psychoruins (quirk-free)
 Duration: 2:15
 URLs:
-- https://homestuck.bandcamp.com/track/psych0ruins-2
+- https://homestuck.bandcamp.com/track/psych0ruins
 - https://youtu.be/ueccsD074a8
 Track Artwork:
 - Label: Official art
@@ -454,7 +454,7 @@ Commentary: |-
 Track: Walls Covered In Blood
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/walls-covered-in-blood-2
+- https://homestuck.bandcamp.com/track/walls-covered-in-blood
 - https://youtu.be/REM1E8wC3Gs
 Track Artwork:
 - Label: Official art
@@ -500,7 +500,7 @@ Additional Names:
 - Desperado Rocket Chairs (quirk-free)
 Duration: 1:37
 URLs:
-- https://homestuck.bandcamp.com/track/desperado-rocket-chairs-2
+- https://homestuck.bandcamp.com/track/desperado-rocket-chairs
 - https://youtu.be/KPYJ9TuXZmQ
 Track Artwork:
 - Label: Official art
@@ -545,7 +545,7 @@ Commentary: |-
 Track: Death of the Lusii
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/death-of-the-lusii-2
+- https://homestuck.bandcamp.com/track/death-of-the-lusii
 - https://youtu.be/mrflmgFRrYo
 Track Artwork:
 - Label: Official art
@@ -591,7 +591,7 @@ Commentary: |-
 Track: Virgin Orb
 Duration: 2:23
 URLs:
-- https://homestuck.bandcamp.com/track/virgin-orb-2
+- https://homestuck.bandcamp.com/track/virgin-orb
 - https://www.youtube.com/watch?v=xHuyPJpvo4Y
 Track Artwork:
 - Label: Official art
@@ -635,7 +635,7 @@ Additional Names:
 - The Last Frontier (English normalized)
 Duration: 1:50
 URLs:
-- https://homestuck.bandcamp.com/track/the-la2t-frontiier-2
+- https://homestuck.bandcamp.com/track/the-la2t-frontiier
 - https://youtu.be/aPd9mP7ZrlY
 Track Artwork:
 - Label: Official art
@@ -694,7 +694,7 @@ Commentary: |-
 Track: Skaian Summoning
 Duration: 2:22
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-summoning-2
+- https://homestuck.bandcamp.com/track/skaian-summoning
 - https://youtu.be/gWBlVTuyp0s
 Track Artwork:
 - Label: Official art
@@ -731,7 +731,6 @@ Description: >-
 Track: The Thirteenth Hour
 Duration: 2:10
 URLs:
-- https://homestuck.bandcamp.com/track/the-thirteenth-hour-2
 - https://youtu.be/SixKHx18sqk
 Track Artwork:
 - Label: Official art
@@ -799,10 +798,10 @@ Commentary: |-
 Track: Spider's Claw
 Additional Names:
 - Name: Spider's Claw (Bonus)
-  Annotation: album download
+  Annotation: [Bandcamp](https://homestuck.bandcamp.com/track/spiders-claw-bonus)
 Duration: 0:37
 URLs:
-- https://homestuck.bandcamp.com/track/spiders-claw
+- https://homestuck.bandcamp.com/track/spiders-claw-bonus
 - https://youtu.be/ZA9M-ZpdlC8
 Track Artwork:
 - Label: Official art
@@ -849,10 +848,10 @@ Commentary: |-
 Track: Staring
 Additional Names:
 - Name: Staring (Bonus)
-  Annotation: album download
+  Annotation: [Bandcamp](https://homestuck.bandcamp.com/track/staring-bonus)
 Duration: 1:21
 URLs:
-- https://homestuck.bandcamp.com/track/staring
+- https://homestuck.bandcamp.com/track/staring-bonus
 - https://youtu.be/4TUOfRlT1ks
 Track Artwork:
 - Label: Official art
@@ -891,10 +890,10 @@ Commentary: |-
 Track: Keepers
 Additional Names:
 - Name: Keepers (Bonus)
-  Annotation: album download
+  Annotation: [Bandcamp](https://homestuck.bandcamp.com/track/keepers-bonus)
 Duration: 1:55
 URLs:
-- https://homestuck.bandcamp.com/track/keepers
+- https://homestuck.bandcamp.com/track/keepers-bonus
 - https://youtu.be/Sy3Au5UsykI
 Track Artwork:
 - Label: Official art
@@ -940,7 +939,6 @@ Additional Names:
   Annotation: album download
 Duration: 1:28
 URLs:
-- https://homestuck.bandcamp.com/track/theme-2
 - https://youtu.be/S2Pr-_j0qcc
 Track Artwork:
 - Label: Official art
@@ -983,7 +981,6 @@ Additional Names:
   Annotation: album download
 Duration: 2:01
 URLs:
-- https://homestuck.bandcamp.com/track/walls-covered-in-blood-dx-2
 - https://youtu.be/WPqca-NWV2k
 Track Artwork:
 - Label: Official art

--- a/album/alternia.yaml
+++ b/album/alternia.yaml
@@ -797,8 +797,10 @@ Commentary: |-
 ---
 Track: Spider's Claw
 Additional Names:
-- Name: Spider's Claw (Bonus)
-  Annotation: [Bandcamp](https://homestuck.bandcamp.com/track/spiders-claw-bonus)
+- Name: >-
+    Spider's Claw (Bonus)
+  Annotation: >-
+    [Bandcamp](https://homestuck.bandcamp.com/track/spiders-claw-bonus)
 Duration: 0:37
 URLs:
 - https://homestuck.bandcamp.com/track/spiders-claw-bonus
@@ -847,8 +849,10 @@ Commentary: |-
 ---
 Track: Staring
 Additional Names:
-- Name: Staring (Bonus)
-  Annotation: [Bandcamp](https://homestuck.bandcamp.com/track/staring-bonus)
+- Name: >-
+    Staring (Bonus)
+  Annotation: >-
+    [Bandcamp](https://homestuck.bandcamp.com/track/staring-bonus)
 Duration: 1:21
 URLs:
 - https://homestuck.bandcamp.com/track/staring-bonus
@@ -889,8 +893,10 @@ Commentary: |-
 ---
 Track: Keepers
 Additional Names:
-- Name: Keepers (Bonus)
-  Annotation: [Bandcamp](https://homestuck.bandcamp.com/track/keepers-bonus)
+- Name: >-
+    Keepers (Bonus)
+  Annotation: >-
+    [Bandcamp](https://homestuck.bandcamp.com/track/keepers-bonus)
 Duration: 1:55
 URLs:
 - https://homestuck.bandcamp.com/track/keepers-bonus

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -300,8 +300,10 @@ Commentary: |-
 Track: 'BL1ND JUST1C3 : 1NV3ST1G4T1ON !!'
 Additional Names:
 - "Blind Justice : Investigation !! (quirk-free)"
-- Name: BL1ND JUST1C3 - 1NV3ST1G4T1ON !!
-  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20201125201310/https://homestuck.bandcamp.com/track/bl1nd-just1c3-1nv3st1g4t1on-2)
+- Name: >-
+    BL1ND JUST1C3 - 1NV3ST1G4T1ON !!
+  Annotation: >-
+    [Bandcamp compilation release](https://web.archive.org/web/20201125201310/https://homestuck.bandcamp.com/track/bl1nd-just1c3-1nv3st1g4t1on-2)
 Artists:
 - Malcolm Brown
 Duration: 2:48

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -2,7 +2,7 @@ Album: AlterniaBound
 Date: March 14, 2011
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/alterniabound-with-alternia
+- https://homestuck.bandcamp.com/album/alterniabound
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFZWO9QOZmD6A3TIK0wZ6xE2
 Cover Artists:
 - Hanni Brosh
@@ -44,7 +44,7 @@ Commentary: |-
 
     I think I'll let the music speak for itself! It is a collaboration among numerous artists, but [[artist:toby-fox|Radiation]] did most of the legwork in organizing this effort. Super cover art by [[artist:hanni-brosh|SaffronScarf]]!
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20110319050222/https://homestuck.bandcamp.com/album/alterniabound))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/alterniabound))
 
     Album includes 8 -- EIGHT!!!!!!!! bonus tracks AND a PDF booklet full of commentary by the musicians!
 
@@ -52,7 +52,7 @@ Commentary: |-
 
     COOL
 
-    <i>Homestuck:</i> ([Bandcamp info blurb](https://web.archive.org/web/20110319050222/https://homestuck.bandcamp.com/album/alterniabound))
+    <i>Homestuck:</i> ([Bandcamp info blurb](https://homestuck.bandcamp.com/album/alterniabound))
 
     Music by:<br>
     [[artist:toby-fox|Toby "Radiation" Fox]]<br>
@@ -103,7 +103,7 @@ Artists:
 - Tensei
 Duration: 2:55
 URLs:
-- https://homestuck.bandcamp.com/track/arisen-anew-2
+- https://homestuck.bandcamp.com/track/arisen-anew
 - https://youtu.be/C0BYVRNGoEo
 Track Artwork:
 - Label: Official art
@@ -171,7 +171,7 @@ Artists:
 - Toby Fox
 Duration: 1:58
 URLs:
-- https://homestuck.bandcamp.com/track/karkats-theme-2
+- https://homestuck.bandcamp.com/track/karkats-theme
 - https://youtu.be/8M5FxI_p5wg
 Track Artwork:
 - Label: Official art
@@ -239,7 +239,7 @@ Artists:
 - Erik Scheele
 Duration: 2:45
 URLs:
-- https://homestuck.bandcamp.com/track/trollcops-2
+- https://homestuck.bandcamp.com/track/trollcops
 - https://youtu.be/agUl2xmrBuA
 Track Artwork:
 - Label: Official art
@@ -304,7 +304,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:48
 URLs:
-- https://homestuck.bandcamp.com/track/bl1nd-just1c3-1nv3st1g4t1on-2
+- https://homestuck.bandcamp.com/track/bl1nd-just1c3-1nv3st1g4t1on
 - https://youtu.be/yg41u9AejSs
 Track Artwork:
 - Label: Official art
@@ -375,7 +375,7 @@ Artists:
 - Toby Fox
 Duration: 2:16
 URLs:
-- https://homestuck.bandcamp.com/track/terezis-theme-2
+- https://homestuck.bandcamp.com/track/terezis-theme
 - https://youtu.be/IIw4NDK7j4w
 Track Artwork:
 - Label: Official art
@@ -433,7 +433,7 @@ Artists:
 - Thomas Ferkol
 Duration: 4:04
 URLs:
-- https://homestuck.bandcamp.com/track/dreamers-and-the-dead-2
+- https://homestuck.bandcamp.com/track/dreamers-and-the-dead
 - https://youtu.be/9PlP0RUzacQ
 Track Artwork:
 - Label: Official art
@@ -477,7 +477,7 @@ Artists:
 - Toby Fox
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/vriskas-theme-2
+- https://homestuck.bandcamp.com/track/vriskas-theme
 - https://youtu.be/LkJHtDiNowk
 Track Artwork:
 - Label: Official art
@@ -530,7 +530,7 @@ Artists:
 - Tensei
 Duration: 3:05
 URLs:
-- https://homestuck.bandcamp.com/track/shes-a-sp8der-2
+- https://homestuck.bandcamp.com/track/shes-a-sp8der
 - https://youtu.be/lqMGkbnWOQU
 Track Artwork:
 - Label: Official art
@@ -576,7 +576,7 @@ Contributors:
 - The_Eighth_Bit (soundfont)
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/fiduspawn-go-2
+- https://homestuck.bandcamp.com/track/fiduspawn-go
 - https://youtu.be/fCBr-v4JswY
 Track Artwork:
 - Label: Official art
@@ -635,7 +635,7 @@ Artists:
 - Toby Fox
 Duration: 2:07
 URLs:
-- https://homestuck.bandcamp.com/track/darling-kanaya-2
+- https://homestuck.bandcamp.com/track/darling-kanaya
 - https://youtu.be/54YThzEi4bk
 Track Artwork:
 - Label: Official art
@@ -685,7 +685,7 @@ Artists:
 - Paige Turner
 Duration: 2:44
 URLs:
-- https://homestuck.bandcamp.com/track/requiem-of-sunshine-and-rainbows-2
+- https://homestuck.bandcamp.com/track/requiem-of-sunshine-and-rainbows
 - https://youtu.be/erj2UQjMlhs
 Track Artwork:
 - Label: Official art
@@ -734,7 +734,7 @@ Contributors:
 - The_Eighth_Bit (soundfont)
 Duration: 2:41
 URLs:
-- https://homestuck.bandcamp.com/track/eridans-theme-2
+- https://homestuck.bandcamp.com/track/eridans-theme
 - https://youtu.be/mFLsoipuscM
 Track Artwork:
 - Label: Official art
@@ -832,7 +832,7 @@ Contributors:
 - The_Eighth_Bit (soundfont)
 Duration: 1:50
 URLs:
-- https://homestuck.bandcamp.com/track/nautical-nightmare-2
+- https://homestuck.bandcamp.com/track/nautical-nightmare
 - https://youtu.be/K5aZ0PdrT3U
 Track Artwork:
 - Label: Official art
@@ -872,7 +872,7 @@ Artists:
 - Toby Fox
 Duration: 1:32
 URLs:
-- https://homestuck.bandcamp.com/track/nepetas-theme-2
+- https://homestuck.bandcamp.com/track/nepetas-theme
 - https://youtu.be/Q7ZUxyLyIao
 Track Artwork:
 - Label: Official art
@@ -922,7 +922,7 @@ Artists:
 - Alex Rosetti
 Duration: 3:23
 URLs:
-- https://homestuck.bandcamp.com/track/horschestra-strong-version-2
+- https://homestuck.bandcamp.com/track/horschestra-strong-version
 - https://youtu.be/HHlaLTjv4So
 Track Artwork:
 - Label: Official art
@@ -973,7 +973,7 @@ Artists:
 - Toby Fox
 Duration: 2:30
 URLs:
-- https://homestuck.bandcamp.com/track/blackest-heart-with-honks-2
+- https://homestuck.bandcamp.com/track/blackest-heart-with-honks
 - https://youtu.be/-lJrvGkxPMI
 Track Artwork:
 - Label: Official art
@@ -1029,7 +1029,7 @@ Artists:
 - Mark J. Hadley
 Duration: 1:50
 URLs:
-- https://homestuck.bandcamp.com/track/midnight-calliope-2
+- https://homestuck.bandcamp.com/track/midnight-calliope
 - https://youtu.be/owRKKJN5PkE
 Track Artwork:
 - Label: Official art
@@ -1069,7 +1069,7 @@ Artists:
 - Thomas Ferkol
 Duration: 2:34
 URLs:
-- https://homestuck.bandcamp.com/track/chaotic-strength-2
+- https://homestuck.bandcamp.com/track/chaotic-strength
 - https://youtu.be/GUMeMEbJB0M
 Track Artwork:
 - Label: Official art
@@ -1128,7 +1128,7 @@ Artists:
 - Tensei
 Duration: 1:14
 URLs:
-- https://homestuck.bandcamp.com/track/trollian-standoff-2
+- https://homestuck.bandcamp.com/track/trollian-standoff
 - https://youtu.be/wbYnGg_QKt4
 Track Artwork:
 - Label: Official art
@@ -1178,7 +1178,7 @@ Artists:
 - Malcolm Brown
 Duration: 6:39
 URLs:
-- https://homestuck.bandcamp.com/track/rex-duodecim-angelus-2
+- https://homestuck.bandcamp.com/track/rex-duodecim-angelus
 - https://youtu.be/hn6Yl371mIc
 Track Artwork:
 - Label: Official art
@@ -1286,7 +1286,7 @@ Artists:
 - Toby Fox
 Duration: 4:20
 URLs:
-- https://homestuck.bandcamp.com/track/killed-by-br8k-spider-2
+- https://homestuck.bandcamp.com/track/killed-by-br8k-spider
 - https://youtu.be/KpnY41JNVbo
 Track Artwork:
 - Label: Official art
@@ -1320,7 +1320,7 @@ Artists:
 - Seth Peelle
 Duration: 3:57
 URLs:
-- https://homestuck.bandcamp.com/track/alternia-2
+- https://homestuck.bandcamp.com/track/alternia
 - https://youtu.be/ouwick_Ii2c
 Track Artwork:
 - Label: Official art
@@ -1389,7 +1389,6 @@ Contributors:
 - Erik Scheele (vocals)
 Duration: 2:59
 URLs:
-- https://homestuck.bandcamp.com/track/trollcops-radio-play-2
 - https://youtu.be/fGQY8jLZa5w
 Track Artwork:
 - Label: Official art
@@ -1427,7 +1426,6 @@ Artists:
 - Toby Fox
 Duration: 1:58
 URLs:
-- https://homestuck.bandcamp.com/track/catapult-capuchin-2
 - https://youtu.be/zOLsLiqSAEo
 Track Artwork:
 - Label: Official art
@@ -1469,7 +1467,6 @@ Artists:
 - Toby Fox
 Duration: 3:06
 URLs:
-- https://homestuck.bandcamp.com/track/science-seahorse-2
 - https://youtu.be/9FsGWsS91r8
 Track Artwork:
 - Label: Official art
@@ -1513,7 +1510,6 @@ Artists:
 - Toby Fox
 Duration: 1:37
 URLs:
-- https://homestuck.bandcamp.com/track/a-fairy-battle-2
 - https://youtu.be/LHr417f4Y8U
 Track Artwork:
 - Label: Official art
@@ -1555,7 +1551,6 @@ Artists:
 - Toby Fox
 Duration: 3:00
 URLs:
-- https://homestuck.bandcamp.com/track/the-blind-prophet-2
 - https://youtu.be/nClhUae7DMs
 Track Artwork:
 - Label: Official art
@@ -1637,7 +1632,6 @@ Artists:
 - Toby Fox
 Duration: 0:20
 URLs:
-- https://homestuck.bandcamp.com/track/alterniabound-2
 - https://youtu.be/FD5tJvMtzDo
 Track Artwork:
 - Label: Official art
@@ -1659,7 +1653,6 @@ Artists:
 - Toby Fox
 Duration: 0:08
 URLs:
-- https://homestuck.bandcamp.com/track/you-won-a-combat-2
 - https://youtu.be/heNdjTRVf5U
 Track Artwork:
 - Label: Official art
@@ -1692,7 +1685,6 @@ Artists:
 - Toby Fox
 Duration: 0:09
 URLs:
-- https://homestuck.bandcamp.com/track/rest-a-while-2
 - https://youtu.be/Iq7clpsMTmA
 Track Artwork:
 - Label: Official art

--- a/album/alterniabound.yaml
+++ b/album/alterniabound.yaml
@@ -300,6 +300,8 @@ Commentary: |-
 Track: 'BL1ND JUST1C3 : 1NV3ST1G4T1ON !!'
 Additional Names:
 - "Blind Justice : Investigation !! (quirk-free)"
+- Name: BL1ND JUST1C3 - 1NV3ST1G4T1ON !!
+  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20201125201310/https://homestuck.bandcamp.com/track/bl1nd-just1c3-1nv3st1g4t1on-2)
 Artists:
 - Malcolm Brown
 Duration: 2:48

--- a/album/cherubim.yaml
+++ b/album/cherubim.yaml
@@ -2,7 +2,7 @@ Album: Cherubim
 Date: March 14, 2013
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-7-8-with-cherubim
+- https://homestuck.bandcamp.com/album/cherubim
 - https://www.youtube.com/watch?v=Ka9R4mX8LZo
 - https://www.youtube.com/playlist?list=PL5wuj4bznbEntObWXb7BFZBl3Jq1Ep1Kb
 Cover Artists:
@@ -32,7 +32,7 @@ Additional Files:
   Files:
   - banner.jpg
 Commentary: |-
-    <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20130316024224/https://homestuck.bandcamp.com/album/cherubim))
+    <i>Homestuck:</i> ([Bandcamp about blurb](https://homestuck.bandcamp.com/album/cherubim))
 
     *u_u ~ tumut*
 
@@ -42,7 +42,7 @@ Commentary: |-
 
     It is called Cherubim. Worth noting: this album contains the song used in [[flash:5261|Caliborn: Enter]]. It's the last track, called [[Eternity Served Cold]], by [[artist:malcolm-brown|Malcolm Brown]].
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20130316024224/https://homestuck.bandcamp.com/album/cherubim))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/cherubim))
 
     Contains material by:
 
@@ -72,7 +72,7 @@ Artists:
 Duration: 4:17
 Color: '#00e500'
 URLs:
-- https://homestuck.bandcamp.com/track/reverie-2
+- https://homestuck.bandcamp.com/track/reverie
 - https://youtu.be/WkpYnDz-Y1w
 Cover Artists:
 - Sylladexter
@@ -98,7 +98,7 @@ Artists:
 - Clark Powell
 Duration: 4:22
 URLs:
-- https://homestuck.bandcamp.com/track/power-fantasy-2
+- https://homestuck.bandcamp.com/track/power-fantasy
 - https://youtu.be/5adGTghTECM
 Color: '#e50000'
 Cover Artists:
@@ -121,7 +121,7 @@ Artists:
 Duration: 3:23
 Color: '#00e500'
 URLs:
-- https://homestuck.bandcamp.com/track/stellarum-salve-2
+- https://homestuck.bandcamp.com/track/stellarum-salve
 - https://youtu.be/J2Vc2JIWPaY
 Cover Artists:
 - Mobble
@@ -141,7 +141,7 @@ Artists:
 - Malcolm Brown
 Duration: 4:23
 URLs:
-- https://homestuck.bandcamp.com/track/carne-vale-2
+- https://homestuck.bandcamp.com/track/carne-vale
 - https://youtu.be/AdPU0emEeUg
 Color: '#e50000'
 Cover Artists:
@@ -221,7 +221,7 @@ Artists:
 Duration: 4:11
 Color: '#00e500'
 URLs:
-- https://homestuck.bandcamp.com/track/green-lolly-2
+- https://homestuck.bandcamp.com/track/green-lolly
 - https://youtu.be/oWC2oXU_hP4
 Cover Artists:
 - Brianne
@@ -238,7 +238,7 @@ Artists:
 - Kalibration
 Duration: 3:44
 URLs:
-- https://homestuck.bandcamp.com/track/red-sucker-2
+- https://homestuck.bandcamp.com/track/red-sucker
 - https://youtu.be/lp7kDAHaWIc
 Color: '#e50000'
 Cover Artists:
@@ -258,7 +258,7 @@ Artists:
 Duration: 3:54
 Color: '#00e500'
 URLs:
-- https://homestuck.bandcamp.com/track/constant-confinement-2
+- https://homestuck.bandcamp.com/track/constant-confinement
 - https://youtu.be/1pp7UpsuTa4
 Cover Artists:
 - Michelle Czajkowski
@@ -281,7 +281,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 4:46
 URLs:
-- https://homestuck.bandcamp.com/track/constant-conquest-2
+- https://homestuck.bandcamp.com/track/constant-conquest
 - https://www.youtube.com/watch?v=BKPUXLOEcqY
 Color: '#e50000'
 Cover Artists:
@@ -331,7 +331,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:35
 URLs:
-- https://homestuck.bandcamp.com/track/the-lyrist-2
+- https://homestuck.bandcamp.com/track/the-lyrist
 - https://youtu.be/Tybj0RZoGks
 Color: '#00e500'
 Cover Artists:
@@ -372,7 +372,7 @@ Artists:
 - Toby Fox
 Duration: 2:51
 URLs:
-- https://homestuck.bandcamp.com/track/the-lordling-2
+- https://homestuck.bandcamp.com/track/the-lordling
 - https://youtu.be/nLrChSME0T8
 Color: '#e50000'
 Cover Artists:
@@ -404,7 +404,7 @@ Artists:
 - Malcolm Brown
 Duration: 8:20
 URLs:
-- https://homestuck.bandcamp.com/track/eternity-served-cold-2
+- https://homestuck.bandcamp.com/track/eternity-served-cold
 - https://youtu.be/wg9jows9Yfo
 Color: '#e50000'
 Cover Artists:

--- a/album/genesis-frog.yaml
+++ b/album/genesis-frog.yaml
@@ -36,7 +36,7 @@ Commentary: |-
 
     Genesis Frog contains of a series of orchestral pieces by [[artist:alex-rosetti|Alex Rosetti]], who was responsible for such Homestuck tracks as the [[track:squiddles|Squiddles Theme]], and the most important song in Homestuck, [[track:horschestra|Horsechestra]].
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20121026013704/https://homestuck.bandcamp.com/album/genesis-frog))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/genesis-frog))
 
     Composed and arranged by [[artist:alex-rosetti|Alexander Rosetti]]
 

--- a/album/hiveswap-act-1-ost.yaml
+++ b/album/hiveswap-act-1-ost.yaml
@@ -441,7 +441,7 @@ Additional Names:
 - Name: >-
     B-SIDE- Old Steps
   Annotation: >-
-    [Bandcamp compilation release](http://web.archive.org/web/20201129022436/https://homestuck.bandcamp.com/track/b-side-old-steps-2)
+    [Bandcamp compilation release](https://web.archive.org/web/20201129022436/https://homestuck.bandcamp.com/track/b-side-old-steps-2)
 Duration: 0:23
 URLs:
 - https://homestuck.bandcamp.com/track/b-side-old-steps
@@ -461,7 +461,7 @@ Additional Names:
 - Name: >-
     B-SIDE- How it Could Have Gone
   Annotation: >-
-    [Bandcamp compilation release](http://web.archive.org/web/20201129023323/https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone-2)
+    [Bandcamp compilation release](https://web.archive.org/web/20201129023323/https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone-2)
 Duration: 1:14
 URLs:
 - https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone
@@ -483,7 +483,7 @@ Additional Names:
 - Name: >-
     B-SIDE- Alternate Recipe
   Annotation: >-
-    [Bandcamp compilation release](http://web.archive.org/web/20201129023150/https://homestuck.bandcamp.com/track/b-side-alternate-recipe-2)
+    [Bandcamp compilation release](https://web.archive.org/web/20201129023150/https://homestuck.bandcamp.com/track/b-side-alternate-recipe-2)
 Duration: 1:30
 URLs:
 - https://homestuck.bandcamp.com/track/b-side-alternate-recipe
@@ -505,7 +505,7 @@ Additional Names:
 - Name: >-
     B-SIDE- Heavy Snaking
   Annotation: >-
-    [Bandcamp compilation release](http://web.archive.org/web/20201129022642/https://homestuck.bandcamp.com/track/b-side-heavy-snaking-2)
+    [Bandcamp compilation release](https://web.archive.org/web/20201129022642/https://homestuck.bandcamp.com/track/b-side-heavy-snaking-2)
 Duration: 2:00
 URLs:
 - https://homestuck.bandcamp.com/track/b-side-heavy-snaking

--- a/album/hiveswap-act-1-ost.yaml
+++ b/album/hiveswap-act-1-ost.yaml
@@ -5,7 +5,7 @@ Artists:
 Date: September 14, 2017 00:00:05
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/hiveswap-act-1-ost-with-the-grubbles
+- https://homestuck.bandcamp.com/album/hiveswap-act-1-ost
 - https://www.youtube.com/watch?v=IgPxbofdLF4
 - https://www.youtube.com/playlist?list=PLYtcpsy5kmMBxI5JuhAvlAV7wHkrts_w9
 Cover Artists:
@@ -34,7 +34,7 @@ Section: Main album
 Track: Definitely Safe Forever
 Duration: 0:21
 URLs:
-- https://homestuck.bandcamp.com/track/definitely-safe-forever-2
+- https://homestuck.bandcamp.com/track/definitely-safe-forever
 - https://youtu.be/NkNtHnzH6cc
 Referenced Tracks:
 - Joey Claire, Extraordinaire
@@ -49,7 +49,7 @@ Commentary: |-
 Track: Snake Escape
 Duration: 0:41
 URLs:
-- https://homestuck.bandcamp.com/track/snake-escape-2
+- https://homestuck.bandcamp.com/track/snake-escape
 - https://youtu.be/NFhRUwGzPcs
 Referenced Tracks:
 - Singular Peril
@@ -62,7 +62,7 @@ Commentary: |-
 Track: Joey Claire, Extraordinaire
 Duration: 2:50
 URLs:
-- https://homestuck.bandcamp.com/track/joey-claire-extraordinaire-2
+- https://homestuck.bandcamp.com/track/joey-claire-extraordinaire
 - https://youtu.be/LL5qZ5zBAIc
 MIDI Project Files:
 - Title: MIDI by Unknown
@@ -77,7 +77,7 @@ Commentary: |-
 Track: Half-Harley Manor
 Duration: 2:52
 URLs:
-- https://homestuck.bandcamp.com/track/half-harley-manor-2
+- https://homestuck.bandcamp.com/track/half-harley-manor
 - https://youtu.be/jfdTeNsU4ow
 Referenced Tracks:
 - Joey Claire, Extraordinaire
@@ -94,7 +94,7 @@ Commentary: |-
 Track: Relatively Visible Darkness
 Duration: 2:02
 URLs:
-- https://homestuck.bandcamp.com/track/relatively-visible-darkness-2
+- https://homestuck.bandcamp.com/track/relatively-visible-darkness
 - https://youtu.be/7ht1khfdGzo
 Referenced Tracks:
 - Half-Harley Manor
@@ -109,7 +109,7 @@ Commentary: |-
 Track: Bedroom for an Annoying Dog
 Duration: 3:32
 URLs:
-- https://homestuck.bandcamp.com/track/bedroom-for-an-annoying-dog-2
+- https://homestuck.bandcamp.com/track/bedroom-for-an-annoying-dog
 - https://youtu.be/y6R4A-3VQIU
 Referenced Tracks:
 - Half-Harley Manor
@@ -124,7 +124,7 @@ Commentary: |-
 Track: That's How I Beat Snake
 Duration: 2:11
 URLs:
-- https://homestuck.bandcamp.com/track/thats-how-i-beat-snake-2
+- https://homestuck.bandcamp.com/track/thats-how-i-beat-snake
 - https://youtu.be/xq9PkYNsTLU
 Referenced Tracks:
 - SERPENT GENESIS
@@ -144,7 +144,7 @@ Commentary: |-
 Track: Jude Harley, Bizarrely
 Duration: 1:38
 URLs:
-- https://homestuck.bandcamp.com/track/jude-harley-bizarrely-2
+- https://homestuck.bandcamp.com/track/jude-harley-bizarrely
 - https://youtu.be/nLTcCJH4QQg
 Referenced Tracks:
 - Half-Harley Manor
@@ -158,7 +158,7 @@ Commentary: |-
 Track: Table for Tooth
 Duration: 2:15
 URLs:
-- https://homestuck.bandcamp.com/track/table-for-tooth-2
+- https://homestuck.bandcamp.com/track/table-for-tooth
 - https://youtu.be/iSHxqEXZ_YU
 Referenced Tracks:
 - Half-Harley Manor
@@ -173,7 +173,7 @@ Commentary: |-
 Track: Final Spice
 Duration: 0:54
 URLs:
-- https://homestuck.bandcamp.com/track/final-spice-2
+- https://homestuck.bandcamp.com/track/final-spice
 - https://youtu.be/xvY_5XLVtj4
 Referenced Tracks:
 - track:alternate-recipe
@@ -190,7 +190,7 @@ Commentary: |-
 Track: Living Legend
 Duration: 1:22
 URLs:
-- https://homestuck.bandcamp.com/track/living-legend-2
+- https://homestuck.bandcamp.com/track/living-legend
 - https://youtu.be/2h1AwHOqSyM
 Referenced Tracks:
 - Half-Harley Manor
@@ -204,7 +204,7 @@ Commentary: |-
 Track: Singular Peril
 Duration: 1:22
 URLs:
-- https://homestuck.bandcamp.com/track/singular-peril-2
+- https://homestuck.bandcamp.com/track/singular-peril
 - https://youtu.be/fQyCThoSwCA
 Referenced Tracks:
 - Half-Harley Manor
@@ -217,7 +217,7 @@ Commentary: |-
 Track: A More Defensible Position
 Duration: 0:57
 URLs:
-- https://homestuck.bandcamp.com/track/a-more-defensible-position-2
+- https://homestuck.bandcamp.com/track/a-more-defensible-position
 - https://youtu.be/DhNOD_CRa5c
 Referenced Tracks:
 - Half-Harley Manor
@@ -230,7 +230,7 @@ Commentary: |-
 Track: Open The Door
 Duration: 1:01
 URLs:
-- https://homestuck.bandcamp.com/track/open-the-door-2
+- https://homestuck.bandcamp.com/track/open-the-door
 - https://youtu.be/VEQt6FPj3-g
 Referenced Tracks:
 - track:how-it-could-have-gone
@@ -243,7 +243,7 @@ Commentary: |-
 Track: Keep Your Head Down
 Duration: 1:10
 URLs:
-- https://homestuck.bandcamp.com/track/keep-your-head-down-2
+- https://homestuck.bandcamp.com/track/keep-your-head-down
 - https://youtu.be/47IOSYnYiRc
 Referenced Tracks:
 - Rustblood
@@ -261,7 +261,7 @@ Commentary: |-
 Track: Oh Whoa, What's This
 Duration: 1:05
 URLs:
-- https://homestuck.bandcamp.com/track/oh-whoa-whats-this-2
+- https://homestuck.bandcamp.com/track/oh-whoa-whats-this
 - https://youtu.be/a1fm7sHekVE
 Referenced Tracks:
 - Some Kind of Alien
@@ -278,7 +278,7 @@ Commentary: |-
 Track: Some Kind of Alien
 Duration: 1:30
 URLs:
-- https://homestuck.bandcamp.com/track/some-kind-of-alien-2
+- https://homestuck.bandcamp.com/track/some-kind-of-alien
 - https://youtu.be/PDZfnEW86Qc
 Referenced Tracks:
 - Crustacean
@@ -302,7 +302,7 @@ Commentary: |-
 Track: Rustblood
 Duration: 1:17
 URLs:
-- https://homestuck.bandcamp.com/track/rustblood-2
+- https://homestuck.bandcamp.com/track/rustblood
 - https://youtu.be/GqRXX0vFNqQ
 MIDI Project Files:
 - Title: MIDI by Unknown (piano)
@@ -319,7 +319,7 @@ Commentary: |-
 Track: Filthy Nuclear Bunker
 Duration: 4:34
 URLs:
-- https://homestuck.bandcamp.com/track/filthy-nuclear-bunker-2
+- https://homestuck.bandcamp.com/track/filthy-nuclear-bunker
 - https://youtu.be/Du1cFu4zl4o
 Referenced Tracks:
 - track:nuclear-james-roach
@@ -342,7 +342,7 @@ Commentary: |-
 Track: SPORTS! Personally, I Love Them.
 Duration: 3:36
 URLs:
-- https://homestuck.bandcamp.com/track/sports-personally-i-love-them-2
+- https://homestuck.bandcamp.com/track/sports-personally-i-love-them
 - https://youtu.be/jNtIznTXLpo
 Referenced Tracks:
 - Rustblood
@@ -359,7 +359,7 @@ Commentary: |-
 Track: Lofted Gunpile
 Duration: 4:08
 URLs:
-- https://homestuck.bandcamp.com/track/lofted-gunpile-2
+- https://homestuck.bandcamp.com/track/lofted-gunpile
 - https://youtu.be/zNrEIxvGA8M
 Referenced Tracks:
 - Some Kind of Alien
@@ -373,7 +373,7 @@ Commentary: |-
 Track: SERPENT GENESIS
 Duration: 1:14
 URLs:
-- https://homestuck.bandcamp.com/track/serpent-genesis-2
+- https://homestuck.bandcamp.com/track/serpent-genesis
 - https://youtu.be/QpYpoQ-9XYc
 Commentary: |-
     <i>James Roach:</i>
@@ -388,7 +388,7 @@ Commentary: |-
 Track: We Shall Go Together
 Duration: 3:18
 URLs:
-- https://homestuck.bandcamp.com/track/we-shall-go-together-2
+- https://homestuck.bandcamp.com/track/we-shall-go-together
 - https://youtu.be/IzsFUuvWIuI
 Referenced Tracks:
 - Joey Claire, Extraordinaire
@@ -401,7 +401,7 @@ Commentary: |-
 Track: Wish You Were Here
 Duration: 0:50
 URLs:
-- https://homestuck.bandcamp.com/track/wish-you-were-here-2
+- https://homestuck.bandcamp.com/track/wish-you-were-here
 - https://youtu.be/GZv2KDakIVs
 Referenced Tracks:
 - Intermission 1
@@ -416,7 +416,7 @@ Commentary: |-
 Track: Intermission 1
 Duration: 2:12
 URLs:
-- https://homestuck.bandcamp.com/track/intermission-1-2
+- https://homestuck.bandcamp.com/track/intermission-1
 - https://youtu.be/CbhUNkmqMHA
 Referenced Tracks:
 - Rustblood
@@ -437,14 +437,14 @@ Additional Names:
 - Name: >-
     B-SIDE: Old Steps
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20170915144245/https://homestuck.bandcamp.com/track/b-side-old-steps)
+    [Bandcamp](https://homestuck.bandcamp.com/track/b-side-old-steps)
 - Name: >-
     B-SIDE- Old Steps
   Annotation: >-
-    [Bandcamp compilation release](https://homestuck.bandcamp.com/track/b-side-old-steps-2)
+    [Bandcamp compilation release](http://web.archive.org/web/20201129022436/https://homestuck.bandcamp.com/track/b-side-old-steps-2)
 Duration: 0:23
 URLs:
-- https://homestuck.bandcamp.com/track/b-side-old-steps-2
+- https://homestuck.bandcamp.com/track/b-side-old-steps
 - https://youtu.be/e8P5G1a4iiA
 Commentary: |-
     <i>James Roach:</i>
@@ -457,14 +457,14 @@ Additional Names:
 - Name: >-
     B-SIDE: How it Could Have Gone
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20170915144227/https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone)
+    [Bandcamp](https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone)
 - Name: >-
     B-SIDE- How it Could Have Gone
   Annotation: >-
-    [Bandcamp compilation release](https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone-2)
+    [Bandcamp compilation release](http://web.archive.org/web/20201129023323/https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone-2)
 Duration: 1:14
 URLs:
-- https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone-2
+- https://homestuck.bandcamp.com/track/b-side-how-it-could-have-gone
 - https://youtu.be/nQcQxJhk6ak
 Referenced Tracks:
 - Half-Harley Manor
@@ -479,14 +479,14 @@ Additional Names:
 - Name: >-
     B-SIDE: Alternate Recipe
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20170915145317/https://homestuck.bandcamp.com/track/b-side-alternate-recipe)
+    [Bandcamp](https://homestuck.bandcamp.com/track/b-side-alternate-recipe)
 - Name: >-
     B-SIDE- Alternate Recipe
   Annotation: >-
-    [Bandcamp compilation release](https://homestuck.bandcamp.com/track/b-side-alternate-recipe-2)
+    [Bandcamp compilation release](http://web.archive.org/web/20201129023150/https://homestuck.bandcamp.com/track/b-side-alternate-recipe-2)
 Duration: 1:30
 URLs:
-- https://homestuck.bandcamp.com/track/b-side-alternate-recipe-2
+- https://homestuck.bandcamp.com/track/b-side-alternate-recipe
 - https://youtu.be/-7hHMdXey9c
 Commentary: |-
     <i>James Roach:</i>
@@ -501,14 +501,14 @@ Additional Names:
 - Name: >-
     B-SIDE: Heavy Snaking
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20170915144338/https://homestuck.bandcamp.com/track/b-side-heavy-snaking)'
+    [Bandcamp](https://homestuck.bandcamp.com/track/b-side-heavy-snaking)
 - Name: >-
     B-SIDE- Heavy Snaking
   Annotation: >-
-    [Bandcamp compilation release](https://homestuck.bandcamp.com/track/b-side-heavy-snaking-2)
+    [Bandcamp compilation release](http://web.archive.org/web/20201129022642/https://homestuck.bandcamp.com/track/b-side-heavy-snaking-2)
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/b-side-heavy-snaking-2
+- https://homestuck.bandcamp.com/track/b-side-heavy-snaking
 - https://youtu.be/GL3l_Klo8ic
 Referenced Tracks:
 - Half-Harley Manor
@@ -531,14 +531,14 @@ Additional Names:
 - Name: >-
     B-SIDE: SPOOKTUNE
   Annotation: >-
-    [original Bandcamp release](https://web.archive.org/web/20170915144219/https://homestuck.bandcamp.com/track/b-side-spooktune)
+    [Bandcamp](https://homestuck.bandcamp.com/track/b-side-spooktune)
 - Name: >-
     B-SIDE- SPOOKTUNE
   Annotation: >-
-    [Bandcamp compilation release](https://homestuck.bandcamp.com/track/b-side-spooktune-2)
+    [Bandcamp compilation release](http://web.archive.org/web/20201129010516/https://homestuck.bandcamp.com/track/b-side-spooktune-2)
 Duration: 0:50
 URLs:
-- https://homestuck.bandcamp.com/track/b-side-spooktune-2
+- https://homestuck.bandcamp.com/track/b-side-spooktune
 - https://youtu.be/dHKbl2r0XfI
 Referenced Tracks:
 - track:spooktune-undertale

--- a/album/homestuck-vol-1-4.yaml
+++ b/album/homestuck-vol-1-4.yaml
@@ -160,8 +160,10 @@ URLs:
 Track: John Sleeps / Skaian Magicant
 Suffix Directory: false
 Additional Names:
-- Name: John Sleeps - Skaian Magicant
-  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20201024173332/https://homestuck.bandcamp.com/track/john-sleeps-skaian-magicant-2)
+- Name: >-
+    John Sleeps - Skaian Magicant
+  Annotation: >-
+    [Bandcamp compilation release](https://web.archive.org/web/20201024173332/https://homestuck.bandcamp.com/track/john-sleeps-skaian-magicant-2)
 - Can't Sleep, Harlequins Will Eat Me (earlier MSPA credit)
 - Skaian Magicant (earlier MSPA credit)
 Artists:

--- a/album/homestuck-vol-1-4.yaml
+++ b/album/homestuck-vol-1-4.yaml
@@ -160,6 +160,8 @@ URLs:
 Track: John Sleeps / Skaian Magicant
 Suffix Directory: false
 Additional Names:
+- Name: John Sleeps - Skaian Magicant
+  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20201024173332/https://homestuck.bandcamp.com/track/john-sleeps-skaian-magicant-2)
 - Can't Sleep, Harlequins Will Eat Me (earlier MSPA credit)
 - Skaian Magicant (earlier MSPA credit)
 Artists:

--- a/album/homestuck-vol-1-4.yaml
+++ b/album/homestuck-vol-1-4.yaml
@@ -4,7 +4,7 @@ Suffix Track Directories: true
 Date: October 24, 2011
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-1-4-with-midnight-crew-drawing-dead
+- https://homestuck.bandcamp.com/album/homestuck-vol-1-4
 - https://www.youtube.com/watch?v=9N342A3G5jo
 Cover Artists:
 - Homestuck
@@ -26,11 +26,11 @@ Additional Files:
   - sburbwp_1440x900.jpg
   - sburbwp_1920x1080.jpg
 Commentary: |-
-    <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20111027162842/https://homestuck.bandcamp.com/album/homestuck-vol-1-4))
+    <i>Homestuck:</i> ([Bandcamp about blurb](https://homestuck.bandcamp.com/album/homestuck-vol-1-4))
 
     *A recollection of classic Homestuck songs from Volumes 1 through 4, now cheaper than ever!*
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20111027162842/https://homestuck.bandcamp.com/album/homestuck-vol-1-4))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/homestuck-vol-1-4))
 
     Also comes with Homestuck wallpaper from [[album:homestuck-vol-4|Volume 4]].
 
@@ -40,7 +40,7 @@ Commentary: |-
 
     Almost equally mega is the newly repackaged Homestuck Vol. 1-4. What is it, exactly? It's [[album:homestuck-vol-1]], [[album:homestuck-vol-2]], [[album:homestuck-vol-3]], and [[album:homestuck-vol-4]], but way more efficient. A small handful of songs have been added. Also added: increased wallet friendliness.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20111027162842/https://homestuck.bandcamp.com/album/homestuck-vol-1-4))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/homestuck-vol-1-4))
 
     By these rad dudes:
 
@@ -74,13 +74,13 @@ Art Tags:
 - John
 Duration: 2:20
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-piano-refrain-3
+- https://homestuck.bandcamp.com/track/showtime-piano-refrain-2
 ---
 Track: Harlequin
 Main Release: Harlequin
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/harlequin-3
+- https://homestuck.bandcamp.com/track/harlequin-2
 ---
 Track: Showtime (Original Mix)
 Main Release: Showtime (Original Mix)
@@ -88,7 +88,7 @@ Art Tags:
 - Dad
 Duration: 2:09
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-original-mix-3
+- https://homestuck.bandcamp.com/track/showtime-original-mix-2
 ---
 Track: Aggrieve (Violin Refrain)
 Main Release: Aggrieve (Violin Refrain)
@@ -96,7 +96,7 @@ Art Tags:
 - Rose
 Duration: 1:34
 URLs:
-- https://homestuck.bandcamp.com/track/aggrieve-violin-refrain-3
+- https://homestuck.bandcamp.com/track/aggrieve-violin-refrain-2
 ---
 Track: Sburban Countdown
 Main Release: Sburban Countdown
@@ -105,7 +105,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 0:38
 URLs:
-- https://homestuck.bandcamp.com/track/sburban-countdown-3
+- https://homestuck.bandcamp.com/track/sburban-countdown-2
 ---
 Track: Aggrieve
 Main Release: Aggrieve
@@ -114,7 +114,7 @@ Art Tags:
 - Maplehoof
 Duration: 2:32
 URLs:
-- https://homestuck.bandcamp.com/track/aggrieve-3
+- https://homestuck.bandcamp.com/track/aggrieve-2
 ---
 Track: Showtime (Imp Strife Mix)
 Main Release: Showtime (Imp Strife Mix)
@@ -123,7 +123,7 @@ Art Tags:
 - Rabbit
 Duration: 1:57
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-imp-strife-mix-3
+- https://homestuck.bandcamp.com/track/showtime-imp-strife-mix-2
 ---
 Track: Nannaquin
 Main Release: Nannaquin
@@ -132,7 +132,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:24
 URLs:
-- https://homestuck.bandcamp.com/track/nannaquin-3
+- https://homestuck.bandcamp.com/track/nannaquin-2
 ---
 Track: Skies of Skaia
 Main Release: Skies of Skaia
@@ -141,7 +141,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:45
 URLs:
-- https://homestuck.bandcamp.com/track/skies-of-skaia-3
+- https://homestuck.bandcamp.com/track/skies-of-skaia-2
 ---
 Section: From Homestuck Vol. 2
 Color: '#cb87f6'
@@ -155,7 +155,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:48
 URLs:
-- https://homestuck.bandcamp.com/track/harlequin-rock-version-3
+- https://homestuck.bandcamp.com/track/harlequin-rock-version-2
 ---
 Track: John Sleeps / Skaian Magicant
 Suffix Directory: false
@@ -168,7 +168,7 @@ Art Tags:
 - Jade
 Duration: 0:41
 URLs:
-- https://homestuck.bandcamp.com/track/john-sleeps-skaian-magicant-2
+- https://homestuck.bandcamp.com/track/john-sleeps-skaian-magicant
 Referenced Tracks:
 - Showtime (Original Mix)
 - Skies of Skaia
@@ -181,7 +181,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 4:20
 URLs:
-- https://homestuck.bandcamp.com/track/upward-movement-dave-owns-3
+- https://homestuck.bandcamp.com/track/upward-movement-dave-owns-2
 ---
 Track: Vagabounce
 Main Release: Vagabounce
@@ -190,7 +190,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:13
 URLs:
-- https://homestuck.bandcamp.com/track/vagabounce-3
+- https://homestuck.bandcamp.com/track/vagabounce-2
 ---
 Track: Explore
 Main Release: Explore
@@ -199,7 +199,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:28
 URLs:
-- https://homestuck.bandcamp.com/track/explore-3
+- https://homestuck.bandcamp.com/track/explore-2
 ---
 Track: Gardener
 Suffix Directory: false
@@ -209,7 +209,7 @@ Art Tags:
 - Jade
 Duration: 1:44
 URLs:
-- https://homestuck.bandcamp.com/track/gardener-2
+- https://homestuck.bandcamp.com/track/gardener
 Referenced Tracks:
 - track:the-beginning-of-something-really-excellent
 Sheet Music Files:
@@ -232,7 +232,7 @@ Track Artwork:
 - Tags:
   - FreshJamz
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-remix-3
+- https://homestuck.bandcamp.com/track/showtime-remix-2
 ---
 Track: Aggrieve Remix
 Main Release: Aggrieve Remix
@@ -242,7 +242,7 @@ Track Artwork:
   Tags:
   - FreshJamz
 URLs:
-- https://homestuck.bandcamp.com/track/aggrieve-remix-3
+- https://homestuck.bandcamp.com/track/aggrieve-remix-2
 ---
 Track: Verdancy (Bassline)
 Main Release: Verdancy (Bassline)
@@ -252,7 +252,7 @@ Track Artwork:
   Tags:
   - FreshJamz
 URLs:
-- https://homestuck.bandcamp.com/track/verdancy-bassline-3
+- https://homestuck.bandcamp.com/track/verdancy-bassline-2
 ---
 Track: Potential Verdancy
 Suffix Directory: false
@@ -263,7 +263,7 @@ Track Artwork:
 - Tags:
   - FreshJamz
 URLs:
-- https://homestuck.bandcamp.com/track/potential-verdancy-2
+- https://homestuck.bandcamp.com/track/potential-verdancy
 Referenced Tracks:
 - Verdancy (Bassline)
 Sampled Tracks:
@@ -283,7 +283,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:32
 URLs:
-- https://homestuck.bandcamp.com/track/beatdown-strider-style-3
+- https://homestuck.bandcamp.com/track/beatdown-strider-style-2
 ---
 Track: Harleboss
 Main Release: Harleboss
@@ -292,7 +292,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:47
 URLs:
-- https://homestuck.bandcamp.com/track/harleboss-3
+- https://homestuck.bandcamp.com/track/harleboss-2
 ---
 Track: Beatdown Round 2
 Main Release: Beatdown Round 2
@@ -302,7 +302,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:27
 URLs:
-- https://homestuck.bandcamp.com/track/beatdown-round-2-3
+- https://homestuck.bandcamp.com/track/beatdown-round-2-2
 ---
 Track: Dissension (Original)
 Main Release: Dissension (Original)
@@ -312,7 +312,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:47
 URLs:
-- https://homestuck.bandcamp.com/track/dissension-original-3
+- https://homestuck.bandcamp.com/track/dissension-original-2
 ---
 Track: Dissension (Remix)
 Main Release: Dissension (Remix)
@@ -322,7 +322,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:03
 URLs:
-- https://homestuck.bandcamp.com/track/dissension-remix-3
+- https://homestuck.bandcamp.com/track/dissension-remix-2
 ---
 Track: Ohgodwhat
 Main Release: Ohgodwhat
@@ -330,7 +330,7 @@ Art Tags:
 - Jade
 Duration: 1:06
 URLs:
-- https://homestuck.bandcamp.com/track/ohgodwhat-3
+- https://homestuck.bandcamp.com/track/ohgodwhat-2
 ---
 Track: Ohgodwhat Remix
 Main Release: Ohgodwhat Remix
@@ -338,19 +338,19 @@ Art Tags:
 - Jade
 Duration: 1:05
 URLs:
-- https://homestuck.bandcamp.com/track/ohgodwhat-remix-3
+- https://homestuck.bandcamp.com/track/ohgodwhat-remix-2
 ---
 Track: Rediscover Fusion
 Main Release: Rediscover Fusion
 Duration: 1:36
 URLs:
-- https://homestuck.bandcamp.com/track/rediscover-fusion-3
+- https://homestuck.bandcamp.com/track/rediscover-fusion-2
 ---
 Track: Explore Remix
 Main Release: Explore Remix
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/explore-remix-3
+- https://homestuck.bandcamp.com/track/explore-remix-2
 ---
 Track: Chorale for Jaspers
 Main Release: Chorale for Jaspers
@@ -360,7 +360,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:15
 URLs:
-- https://homestuck.bandcamp.com/track/chorale-for-jaspers-3
+- https://homestuck.bandcamp.com/track/chorale-for-jaspers-2
 ---
 Track: Pony Chorale
 Main Release: Pony Chorale
@@ -369,7 +369,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:03
 URLs:
-- https://homestuck.bandcamp.com/track/pony-chorale-3
+- https://homestuck.bandcamp.com/track/pony-chorale-2
 ---
 Section: From Homestuck Vol. 4
 Color: '#51a2fd'
@@ -383,7 +383,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 0:43
 URLs:
-- https://homestuck.bandcamp.com/track/revelawesome-3
+- https://homestuck.bandcamp.com/track/revelawesome-2
 ---
 Track: Hardlyquin
 Main Release: Hardlyquin
@@ -392,7 +392,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:38
 URLs:
-- https://homestuck.bandcamp.com/track/hardlyquin-3
+- https://homestuck.bandcamp.com/track/hardlyquin-2
 ---
 Track: Carefree Victory
 Main Release: Carefree Victory
@@ -404,7 +404,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:36
 URLs:
-- https://homestuck.bandcamp.com/track/carefree-victory-3
+- https://homestuck.bandcamp.com/track/carefree-victory-2
 ---
 Track: Ballad of Awakening
 Main Release: Ballad of Awakening
@@ -415,7 +415,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 3:08
 URLs:
-- https://homestuck.bandcamp.com/track/ballad-of-awakening-3
+- https://homestuck.bandcamp.com/track/ballad-of-awakening-2
 ---
 Track: Sburban Jungle
 Main Release: Sburban Jungle
@@ -436,7 +436,7 @@ Track Artwork:
   - 'Rainbow Falls, NY'
 Duration: 3:39
 URLs:
-- https://homestuck.bandcamp.com/track/sburban-jungle-3
+- https://homestuck.bandcamp.com/track/sburban-jungle-2
 - https://www.youtube.com/watch?v=PP6916yGx6c
 - https://open.spotify.com/track/1SW1ybpwtkCeP9d4X3oDnG
 ---
@@ -446,7 +446,7 @@ Directory: three-in-the-morning-rj # suffixed
 Cover Art File Extension: jpg
 Duration: 6:29
 URLs:
-- https://homestuck.bandcamp.com/track/three-in-the-morning-rjs-i-can-barely-sleep-in-this-casino-remix-3
+- https://homestuck.bandcamp.com/track/three-in-the-morning-rjs-i-can-barely-sleep-in-this-casino-remix-2
 ---
 Track: Doctor
 Main Release: Doctor
@@ -455,7 +455,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:37
 URLs:
-- https://homestuck.bandcamp.com/track/doctor-3
+- https://homestuck.bandcamp.com/track/doctor-2
 ---
 Track: Endless Climb
 Main Release: Endless Climb
@@ -465,7 +465,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:24
 URLs:
-- https://homestuck.bandcamp.com/track/endless-climb-3
+- https://homestuck.bandcamp.com/track/endless-climb-2
 ---
 Track: Atomyk Ebonpyre
 Main Release: Atomyk Ebonpyre
@@ -475,7 +475,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 1:10
 URLs:
-- https://homestuck.bandcamp.com/track/atomyk-ebonpyre-3
+- https://homestuck.bandcamp.com/track/atomyk-ebonpyre-2
 ---
 Track: Black
 Main Release: Black
@@ -485,7 +485,7 @@ Art Tags:
 Cover Art File Extension: jpg
 Duration: 2:24
 URLs:
-- https://homestuck.bandcamp.com/track/black-3
+- https://homestuck.bandcamp.com/track/black-2
 ---
 Section: Bonus track
 Description: >-
@@ -498,7 +498,6 @@ Artists:
 Cover Art File Extension: jpg
 Duration: 0:54
 URLs:
-- https://homestuck.bandcamp.com/track/doctor-original-loop-2
 - https://www.youtube.com/watch?v=o0Um9OiP8dU
 Commentary: |-
     <i>Buzinkai:</i> (['Doctor' Explained](https://www.youtube.com/watch?v=EsG71P_zEIE), partial transcript, 6/10/2014)

--- a/album/homestuck-vol-1.yaml
+++ b/album/homestuck-vol-1.yaml
@@ -72,7 +72,7 @@ Track Artwork:
   - Standing Piano
 Duration: 2:20
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-piano-refrain-3
+- https://homestuck.bandcamp.com/track/showtime-piano-refrain-2
 - https://youtu.be/U5ggzIxfGDs
 Referenced Tracks:
 - Showtime (Original Mix)
@@ -109,7 +109,7 @@ Track Artwork:
   - Harlequinsprite
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/harlequin-3
+- https://homestuck.bandcamp.com/track/harlequin-2
 - https://youtu.be/Y6LcnuowRc0
 Sheet Music Files:
 - Title: Piano score by Mark J. Hadley (original composer)
@@ -159,7 +159,7 @@ MIDI Project Files:
   Files:
   - 'Showtime (Original Mix) - Twix Stix.mid'
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-original-mix-3
+- https://homestuck.bandcamp.com/track/showtime-original-mix-2
 - https://youtu.be/RKURlfskGsE
 Commentary: |-
     <i>Malcolm Brown:</i> (via [[media:misc/commentary-collection.txt|early commentary collection]])
@@ -219,7 +219,7 @@ Contributors:
 - Gabriel Nezovic (mastering)
 Duration: 1:34
 URLs:
-- https://homestuck.bandcamp.com/track/aggrieve-violin-refrain-3
+- https://homestuck.bandcamp.com/track/aggrieve-violin-refrain-2
 - https://youtu.be/h46wSFVeWAs
 Referenced Tracks:
 - Aggrieve
@@ -245,7 +245,7 @@ Track Artwork:
   - Reckoning
   - 'Maple Valley, WA'
 URLs:
-- https://homestuck.bandcamp.com/track/sburban-countdown-3
+- https://homestuck.bandcamp.com/track/sburban-countdown-2
 - https://youtu.be/C3cvihYafCs
 Referenced Tracks:
 - Sburban Jungle
@@ -276,7 +276,7 @@ Track Artwork:
   - Knitting Needles
 Duration: 2:32
 URLs:
-- https://homestuck.bandcamp.com/track/aggrieve-3
+- https://homestuck.bandcamp.com/track/aggrieve-2
 - https://youtu.be/kgZNDUF64L4
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
@@ -316,7 +316,7 @@ Track Artwork:
   - Rag of Souls
 Duration: 1:57
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-imp-strife-mix-3
+- https://homestuck.bandcamp.com/track/showtime-imp-strife-mix-2
 - https://youtu.be/WQyRS_czmgc
 Referenced Tracks:
 - Showtime (Original Mix)
@@ -342,7 +342,7 @@ Track Artwork:
   - John's nanna
 Duration: 1:24
 URLs:
-- https://homestuck.bandcamp.com/track/nannaquin-3
+- https://homestuck.bandcamp.com/track/nannaquin-2
 - https://youtu.be/Pf5YpbDgCSU
 Referenced Tracks:
 - Harlequin
@@ -367,7 +367,7 @@ Track Artwork:
   - Skaia
 Duration: 2:45
 URLs:
-- https://homestuck.bandcamp.com/track/skies-of-skaia-3
+- https://homestuck.bandcamp.com/track/skies-of-skaia-2
 - https://youtu.be/vwzfyi4OdkU
 Sheet Music Files:
 - Title: Piano score by Resound

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -2,7 +2,7 @@ Album: Homestuck Vol. 10
 Date: June 12, 2016
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-9-10-with-s-collide-and-act-7
+- https://homestuck.bandcamp.com/album/homestuck-vol-10
 - https://www.youtube.com/watch?v=LW9-Ov8CiRY
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFZV53x19jl4NTpDEQtOaoR5
 Cover Artists:
@@ -167,7 +167,7 @@ Commentary: |-
 
     It's funny that Vol. 10 became sanctioned because of [[artist:james-roach|James Roach's]] involvement to me because he was notably a massive exception to the "you can't sell Homestuck fan music" rule, as far back as 2012
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20160615084917/https://homestuck.bandcamp.com/album/homestuck-vol-10))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/homestuck-vol-10))
 
     [[artist:seth-peelle|Seth "Beatfox” Peelle]]<br>
     [[artist:buzinkai|George Buzinkai]]<br>
@@ -229,7 +229,7 @@ Artists:
 - Seth Peelle
 Duration: 8:12
 URLs:
-- https://homestuck.bandcamp.com/track/creata-3
+- https://homestuck.bandcamp.com/track/creata-2
 - https://youtu.be/lXmiKt-rBjo
 Cover Artists:
 - PJ Tush
@@ -306,7 +306,7 @@ Artists:
 - Buzinkai
 Duration: 1:33
 URLs:
-- https://homestuck.bandcamp.com/track/train-2
+- https://homestuck.bandcamp.com/track/train
 - https://youtu.be/vhzgtJcLouU
 Cover Artists:
 - Kate Holden
@@ -331,7 +331,7 @@ Additional Names:
 - Of Sylphs and Sekrets (alternative title)
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/of-gods-and-witches-2
+- https://homestuck.bandcamp.com/track/of-gods-and-witches
 - https://youtu.be/a7qyOw3LuLE
 Cover Artists:
 - Archeia
@@ -367,7 +367,7 @@ Artists:
 - Riki Tsuji
 Duration: 5:11
 URLs:
-- https://homestuck.bandcamp.com/track/beatup-2
+- https://homestuck.bandcamp.com/track/beatup
 - https://youtu.be/vHClZp44AQg
 Cover Artists:
 - Shan Murphy
@@ -429,7 +429,7 @@ Contributors:
 - Noel Sadwin (violin)
 Duration: 4:22
 URLs:
-- https://homestuck.bandcamp.com/track/you-killed-my-father-prepare-to-die-2
+- https://homestuck.bandcamp.com/track/you-killed-my-father-prepare-to-die
 - https://youtu.be/jJ7XGZ04Fgc
 Cover Artists:
 - Mika B.
@@ -492,7 +492,7 @@ Artists:
 - Malcolm Brown
 Duration: 3:26
 URLs:
-- https://homestuck.bandcamp.com/track/sound-judgement-2
+- https://homestuck.bandcamp.com/track/sound-judgement
 - https://youtu.be/SgFCP-3EkNw
 Cover Artists:
 - Sera B.
@@ -531,7 +531,7 @@ Artists:
 - Mark J. Hadley
 Duration: 3:41
 URLs:
-- https://homestuck.bandcamp.com/track/aggrievocation-2
+- https://homestuck.bandcamp.com/track/aggrievocation
 - https://youtu.be/JB3kKp7jRag
 Cover Artists:
 - Rachel Lake
@@ -554,7 +554,7 @@ Artists:
 - Kalibration
 Duration: 3:26
 URLs:
-- https://homestuck.bandcamp.com/track/stride-2
+- https://homestuck.bandcamp.com/track/stride
 - https://youtu.be/h3n1ToY-UvA
 Cover Artists:
 - slogbait
@@ -588,10 +588,10 @@ Track: Skaian Overdrive
 Additional Names:
 - Name: Skaian Overdrive*
   Annotation: >-
-    [original release](https://web.archive.org/web/20160615084929/http://homestuck.bandcamp.com/track/skaian-overdrive)
+    [Bandcamp](http://homestuck.bandcamp.com/track/skaian-overdrive)
 - Name: Skaian Overdrive-
   Annotation: >-
-    [2019 compilation rerelease](https://homestuck.bandcamp.com/track/skaian-overdrive-2)
+    [2019 compilation rerelease](https://web.archive.org/web/20201129020840/https://homestuck.bandcamp.com/track/skaian-overdrive-2)
 - Name: >-
     SKAIAN STARSTORM
   Annotation: >-
@@ -600,7 +600,7 @@ Artists:
 - Thomas Ferkol
 Duration: 2:27
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-overdrive-2
+- https://homestuck.bandcamp.com/track/skaian-overdrive
 - https://youtu.be/_uhUEvkcTfY
 Cover Artists:
 - slogbait
@@ -633,7 +633,7 @@ Commentary: |-
 
     Wish we saw more of them.
 
-    <i>Homestuck:</i> ([Bandcamp blurb](https://web.archive.org/web/20160615084929/http://homestuck.bandcamp.com/track/skaian-overdrive))
+    <i>Homestuck:</i> ([Bandcamp blurb](http://homestuck.bandcamp.com/track/skaian-overdrive))
 
     \*note: track is not actually [[Skaian Starstorm|"Skaian Starstorm"]]<br>
     \*oops
@@ -643,7 +643,7 @@ Artists:
 - rj lake
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/freefall-2
+- https://homestuck.bandcamp.com/track/freefall
 - https://youtu.be/4pZP1Fkt9Mc
 Cover Artists:
 - Nico J. Dolloso
@@ -698,7 +698,7 @@ Contributors:
 - Toby Fox (with apologies to)
 Duration: 7:57
 URLs:
-- https://homestuck.bandcamp.com/track/moonsweater-2
+- https://homestuck.bandcamp.com/track/moonsweater
 - https://youtu.be/mB3xE2h_Bo4
 Cover Artists:
 - David Litt
@@ -744,7 +744,7 @@ Artists:
 - Buzinkai
 Duration: 1:13
 URLs:
-- https://homestuck.bandcamp.com/track/castle-2
+- https://homestuck.bandcamp.com/track/castle
 - https://youtu.be/DMWGKi9FqhA
 Cover Artists:
 - Kiko B.
@@ -791,7 +791,7 @@ Artists:
 - Seth Peelle
 Duration: 2:06
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-happy-flight-2
+- https://homestuck.bandcamp.com/track/skaian-happy-flight
 - https://youtu.be/rozLPCPXopw
 Cover Artists:
 - Alyssa Lee Dalangin
@@ -836,7 +836,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:14
 URLs:
-- https://homestuck.bandcamp.com/track/voidlight-2
+- https://homestuck.bandcamp.com/track/voidlight
 - https://youtu.be/FOG0NbZnKzU
 Cover Artists:
 - Zilleniose
@@ -855,7 +855,7 @@ Artists:
 - Curt Blakeslee
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/beatdown-dx-2
+- https://homestuck.bandcamp.com/track/beatdown-dx
 - https://youtu.be/EJPtdTzq6uY
 Cover Artists:
 - ranchuppi
@@ -892,7 +892,7 @@ Contributors:
 - Jamie Paige (drums)
 Duration: 5:06
 URLs:
-- https://homestuck.bandcamp.com/track/solar-voyage-2
+- https://homestuck.bandcamp.com/track/solar-voyage
 - https://www.youtube.com/watch?v=BiYdzIFLdcs
 Cover Artists:
 - slogbait
@@ -953,7 +953,7 @@ Artists:
 - rj lake (production, arrangement)
 Duration: 3:14
 URLs:
-- https://homestuck.bandcamp.com/track/feel-alive-2
+- https://homestuck.bandcamp.com/track/feel-alive
 - https://youtu.be/Yngy9XIzRLY
 Cover Artists:
 - PJ Tush
@@ -1011,7 +1011,7 @@ Artists:
 - Erik Scheele
 Duration: 5:16
 URLs:
-- https://homestuck.bandcamp.com/track/breeze-2
+- https://homestuck.bandcamp.com/track/breeze
 - https://youtu.be/h9E2e6JgIp0
 Cover Artists:
 - Richard Gung
@@ -1038,7 +1038,7 @@ Contributors:
 - Justin Hellier (special thanks)
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/starfall-2
+- https://homestuck.bandcamp.com/track/starfall
 - https://youtu.be/1H26iJNOtx4
 Cover Artists:
 - Lunise
@@ -1081,7 +1081,7 @@ Artists:
 - Tensei
 Duration: 6:12
 URLs:
-- https://homestuck.bandcamp.com/track/ascend-2
+- https://homestuck.bandcamp.com/track/ascend
 - https://youtu.be/e9gGXYbtSt8
 - https://open.spotify.com/album/2BJvcDGtwmzpXdfdxrBpit
 Cover Artists:
@@ -1156,7 +1156,7 @@ Artists:
 - Malcolm Brown
 Duration: 3:51
 URLs:
-- https://homestuck.bandcamp.com/track/lilith-in-starlight-2
+- https://homestuck.bandcamp.com/track/lilith-in-starlight
 - https://youtu.be/9ZRH3pMAsEw
 Cover Artists:
 - Sera B.
@@ -1194,7 +1194,7 @@ Artists:
 - Max Wright
 Duration: 3:31
 URLs:
-- https://homestuck.bandcamp.com/track/thanks-for-playing-2
+- https://homestuck.bandcamp.com/track/thanks-for-playing
 - https://youtu.be/XsCBaAv59cc
 Cover Artists:
 - slogbait
@@ -1241,7 +1241,7 @@ Contributors:
 - Stephen "Jeebes" Wiley (choir)
 Duration: 9:10
 URLs:
-- https://homestuck.bandcamp.com/track/renewed-return-2
+- https://homestuck.bandcamp.com/track/renewed-return
 - https://www.youtube.com/watch?v=uOX_0LI70-M
 Cover Artists:
 - Zilleniose
@@ -1335,7 +1335,7 @@ Artists:
 - Alex Rosetti
 Duration: 4:02
 URLs:
-- https://homestuck.bandcamp.com/track/this-pumpkin-2
+- https://homestuck.bandcamp.com/track/this-pumpkin
 - https://youtu.be/ekWbliUNqfM
 Cover Artists:
 - Worthikids
@@ -1395,7 +1395,7 @@ Artists:
 - Seth Peelle
 Duration: 7:47
 URLs:
-- https://homestuck.bandcamp.com/track/conclude-2
+- https://homestuck.bandcamp.com/track/conclude
 - https://youtu.be/5Dq01x-oxWM
 Cover Artists:
 - Kiko B.

--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -591,7 +591,7 @@ Additional Names:
     [Bandcamp](http://homestuck.bandcamp.com/track/skaian-overdrive)
 - Name: Skaian Overdrive-
   Annotation: >-
-    [2019 compilation rerelease](https://web.archive.org/web/20201129020840/https://homestuck.bandcamp.com/track/skaian-overdrive-2)
+    [2019 compilation rerelease](https://web.archive.org/web/20210301075444/https://homestuck.bandcamp.com/track/skaian-overdrive-2)
 - Name: >-
     SKAIAN STARSTORM
   Annotation: >-

--- a/album/homestuck-vol-2.yaml
+++ b/album/homestuck-vol-2.yaml
@@ -59,7 +59,7 @@ Track Artwork:
   - Standing Piano
 Duration: 2:48
 URLs:
-- https://homestuck.bandcamp.com/track/harlequin-rock-version-3
+- https://homestuck.bandcamp.com/track/harlequin-rock-version-2
 - https://youtu.be/g5TDTcMEL_c
 Referenced Tracks:
 - Harlequin
@@ -113,7 +113,7 @@ Track Artwork:
   - Dave's home
 Duration: 4:20
 URLs:
-- https://homestuck.bandcamp.com/track/upward-movement-dave-owns-3
+- https://homestuck.bandcamp.com/track/upward-movement-dave-owns-2
 - https://youtu.be/j6UiUu_7LVc
 Referenced Tracks:
 - track:amen-brother
@@ -150,7 +150,7 @@ Track Artwork:
   - Skyship Base
 Duration: 1:13
 URLs:
-- https://homestuck.bandcamp.com/track/vagabounce-3
+- https://homestuck.bandcamp.com/track/vagabounce-2
 - https://youtu.be/GFYnHrqW6LM
 ---
 Track: Explore
@@ -169,7 +169,7 @@ Track Artwork:
   - Sburb
 Duration: 2:28
 URLs:
-- https://homestuck.bandcamp.com/track/explore-3
+- https://homestuck.bandcamp.com/track/explore-2
 - https://youtu.be/l03ijKa3NlA
 Sheet Music Files:
 - Title: Sheet music by EuniverseCat
@@ -276,7 +276,7 @@ Track Artwork:
   - Music Note
 Duration: 2:02
 URLs:
-- https://homestuck.bandcamp.com/track/showtime-remix-3
+- https://homestuck.bandcamp.com/track/showtime-remix-2
 - https://youtu.be/VliU0X6XVpA
 Sampled Tracks:
 - Showtime (Piano Refrain)
@@ -294,7 +294,7 @@ Artists:
 - Gabriel Nezovic
 Duration: 2:11
 URLs:
-- https://homestuck.bandcamp.com/track/aggrieve-remix-3
+- https://homestuck.bandcamp.com/track/aggrieve-remix-2
 - https://youtu.be/DpB5llhN2L0
 Referenced Tracks:
 - Aggrieve (Violin Refrain)
@@ -314,7 +314,7 @@ Artists:
 - Kalibration
 Duration: 0:52
 URLs:
-- https://homestuck.bandcamp.com/track/verdancy-bassline-3
+- https://homestuck.bandcamp.com/track/verdancy-bassline-2
 - https://youtu.be/UudwG8_AoOQ
 ---
 Track: Kinetic Verdancy

--- a/album/homestuck-vol-3.yaml
+++ b/album/homestuck-vol-3.yaml
@@ -74,7 +74,7 @@ MIDI Project Files:
   Files:
   - 'Beatdown (Strider Style) - MrCheeze.mid'
 URLs:
-- https://homestuck.bandcamp.com/track/beatdown-strider-style-3
+- https://homestuck.bandcamp.com/track/beatdown-strider-style-2
 - https://youtu.be/laPOcRplQrw
 ---
 Track: Harleboss
@@ -89,7 +89,7 @@ Track Artwork:
   - John
 Duration: 2:47
 URLs:
-- https://homestuck.bandcamp.com/track/harleboss-3
+- https://homestuck.bandcamp.com/track/harleboss-2
 - https://youtu.be/51vrPLt_LG8
 Referenced Tracks:
 - Harlequin
@@ -117,7 +117,7 @@ Track Artwork:
   - Smuppets
 Duration: 2:27
 URLs:
-- https://homestuck.bandcamp.com/track/beatdown-round-2-3
+- https://homestuck.bandcamp.com/track/beatdown-round-2-2
 - https://youtu.be/CuQpu45cmtw
 Referenced Tracks:
 - Beatdown (Strider Style)
@@ -146,7 +146,7 @@ MIDI Project Files:
   Files:
   - 'Dissension (Original) - Unknown.mid'
 URLs:
-- https://homestuck.bandcamp.com/track/dissension-original-3
+- https://homestuck.bandcamp.com/track/dissension-original-2
 - https://youtu.be/az71j7AvBuQ
 ---
 Track: Dissension (Remix)
@@ -163,7 +163,7 @@ Track Artwork:
   - Jade's home
 Duration: 2:03
 URLs:
-- https://homestuck.bandcamp.com/track/dissension-remix-3
+- https://homestuck.bandcamp.com/track/dissension-remix-2
 - https://youtu.be/mkPXt83h73w
 Referenced Tracks:
 - Dissension (Original)
@@ -201,7 +201,7 @@ Track Artwork:
   - Music Note
 Duration: 1:06
 URLs:
-- https://homestuck.bandcamp.com/track/ohgodwhat-3
+- https://homestuck.bandcamp.com/track/ohgodwhat-2
 - https://youtu.be/eX3QCmtmt4E
 MIDI Project Files:
 - Title: MIDI by IronInvoker47
@@ -235,7 +235,7 @@ Track Artwork:
   - Music Note
 Duration: 1:05
 URLs:
-- https://homestuck.bandcamp.com/track/ohgodwhat-remix-3
+- https://homestuck.bandcamp.com/track/ohgodwhat-remix-2
 - https://youtu.be/ZuaMHCPnqOc
 Referenced Tracks:
 - Ohgodwhat
@@ -267,7 +267,7 @@ Track Artwork:
   - Music Note
 Duration: 1:36
 URLs:
-- https://homestuck.bandcamp.com/track/rediscover-fusion-3
+- https://homestuck.bandcamp.com/track/rediscover-fusion-2
 - https://youtu.be/5j7mzL-ctNo
 Commentary: |-
     <i>BurnedKirby:</i> ([SoundCloud, on another track...](https://soundcloud.com/burnedkirby/electric-dream), 9/8/2012)
@@ -307,7 +307,7 @@ Track Artwork:
   - Music Note
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/explore-remix-3
+- https://homestuck.bandcamp.com/track/explore-remix-2
 - https://youtu.be/06qu70cLPaE
 Referenced Tracks:
 - Explore
@@ -329,7 +329,7 @@ Track Artwork:
   - 'Rainbow Falls, NY'
 Duration: 1:15
 URLs:
-- https://homestuck.bandcamp.com/track/chorale-for-jaspers-3
+- https://homestuck.bandcamp.com/track/chorale-for-jaspers-2
 - https://youtu.be/YkSq79X6MAw
 Sheet Music Files:
 - Title: Sheet music by Zephyr
@@ -362,7 +362,7 @@ Track Artwork:
   - John
 Duration: 1:03
 URLs:
-- https://homestuck.bandcamp.com/track/pony-chorale-3
+- https://homestuck.bandcamp.com/track/pony-chorale-2
 - https://youtu.be/MHsZHFb5FqU
 Referenced Tracks:
 - Chorale for Jaspers

--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -92,7 +92,7 @@ Track Artwork:
   - John
   - Bing Crosby
 URLs:
-- https://homestuck.bandcamp.com/track/revelawesome-3
+- https://homestuck.bandcamp.com/track/revelawesome-2
 - https://youtu.be/yeIEkiIjw5c
 MIDI Project Files:
 - Title: MIDI by MrCheeze
@@ -119,7 +119,7 @@ Track Artwork:
   - John
 Duration: 1:38
 URLs:
-- https://homestuck.bandcamp.com/track/hardlyquin-3
+- https://homestuck.bandcamp.com/track/hardlyquin-2
 - https://youtu.be/CN04ruWv30g
 Referenced Tracks:
 - Harlequin
@@ -168,7 +168,7 @@ Track Artwork:
   - Pacific Island
 Duration: 1:36
 URLs:
-- https://homestuck.bandcamp.com/track/carefree-victory-3
+- https://homestuck.bandcamp.com/track/carefree-victory-2
 - https://youtu.be/2z1Rp2UynQE
 Referenced Tracks:
 - track:carefree-action
@@ -248,7 +248,7 @@ Track Artwork:
   - Prospit
 Duration: 3:08
 URLs:
-- https://homestuck.bandcamp.com/track/ballad-of-awakening-3
+- https://homestuck.bandcamp.com/track/ballad-of-awakening-2
 - https://youtu.be/ZmJ3Ex2jguE
 Sheet Music Files:
 - Title: Sheet music by EuniverseCat
@@ -289,7 +289,7 @@ Track Artwork:
   - 'Rainbow Falls, NY'
 Duration: 3:39
 URLs:
-- https://homestuck.bandcamp.com/track/sburban-jungle-3
+- https://homestuck.bandcamp.com/track/sburban-jungle-2
 - https://www.youtube.com/watch?v=PP6916yGx6c
 - https://open.spotify.com/track/1SW1ybpwtkCeP9d4X3oDnG
 - https://music.apple.com/album/sburban-jungle/1684301712?i=1684301713
@@ -355,7 +355,7 @@ Track Artwork:
     From [[flash:1267]] (page 1267)
 Duration: 6:29
 URLs:
-- https://homestuck.bandcamp.com/track/three-in-the-morning-rjs-i-can-barely-sleep-in-this-casino-remix-3
+- https://homestuck.bandcamp.com/track/three-in-the-morning-rjs-i-can-barely-sleep-in-this-casino-remix-2
 - https://youtu.be/GACczxr7464
 Referenced Tracks:
 - track:three-in-the-morning
@@ -377,7 +377,7 @@ Track Artwork:
   - LoWaS
 Duration: 2:37
 URLs:
-- https://homestuck.bandcamp.com/track/doctor-3
+- https://homestuck.bandcamp.com/track/doctor-2
 - https://youtu.be/ve7TB0FggaY
 Referenced Tracks:
 - Doctor (Original Loop)
@@ -557,7 +557,7 @@ Track Artwork:
   - LoLaR
 Duration: 1:24
 URLs:
-- https://homestuck.bandcamp.com/track/endless-climb-3
+- https://homestuck.bandcamp.com/track/endless-climb-2
 - https://youtu.be/_cCc7xv6uCk
 Sheet Music Files:
 - Title: Sheet music by EuniverseCat
@@ -587,7 +587,7 @@ Track Artwork:
   - LoHaC
 Duration: 1:10
 URLs:
-- https://homestuck.bandcamp.com/track/atomyk-ebonpyre-3
+- https://homestuck.bandcamp.com/track/atomyk-ebonpyre-2
 - https://youtu.be/zECoOQ668nA
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
@@ -620,7 +620,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 2:24
 URLs:
-- https://homestuck.bandcamp.com/track/black-3
+- https://homestuck.bandcamp.com/track/black-2
 - https://youtu.be/5NACWZBDtN8
 Referenced Tracks:
 - Plasmatic Blaquaciousness

--- a/album/homestuck-vol-5.yaml
+++ b/album/homestuck-vol-5.yaml
@@ -1251,6 +1251,8 @@ Commentary: |-
 ---
 Track: Bed of Rose's / Dreams of Derse
 Additional Names:
+- Name: Bed of Rose's - Dreams of Derse
+  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20201024194057/https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse-2)
 - Bed of Rose's (earlier MSPA credit)
 Artists:
 - Mark J. Hadley

--- a/album/homestuck-vol-5.yaml
+++ b/album/homestuck-vol-5.yaml
@@ -1251,8 +1251,10 @@ Commentary: |-
 ---
 Track: Bed of Rose's / Dreams of Derse
 Additional Names:
-- Name: Bed of Rose's - Dreams of Derse
-  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20201024194057/https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse-2)
+- Name: >-
+    Bed of Rose's - Dreams of Derse
+  Annotation: >-
+    [Bandcamp compilation release](https://web.archive.org/web/20201024194057/https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse-2)
 - Bed of Rose's (earlier MSPA credit)
 Artists:
 - Mark J. Hadley

--- a/album/homestuck-vol-5.yaml
+++ b/album/homestuck-vol-5.yaml
@@ -3,7 +3,7 @@ Directory Suffix: vol5
 Date: June 13, 2010
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt
+- https://homestuck.bandcamp.com/album/homestuck-vol-5
 - https://www.youtube.com/watch?v=DuBmOO4muV8
 Cover Artists:
 - Lexxy
@@ -125,11 +125,11 @@ Commentary: |-
 
     Unfortunately, for some reason, the first post has been deleted. Kind of an empty gesture to make up to that, but the credits for that one are, in this order: [[artist:linde-enge|linde-enge]], [[artist:seiii-tan|seiii-tan]], [[artist:cityinthesea|cityinthesea]], [[artist:fizzmouth|fizzmouth]] and [[artist:sollay|sollay-b]].
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20100615165450/https://homestuck.bandcamp.com/album/homestuck-vol-5))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/homestuck-vol-5))
 
     Includes full album cover art and musician credits pages by the singularly talented Alexandra "Lexxy" Douglass.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20100615165450/https://homestuck.bandcamp.com/album/homestuck-vol-5))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/homestuck-vol-5))
 
     Ladies and Gentlemen, your musicians:
 
@@ -169,7 +169,7 @@ Artists:
 - Clark Powell
 Duration: 3:14
 URLs:
-- https://homestuck.bandcamp.com/track/homestuck-anthem-2
+- https://homestuck.bandcamp.com/track/homestuck-anthem
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -197,7 +197,7 @@ Artists:
 - Toby Fox
 Duration: 2:09
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-skirmish-2
+- https://homestuck.bandcamp.com/track/skaian-skirmish
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -217,7 +217,7 @@ Artists:
 - Toby Fox
 Duration: 2:26
 URLs:
-- https://homestuck.bandcamp.com/track/savior-of-the-waking-world-2
+- https://homestuck.bandcamp.com/track/savior-of-the-waking-world
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -269,7 +269,7 @@ Artists:
 - Clark Powell
 Duration: 0:35
 URLs:
-- https://homestuck.bandcamp.com/track/clockwork-melody-2
+- https://homestuck.bandcamp.com/track/clockwork-melody
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -306,7 +306,7 @@ Artists:
 - Alex Rosetti
 Duration: 2:42
 URLs:
-- https://homestuck.bandcamp.com/track/heirfare-2
+- https://homestuck.bandcamp.com/track/heirfare
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -337,7 +337,7 @@ Artists:
 - David Ko
 Duration: 0:48
 URLs:
-- https://homestuck.bandcamp.com/track/jades-lullaby-2
+- https://homestuck.bandcamp.com/track/jades-lullaby
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -357,7 +357,7 @@ Artists:
 - Mark J. Hadley
 Duration: 3:01
 URLs:
-- https://homestuck.bandcamp.com/track/aggrievance-2
+- https://homestuck.bandcamp.com/track/aggrievance
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -386,7 +386,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 0:34
 URLs:
-- https://homestuck.bandcamp.com/track/happy-cat-song-2
+- https://homestuck.bandcamp.com/track/happy-cat-song
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -421,7 +421,7 @@ Contributors:
 - Michael Guy Bowman (meows)
 Duration: 2:54
 URLs:
-- https://homestuck.bandcamp.com/track/hardchorale-2
+- https://homestuck.bandcamp.com/track/hardchorale
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -459,7 +459,7 @@ Artists:
 - Kalibration
 Duration: 2:30
 URLs:
-- https://homestuck.bandcamp.com/track/an-unbreakable-union-2
+- https://homestuck.bandcamp.com/track/an-unbreakable-union
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -489,7 +489,7 @@ Artists:
 - Seth Peelle (arrangement)
 Duration: 3:04
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-ride-2
+- https://homestuck.bandcamp.com/track/skaian-ride
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -523,7 +523,7 @@ Commentary: |-
 
     <i>awildcale:</i> (anthology artist, Tumblr [(dead link)](https://the-cale.tumblr.com/post/159561376331/skaian-ride-heres-my-piece-for-the-vol-5-anthology))
 
-    [skaian ride](https://homestuck.bandcamp.com/track/skaian-ride-2)
+    [skaian ride](https://homestuck.bandcamp.com/track/skaian-ride)
 
     heres my piece for the vol 5 anthology project! the song is super peaceful and calming to listen to, i highly recommend it. also, the alpha kids! remember [[flash-act:a6i1|act 6 intermission 1]]? i thought, why couldnt this have happened during more peaceful times? maybe with the kids doing stuff they liked to do instead
 
@@ -536,7 +536,7 @@ Artists:
 - Toby Fox
 Duration: 1:25
 URLs:
-- https://homestuck.bandcamp.com/track/white-2
+- https://homestuck.bandcamp.com/track/white
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -596,7 +596,7 @@ Artists:
 - Toby Fox
 Duration: 2:11
 URLs:
-- https://homestuck.bandcamp.com/track/octoroon-rangoon-2
+- https://homestuck.bandcamp.com/track/octoroon-rangoon
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -725,7 +725,7 @@ Artists:
 - Seth Peelle
 Duration: 3:57
 URLs:
-- https://homestuck.bandcamp.com/track/pumpkin-cravings-2
+- https://homestuck.bandcamp.com/track/pumpkin-cravings
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -750,7 +750,7 @@ Artists:
 - rj lake
 Duration: 3:18
 URLs:
-- https://homestuck.bandcamp.com/track/welcome-to-the-new-extreme-2
+- https://homestuck.bandcamp.com/track/welcome-to-the-new-extreme
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -773,7 +773,7 @@ Artists:
 - Alex Rosetti
 Duration: 1:27
 URLs:
-- https://homestuck.bandcamp.com/track/crystalanthemums-2
+- https://homestuck.bandcamp.com/track/crystalanthemums
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -829,7 +829,7 @@ Artists:
 - Solatrus
 Duration: 5:06
 URLs:
-- https://homestuck.bandcamp.com/track/skaia-incipisphere-mix-2
+- https://homestuck.bandcamp.com/track/skaia-incipisphere-mix
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -903,7 +903,7 @@ Artists:
 - Erik Scheele
 Duration: 2:18
 URLs:
-- https://homestuck.bandcamp.com/track/sarabande-2
+- https://homestuck.bandcamp.com/track/sarabande
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -953,7 +953,7 @@ Artists:
 - David Ko
 Duration: 1:04
 URLs:
-- https://homestuck.bandcamp.com/track/clockwork-sorrow-2
+- https://homestuck.bandcamp.com/track/clockwork-sorrow
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -986,7 +986,7 @@ Artists:
 - Alex Rosetti
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/phantasmagoric-waltz-2
+- https://homestuck.bandcamp.com/track/phantasmagoric-waltz
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1025,7 +1025,7 @@ Artists:
 - Seth Peelle
 Duration: 3:05
 URLs:
-- https://homestuck.bandcamp.com/track/sunslammer-2
+- https://homestuck.bandcamp.com/track/sunslammer
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1081,7 +1081,7 @@ Artists:
 - Toby Fox
 Duration: 1:52
 URLs:
-- https://homestuck.bandcamp.com/track/lotus-land-story-2
+- https://homestuck.bandcamp.com/track/lotus-land-story
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1106,7 +1106,7 @@ Artists:
 - Steve Everson
 Duration: 1:37
 URLs:
-- https://homestuck.bandcamp.com/track/chorale-for-war-2
+- https://homestuck.bandcamp.com/track/chorale-for-war
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1161,7 +1161,7 @@ Artists:
 - Alex Rosetti
 Duration: 0:56
 URLs:
-- https://homestuck.bandcamp.com/track/unsheathd-2
+- https://homestuck.bandcamp.com/track/unsheathd
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1188,7 +1188,7 @@ Artists:
 - Toby Fox
 Duration: 2:03
 URLs:
-- https://homestuck.bandcamp.com/track/versus-2
+- https://homestuck.bandcamp.com/track/versus
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1215,7 +1215,7 @@ Contributors:
 - Erik Scheele (various material)
 Duration: 1:39
 URLs:
-- https://homestuck.bandcamp.com/track/planet-healer-2
+- https://homestuck.bandcamp.com/track/planet-healer
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1256,7 +1256,7 @@ Artists:
 - Mark J. Hadley
 Duration: 1:43
 URLs:
-- https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse-2
+- https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1299,7 +1299,7 @@ Commentary: |-
 
     <i>Seagrot:</i> (anthology artist, [Tumblr](https://www.tumblr.com/dumbbitche/159551398865/my-bed-of-rosesdreams-of-derse-piece-for-the-vol), 4/14/2017)
 
-    my [bed of rose’s/dreams of derse](https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse-2) piece for the [vol 5 anthology project](https://vol5anthology.tumblr.com/)..! w a bit of flair. happy 413 yall
+    my [bed of rose’s/dreams of derse](https://homestuck.bandcamp.com/track/bed-of-roses-dreams-of-derse) piece for the [vol 5 anthology project](https://vol5anthology.tumblr.com/)..! w a bit of flair. happy 413 yall
 
     <small>#this project turned out soooooo well thanks everyone. vol 5 is hands down best album</small>
 ---
@@ -1308,7 +1308,7 @@ Artists:
 - Kalibration
 Duration: 1:30
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-flight-2
+- https://homestuck.bandcamp.com/track/skaian-flight
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1337,7 +1337,7 @@ Contributors:
 - Nick Smalley (guitar solo)
 Duration: 3:43
 URLs:
-- https://homestuck.bandcamp.com/track/how-do-i-live-bunny-back-in-the-box-version-2
+- https://homestuck.bandcamp.com/track/how-do-i-live-bunny-back-in-the-box-version
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1427,7 +1427,7 @@ Artists:
 - Toby Fox
 Duration: 2:24
 URLs:
-- https://homestuck.bandcamp.com/track/dupliblaze-comagma-2
+- https://homestuck.bandcamp.com/track/dupliblaze-comagma
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1466,7 +1466,7 @@ Artists:
 - Toby Fox
 Duration: 1:17
 URLs:
-- https://homestuck.bandcamp.com/track/moonshatter-2
+- https://homestuck.bandcamp.com/track/moonshatter
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1484,7 +1484,7 @@ Commentary: |-
 
     Since it’s 4/13 and all of the entries for the [Homestuck Vol. 5 Track Art Fan Anthology](https://vol5anthology.tumblr.com/) are posted, I thought I’d put my piece up here.
 
-    My track was [Moonshatter](https://homestuck.bandcamp.com/track/moonshatter-2)!
+    My track was [Moonshatter](https://homestuck.bandcamp.com/track/moonshatter)!
 
     Mack sure you check out the other entries and happy 4/13!
 ---
@@ -1493,7 +1493,7 @@ Artists:
 - Toby Fox
 Duration: 1:32
 URLs:
-- https://homestuck.bandcamp.com/track/sunsetter-2
+- https://homestuck.bandcamp.com/track/sunsetter
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1516,7 +1516,7 @@ Artists:
 - Seth Peelle
 Duration: 1:39
 URLs:
-- https://homestuck.bandcamp.com/track/lotus-2
+- https://homestuck.bandcamp.com/track/lotus
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1545,7 +1545,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 3:09
 URLs:
-- https://homestuck.bandcamp.com/track/ruins-with-strings-2
+- https://homestuck.bandcamp.com/track/ruins-with-strings
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1626,7 +1626,7 @@ Artists:
 - David Ko
 Duration: 1:39
 URLs:
-- https://homestuck.bandcamp.com/track/ectobiology-2
+- https://homestuck.bandcamp.com/track/ectobiology
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1659,7 +1659,7 @@ Artists:
 - Alex Rosetti
 Duration: 1:44
 URLs:
-- https://homestuck.bandcamp.com/track/upholding-the-law-2
+- https://homestuck.bandcamp.com/track/upholding-the-law
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1686,7 +1686,7 @@ Artists:
 - Steve Everson
 Duration: 2:25
 URLs:
-- https://homestuck.bandcamp.com/track/underworld-2
+- https://homestuck.bandcamp.com/track/underworld
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1712,7 +1712,7 @@ Artists:
 - Erik Scheele
 Duration: 3:10
 URLs:
-- https://homestuck.bandcamp.com/track/crystamanthequins-2
+- https://homestuck.bandcamp.com/track/crystamanthequins
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1756,7 +1756,7 @@ Artists:
 - Perry Sullivan
 Duration: 2:12
 URLs:
-- https://homestuck.bandcamp.com/track/endless-climbing-2
+- https://homestuck.bandcamp.com/track/endless-climbing
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1775,7 +1775,7 @@ Artists:
 - David Ko
 Duration: 1:44
 URLs:
-- https://homestuck.bandcamp.com/track/land-of-the-salamanders-2
+- https://homestuck.bandcamp.com/track/land-of-the-salamanders
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1796,14 +1796,14 @@ Referenced Tracks:
 Commentary: |-
     <i>Kisbys:</i> (anthology artist, [Tumblr](https://clock-heart.tumblr.com/post/159537592103/kisbys-heres-the-piece-i-made-for), 4/13/2017)
 
-    here’s the piece i made for @vol5anthology !! my song was [land of the salamanders](https://homestuck.bandcamp.com/track/land-of-the-salamanders-2)! all the other artists did a wonderful job with their track art and i recommend checking out the blog to see the other fantastic pieces!
+    here’s the piece i made for @vol5anthology !! my song was [land of the salamanders](https://homestuck.bandcamp.com/track/land-of-the-salamanders)! all the other artists did a wonderful job with their track art and i recommend checking out the blog to see the other fantastic pieces!
 ---
 Track: Medical Emergency
 Artists:
 - Alex Rosetti
 Duration: 2:08
 URLs:
-- https://homestuck.bandcamp.com/track/medical-emergency-2
+- https://homestuck.bandcamp.com/track/medical-emergency
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1823,7 +1823,7 @@ Commentary: |-
     <i>Nolvini:</i> (anthology artist, [Tumblr](https://nolvini.tumblr.com/post/159613597019/my-piece-created-for-the-vol5anthology-the-song), 4/15/2017)
 
     My piece created for the @vol5anthology!<br>
-    The song I had was [Medical Emergency](https://homestuck.bandcamp.com/track/medical-emergency-2)<br>
+    The song I had was [Medical Emergency](https://homestuck.bandcamp.com/track/medical-emergency)<br>
     [Everyone did such an amazing job, I’m glad to have been able to participate in this!!](https://vol5anthology.tumblr.com/participants)
 
     <small>#holy shit!!! #everyone was so good #i felt embarassed hah #i'm glad i got chosen even tho i was a runner up #i felt honored ;u; #props to everyone #please check them out ahhhhhhh</small>
@@ -1921,7 +1921,7 @@ Artists:
 - Clark Powell
 Duration: 4:33
 URLs:
-- https://homestuck.bandcamp.com/track/clockwork-contrivance-2
+- https://homestuck.bandcamp.com/track/clockwork-contrivance
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1941,7 +1941,7 @@ Artists:
 - Toby Fox
 Duration: 1:18
 URLs:
-- https://homestuck.bandcamp.com/track/get-up-2
+- https://homestuck.bandcamp.com/track/get-up
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1960,7 +1960,7 @@ Artists:
 - Toby Fox
 Duration: 1:32
 URLs:
-- https://homestuck.bandcamp.com/track/vertical-motion-2
+- https://homestuck.bandcamp.com/track/vertical-motion
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -1984,7 +1984,7 @@ Artists:
 - rj lake
 Duration: 5:27
 URLs:
-- https://homestuck.bandcamp.com/track/the-beginning-of-something-really-excellent-2
+- https://homestuck.bandcamp.com/track/the-beginning-of-something-really-excellent
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2001,7 +2001,7 @@ Artists:
 - rj lake
 Duration: 3:02
 URLs:
-- https://homestuck.bandcamp.com/track/pyrocumulus-kickstart-2
+- https://homestuck.bandcamp.com/track/pyrocumulus-kickstart
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2018,7 +2018,7 @@ Artists:
 - Andrew Huo
 Duration: 2:11
 URLs:
-- https://homestuck.bandcamp.com/track/skaian-skuffle-2
+- https://homestuck.bandcamp.com/track/skaian-skuffle
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2040,14 +2040,14 @@ Commentary: |-
 
     <i>innocuoussketches:</i> (anthology artist, [Tumblr](https://innocuoussketches.tumblr.com/post/159539323467/heres-my-piece-from-the-vol-5-anthology-fan), 4/13/2017)
 
-    Here’s my piece from the [Vol. 5 Anthology fan project](http://vol5anthology.tumblr.com/) and illustrated art for the track [Skaian Skuffle](https://homestuck.bandcamp.com/track/skaian-skuffle-2).  You should check out all of the art from the project because it’s really gorgeous!
+    Here’s my piece from the [Vol. 5 Anthology fan project](http://vol5anthology.tumblr.com/) and illustrated art for the track [Skaian Skuffle](https://homestuck.bandcamp.com/track/skaian-skuffle).  You should check out all of the art from the project because it’s really gorgeous!
 ---
 Track: Throwdown
 Artists:
 - Steve Everson
 Duration: 1:36
 URLs:
-- https://homestuck.bandcamp.com/track/throwdown-2
+- https://homestuck.bandcamp.com/track/throwdown
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2091,7 +2091,7 @@ Artists:
 - Kalibration
 Duration: 3:06
 URLs:
-- https://homestuck.bandcamp.com/track/valhalla-2
+- https://homestuck.bandcamp.com/track/valhalla
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2112,7 +2112,7 @@ Artists:
 - Toby Fox
 Duration: 1:40
 URLs:
-- https://homestuck.bandcamp.com/track/amphibious-subterrain-2
+- https://homestuck.bandcamp.com/track/amphibious-subterrain
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2130,7 +2130,7 @@ Artists:
 - Erik Scheele
 Duration: 4:27
 URLs:
-- https://homestuck.bandcamp.com/track/light-3
+- https://homestuck.bandcamp.com/track/light
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2163,7 +2163,7 @@ Artists:
 - rj lake
 Duration: 3:04
 URLs:
-- https://homestuck.bandcamp.com/track/softly-2
+- https://homestuck.bandcamp.com/track/softly
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2186,7 +2186,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 2:50
 URLs:
-- https://homestuck.bandcamp.com/track/greenhouse-2
+- https://homestuck.bandcamp.com/track/greenhouse
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2228,7 +2228,7 @@ Artists:
 - David Ko
 Duration: 0:50
 URLs:
-- https://homestuck.bandcamp.com/track/space-prankster-2
+- https://homestuck.bandcamp.com/track/space-prankster
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2244,14 +2244,14 @@ Track Artwork:
 Commentary: |-
     <i>kindergraph:</i> (anthology artist, [Tumblr](https://www.tumblr.com/kindergraph/159546407960/here-is-my-contribution-for-the-vol5anthology), 4/13/2017)
 
-    here is my contribution for the @vol5anthology homestuck fan project!! i did track 52, [space prankster](https://homestuck.bandcamp.com/track/space-prankster-2)! i had SO much fun drawing this and there were so many incredibly talented artists working on the anthology and everything came out looking so good ;___; HAPPY 4/13 EVERYBODY I LOVE HOMESTUCK
+    here is my contribution for the @vol5anthology homestuck fan project!! i did track 52, [space prankster](https://homestuck.bandcamp.com/track/space-prankster)! i had SO much fun drawing this and there were so many incredibly talented artists working on the anthology and everything came out looking so good ;___; HAPPY 4/13 EVERYBODY I LOVE HOMESTUCK
 ---
 Track: Ecstasy
 Artists:
 - Steve Everson
 Duration: 2:48
 URLs:
-- https://homestuck.bandcamp.com/track/ecstasy-2
+- https://homestuck.bandcamp.com/track/ecstasy
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2285,7 +2285,7 @@ Artists:
 - Toby Fox
 Duration: 2:10
 URLs:
-- https://homestuck.bandcamp.com/track/snow-pollen-2
+- https://homestuck.bandcamp.com/track/snow-pollen
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2312,7 +2312,7 @@ Artists:
 - James Dever
 Duration: 2:34
 URLs:
-- https://homestuck.bandcamp.com/track/candles-and-clockwork-2
+- https://homestuck.bandcamp.com/track/candles-and-clockwork
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2337,7 +2337,7 @@ Artists:
 - Alex Rosetti
 Duration: 1:40
 URLs:
-- https://homestuck.bandcamp.com/track/can-town-2
+- https://homestuck.bandcamp.com/track/can-town
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2360,7 +2360,7 @@ Artists:
 - Steve Everson
 Duration: 1:13
 URLs:
-- https://homestuck.bandcamp.com/track/plague-doctor-2
+- https://homestuck.bandcamp.com/track/plague-doctor
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2385,7 +2385,7 @@ Artists:
 - Steve Everson
 Duration: 1:15
 URLs:
-- https://homestuck.bandcamp.com/track/enlightenment-2
+- https://homestuck.bandcamp.com/track/enlightenment
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2407,7 +2407,7 @@ Artists:
 - Gabriel Nezovic
 Duration: 0:58
 URLs:
-- https://homestuck.bandcamp.com/track/doctor-remix-2
+- https://homestuck.bandcamp.com/track/doctor-remix
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2432,7 +2432,7 @@ Artists:
 - rj lake
 Duration: 3:39
 URLs:
-- https://homestuck.bandcamp.com/track/biophosphoradelecrystalluminescence-2
+- https://homestuck.bandcamp.com/track/biophosphoradelecrystalluminescence
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2497,7 +2497,7 @@ Artists:
 - Steve Everson
 Duration: 2:09
 URLs:
-- https://homestuck.bandcamp.com/track/song-of-life-2
+- https://homestuck.bandcamp.com/track/song-of-life
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2510,7 +2510,7 @@ Track Artwork:
 Commentary: |-
     <i>AroSoup:</i> (anthology artist, [Tumblr](https://vol5anthology.tumblr.com/post/160150012524/arosoup-this-is-my-art-for-the-vol-5-anthology), 4/16/2017)
 
-    This is my art for the [Vol 5 anthology](https://vol5anthology.tumblr.com)!! This art is specifically for [Song of Life.](https://homestuck.bandcamp.com/track/song-of-life-2) Everyone was super nice and it was real fun animating some art for the video!! Have a happy rest of the week everybody I’ve been too lazy to post this on 4/13.
+    This is my art for the [Vol 5 anthology](https://vol5anthology.tumblr.com)!! This art is specifically for [Song of Life.](https://homestuck.bandcamp.com/track/song-of-life) Everyone was super nice and it was real fun animating some art for the video!! Have a happy rest of the week everybody I’ve been too lazy to post this on 4/13.
 ---
 Track: Cathedral of the End
 Artists:
@@ -2532,7 +2532,7 @@ Artists:
 - Toby Fox
 Duration: 4:25
 URLs:
-- https://homestuck.bandcamp.com/track/descend-2
+- https://homestuck.bandcamp.com/track/descend
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'
@@ -2614,7 +2614,7 @@ Artists:
 - Mark J. Hadley
 Duration: 2:27
 URLs:
-- https://homestuck.bandcamp.com/track/homestuck-2
+- https://homestuck.bandcamp.com/track/homestuck
 Track Artwork:
 - Label: Anthology fanart
   Source: '[Vol. 5 Anthology](https://sollay-b.tumblr.com/post/188094230423/hello-a-couple-of-years-ago-allyssinian)'

--- a/album/homestuck-vol-6.yaml
+++ b/album/homestuck-vol-6.yaml
@@ -4,7 +4,7 @@ Directory Suffix: vol6
 Date: January 5 2011
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt
+- https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent
 - https://www.youtube.com/watch?v=jrNz5d97JIA
 Cover Artists:
 - Andrew Hussie
@@ -66,7 +66,7 @@ Commentary: |-
 
     The sixth official Homestuck album......... IS GREAT!
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110108034132/https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent))
 
     Music by:<br>
     [[artist:kalibration|Robert Blaker]]<br>
@@ -106,7 +106,7 @@ Track Artwork:
   - LoFaF
 Duration: 5:05
 URLs:
-- https://homestuck.bandcamp.com/track/frost-3
+- https://homestuck.bandcamp.com/track/frost
 Referenced Tracks:
 - track:flow-solatrus
 - Vertigo
@@ -177,7 +177,7 @@ Track Artwork:
   - Reckoning
 Duration: 4:37
 URLs:
-- https://homestuck.bandcamp.com/track/courser-2
+- https://homestuck.bandcamp.com/track/courser
 Referenced Tracks:
 - Sburban Jungle
 - Lotus
@@ -196,7 +196,7 @@ Track Artwork:
   - Jade
 Duration: 3:33
 URLs:
-- https://homestuck.bandcamp.com/track/umbral-ultimatum-2
+- https://homestuck.bandcamp.com/track/umbral-ultimatum
 Referenced Tracks:
 - Penumbra Phantasm
 - An Unbreakable Union
@@ -236,7 +236,7 @@ Track Artwork:
     [YouTube](https://www.youtube.com/watch?v=k_-LPPdHEyA)
 Duration: 3:24
 URLs:
-- https://homestuck.bandcamp.com/track/gamebro-original-1990-mix-2
+- https://homestuck.bandcamp.com/track/gamebro-original-1990-mix
 - https://youtu.be/k_-LPPdHEyA
 Referenced Tracks:
 - Say "I Gotta Believe!"
@@ -336,7 +336,7 @@ Commentary: |-
 
     (alternatively: where the heck did that horrible dude come from get him out of the way of the album art jesus)
 
-    If you have some money, you should consider getting [the whole album](https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt), it'll sound much better from there and there's also a buttload of other great stuff on there.
+    If you have some money, you should consider getting [the whole album](https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent), it'll sound much better from there and there's also a buttload of other great stuff on there.
 
     <i>Erik Scheele:</i> ([YouTube comment](https://www.youtube.com/watch?v=k_-LPPdHEyA&lc=Ugi8uWiElrLFBngCoAEC.8JU1nbN61lI8JU8OpO0TJn), 10/1/2016)
 
@@ -368,7 +368,7 @@ Track Artwork:
     [YouTube](https://www.youtube.com/watch?v=xStVhvhg1i4)
 Duration: 1:48
 URLs:
-- https://homestuck.bandcamp.com/track/tribal-ebonpyre-2
+- https://homestuck.bandcamp.com/track/tribal-ebonpyre
 - https://youtu.be/xStVhvhg1i4
 Referenced Tracks:
 - Atomyk Ebonpyre
@@ -380,7 +380,7 @@ Commentary: |-
 
     Although I didn't think the crocodiles would be so low, but whichever
 
-    Also you should check out the whole album here: [(Bandcamp link)](https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt)
+    Also you should check out the whole album here: [(Bandcamp link)](https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent)
 
     Also you apparently need to be in 480p for it to sound correctly. How annoying.
 ---
@@ -397,7 +397,7 @@ Track Artwork:
   - Liv Tyler
 Duration: 3:57
 URLs:
-- https://homestuck.bandcamp.com/track/i-dont-want-to-miss-a-thing-2
+- https://homestuck.bandcamp.com/track/i-dont-want-to-miss-a-thing
 Referenced Tracks:
 - track:i-dont-want-to-miss-a-thing-aerosmith
 - Sburban Jungle
@@ -514,7 +514,7 @@ Track Artwork:
   - Vriska
 Duration: 2:47
 URLs:
-- https://homestuck.bandcamp.com/track/megalovania-2
+- https://homestuck.bandcamp.com/track/megalovania
 Referenced Tracks:
 - track:megalovania-ebhh
 - Spider's Claw
@@ -574,7 +574,7 @@ Track Artwork:
   - LoPaH
 Duration: 3:29
 URLs:
-- https://homestuck.bandcamp.com/track/walk-stab-walk-r-e-2
+- https://homestuck.bandcamp.com/track/walk-stab-walk-r-e
 - https://youtu.be/4UpaT_FjsH8
 Referenced Tracks:
 - Walk-Smash-Walk
@@ -587,7 +587,7 @@ Commentary: |-
 
     No special picture this time because <s>I am lazy</s>
 
-    Also you should check out the whole album, it's amazing and awesome: [(Bandcamp link)](https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt)
+    Also you should check out the whole album, it's amazing and awesome: [(Bandcamp link)](https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent)
 ---
 Track: Gaia Queen
 Artists:
@@ -603,7 +603,7 @@ Track Artwork:
   - LoFaF
 Duration: 3:06
 URLs:
-- https://homestuck.bandcamp.com/track/gaia-queen-2
+- https://homestuck.bandcamp.com/track/gaia-queen
 Referenced Tracks:
 - Showdown
 Lyrics: |-
@@ -623,7 +623,7 @@ Track Artwork:
   - LoHaC
 Duration: 2:09
 URLs:
-- https://homestuck.bandcamp.com/track/elevatorstuck-2
+- https://homestuck.bandcamp.com/track/elevatorstuck
 Referenced Tracks:
 - Homestuck
 Sheet Music Files:
@@ -657,7 +657,7 @@ Track Artwork:
   - Ruined Earth
 Duration: 2:05
 URLs:
-- https://homestuck.bandcamp.com/track/wacky-antics-2
+- https://homestuck.bandcamp.com/track/wacky-antics
 Referenced Tracks:
 - Vagabounce
 ---
@@ -672,7 +672,7 @@ Track Artwork:
   - Horses
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/horschestra-2
+- https://homestuck.bandcamp.com/track/horschestra
 ---
 Track: Heir Transparent
 Artists:
@@ -686,7 +686,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 4:01
 URLs:
-- https://homestuck.bandcamp.com/track/heir-transparent-2
+- https://homestuck.bandcamp.com/track/heir-transparent
 Referenced Tracks:
 - Doctor
 ---
@@ -700,7 +700,7 @@ Track Artwork:
   - John
 Duration: 2:46
 URLs:
-- https://homestuck.bandcamp.com/track/boy-skylark-brief-2
+- https://homestuck.bandcamp.com/track/boy-skylark-brief
 Referenced Tracks:
 - Boy Skylark
 Sampled Tracks:
@@ -718,7 +718,7 @@ Track Artwork:
   - Squiddles
   - Dream Bubbles
 URLs:
-- https://homestuck.bandcamp.com/track/squidissension-2
+- https://homestuck.bandcamp.com/track/squidissension
 Referenced Tracks:
 - Dissension (Original)
 - Squiddles!
@@ -742,7 +742,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 2:32
 URLs:
-- https://homestuck.bandcamp.com/track/blackest-heart-2
+- https://homestuck.bandcamp.com/track/blackest-heart
 Referenced Tracks:
 - Liquid Negrocity
 Commentary: |-
@@ -767,7 +767,7 @@ Track Artwork:
   - Trolls' meteor
 Duration: 2:45
 URLs:
-- https://homestuck.bandcamp.com/track/nic-cage-song-2
+- https://homestuck.bandcamp.com/track/nic-cage-song
 Referenced Tracks:
 - Drop It Like It's Hot
 - Alphabet song
@@ -865,7 +865,7 @@ Track Artwork:
   - Trolls' meteor
 Duration: 3:18
 URLs:
-- https://homestuck.bandcamp.com/track/phrenic-phever-2
+- https://homestuck.bandcamp.com/track/phrenic-phever
 Referenced Tracks:
 - Doctor
 ---
@@ -879,7 +879,7 @@ Track Artwork:
   - Snowman
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/3-in-the-morning-pianokind-2
+- https://homestuck.bandcamp.com/track/3-in-the-morning-pianokind
 - https://www.youtube.com/watch?v=jMn9u4BMPE4
 Referenced Tracks:
 - Three in the Morning
@@ -902,8 +902,8 @@ Commentary: |-
 
     ANYWAY 3 IN THE MORNING YEAH.
 
-    Go to the original page here, help support the people who made it: [(Bandcamp link)](https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt)<br>
-    Or alternatively go to the page for this song to hear it better: [(Bandcamp link)](https://homestuck.bandcamp.com/track/3-in-the-morning-pianokind-2)
+    Go to the original page here, help support the people who made it: [(Bandcamp link)](https://homestuck.bandcamp.com/album/homestuck-vol-6-heir-transparent)<br>
+    Or alternatively go to the page for this song to hear it better: [(Bandcamp link)](https://homestuck.bandcamp.com/track/3-in-the-morning-pianokind)
 ---
 Track: A Tender Moment
 Artists:
@@ -918,7 +918,7 @@ Track Artwork:
   - Jade's home
 Duration: 2:17
 URLs:
-- https://homestuck.bandcamp.com/track/a-tender-moment-2
+- https://homestuck.bandcamp.com/track/a-tender-moment
 Referenced Tracks:
 - Atomyk Ebonpyre
 MIDI Project Files:
@@ -936,7 +936,7 @@ Track Artwork:
   - Vriska
 Duration: 4:44
 URLs:
-- https://homestuck.bandcamp.com/track/crystalanthology-2
+- https://homestuck.bandcamp.com/track/crystalanthology
 Referenced Tracks:
 - Crystalanthemums
 Commentary: |-

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -70,8 +70,10 @@ Section: Main album
 ---
 Track: Black Rose / Green Sun
 Additional Names:
-- Name: Black Rose - Green Sun
-  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20200331160526/https://homestuck.bandcamp.com/track/black-rose-green-sun-2)
+- Name: >-
+    Black Rose - Green Sun
+  Annotation: >-
+    [Bandcamp compilation release](https://web.archive.org/web/20200331160526/https://homestuck.bandcamp.com/track/black-rose-green-sun-2)
 - Black Rose, Green Sun (earlier MSPA credit)
 Artists:
 - Malcolm Brown

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -70,6 +70,8 @@ Section: Main album
 ---
 Track: Black Rose / Green Sun
 Additional Names:
+- Name: Black Rose - Green Sun
+  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20200331160526/https://homestuck.bandcamp.com/track/black-rose-green-sun-2)
 - Black Rose, Green Sun (earlier MSPA credit)
 Artists:
 - Malcolm Brown

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -3,7 +3,7 @@ Directory: homestuck-vol-7
 Date: May 31, 2011 00:00:05
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-7-8-with-cherubim
+- https://homestuck.bandcamp.com/album/homestuck-vol-7-at-the-price-of-oblivion
 - https://www.youtube.com/watch?v=mNibQ4LxeME
 - https://www.youtube.com/playlist?list=PL42042A1D4689C9E0
 Cover Artists:
@@ -49,7 +49,7 @@ Commentary: |-
 
     At the same time that [[album:mobius-trip-and-hadron-kaleido|Mobius Trip & Hadron Kaleido]] came out, we released Homestuck Volume 7. That summer of 2011 was so cool because we were in full swing releasing one of these cool spinoff albums, and one of these compilation albums, like, every month. So we were operating on the capacity of an independent label, and like, really killing it. I would have loved to see that continue.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110603145524/https://homestuck.bandcamp.com/album/homestuck-vol-7-at-the-price-of-oblivion))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/homestuck-vol-7-at-the-price-of-oblivion))
 
     Music by:<br>
     [[artist:malcolm-brown]]<br>
@@ -75,7 +75,7 @@ Artists:
 - Malcolm Brown
 Duration: 3:18
 URLs:
-- https://homestuck.bandcamp.com/track/black-rose-green-sun-2
+- https://homestuck.bandcamp.com/track/black-rose-green-sun
 - https://youtu.be/XoFbJllomCo
 Cover Artists:
 - Vinks (lines)
@@ -114,7 +114,7 @@ Artists:
 - Malcolm Brown
 Duration: 3:23
 URLs:
-- https://homestuck.bandcamp.com/track/at-the-price-of-oblivion-2
+- https://homestuck.bandcamp.com/track/at-the-price-of-oblivion
 - https://youtu.be/u--wSgeJUOs
 Track Artwork:
 - Artists:
@@ -169,7 +169,7 @@ Artists:
 - Clark Powell
 Duration: 2:32
 URLs:
-- https://homestuck.bandcamp.com/track/even-in-death-2
+- https://homestuck.bandcamp.com/track/even-in-death
 - https://youtu.be/T86uquWB9Mw
 Track Artwork:
 - Artists:
@@ -207,7 +207,7 @@ Artists:
 - Toby Fox
 Duration: 1:39
 URLs:
-- https://homestuck.bandcamp.com/track/terezi-owns-2
+- https://homestuck.bandcamp.com/track/terezi-owns
 - https://youtu.be/2pfcakhXhE8
 Track Artwork:
 - Artists:
@@ -243,7 +243,7 @@ Artists:
 - Malcolm Brown
 Duration: 1:29
 URLs:
-- https://homestuck.bandcamp.com/track/trial-and-execution-2
+- https://homestuck.bandcamp.com/track/trial-and-execution
 - https://youtu.be/uxWIej66zwc
 Track Artwork:
 - Artists:
@@ -292,7 +292,7 @@ Artists:
 - Erik Scheele
 Duration: 2:15
 URLs:
-- https://homestuck.bandcamp.com/track/the-carnival-2
+- https://homestuck.bandcamp.com/track/the-carnival
 - https://youtu.be/Q5gjYuJrfbc
 Track Artwork:
 - Artists:
@@ -321,7 +321,7 @@ Artists:
 - Tensei
 Duration: 2:44
 URLs:
-- https://homestuck.bandcamp.com/track/spider8reath-2
+- https://homestuck.bandcamp.com/track/spider8reath
 - https://youtu.be/83B083Lsbfc
 Track Artwork:
 - Artists:
@@ -376,7 +376,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:38
 URLs:
-- https://homestuck.bandcamp.com/track/lifdoff-2
+- https://homestuck.bandcamp.com/track/lifdoff
 - https://youtu.be/8NvMi8GJKUM
 Track Artwork:
 - Artists:
@@ -408,7 +408,7 @@ Artists:
 - Erik Scheele
 Duration: 3:57
 URLs:
-- https://homestuck.bandcamp.com/track/awakening-2
+- https://homestuck.bandcamp.com/track/awakening
 - https://youtu.be/ss0NXbwO_Xs
 Track Artwork:
 - Artists:
@@ -444,7 +444,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:16
 URLs:
-- https://homestuck.bandcamp.com/track/havoc-to-be-wrought-2
+- https://homestuck.bandcamp.com/track/havoc-to-be-wrought
 - https://youtu.be/E7pBfnN7b1w
 Track Artwork:
 - Artists:
@@ -502,7 +502,7 @@ Artists:
 - Kalibration
 Duration: 3:36
 URLs:
-- https://homestuck.bandcamp.com/track/play-the-wind-2
+- https://homestuck.bandcamp.com/track/play-the-wind
 - https://youtu.be/wR-NTkyJ0eg
 Cover Artists:
 - Suki
@@ -526,7 +526,7 @@ Artists:
 - Toby Fox
 Duration: 2:42
 URLs:
-- https://homestuck.bandcamp.com/track/rumble-at-the-rink-2
+- https://homestuck.bandcamp.com/track/rumble-at-the-rink
 - https://youtu.be/Mpyny6XTDY8
 Track Artwork:
 - Artists:
@@ -566,7 +566,7 @@ Artists:
 - rj lake
 Duration: 4:25
 URLs:
-- https://homestuck.bandcamp.com/track/lets-all-rock-the-heist-2
+- https://homestuck.bandcamp.com/track/lets-all-rock-the-heist
 - https://youtu.be/h1kBHhIFYIQ
 Track Artwork:
 - Artists:
@@ -616,7 +616,7 @@ Artists:
 - Erik Scheele
 Duration: 3:36
 URLs:
-- https://homestuck.bandcamp.com/track/wsw-beatdown-2
+- https://homestuck.bandcamp.com/track/wsw-beatdown
 - https://youtu.be/-dusgXh-taQ
 Track Artwork:
 - Artists:
@@ -649,7 +649,7 @@ Artists:
 - Toby Fox
 Duration: 2:58
 URLs:
-- https://homestuck.bandcamp.com/track/earthsea-borealis-2
+- https://homestuck.bandcamp.com/track/earthsea-borealis
 - https://youtu.be/KXgPNyd45A4
 Track Artwork:
 - Artists:
@@ -686,7 +686,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 0:49
 URLs:
-- https://homestuck.bandcamp.com/track/warhammer-of-zillyhoo-2
+- https://homestuck.bandcamp.com/track/warhammer-of-zillyhoo
 - https://youtu.be/0EVrOapzDvg
 Cover Artists:
 - Vinks (lines)
@@ -718,7 +718,7 @@ Artists:
 - Malcolm Brown
 Duration: 4:10
 URLs:
-- https://homestuck.bandcamp.com/track/savior-of-the-dreaming-dead-2
+- https://homestuck.bandcamp.com/track/savior-of-the-dreaming-dead
 - https://youtu.be/Y0PIafh0ssQ
 Cover Artists:
 - wodnesse
@@ -748,7 +748,6 @@ Contributors:
 - Tavia Morra (vocals)
 Duration: 3:01
 URLs:
-- https://homestuck.bandcamp.com/track/maplehoofs-adventure-2
 - https://youtu.be/d-7SMRSvnv8
 Track Artwork:
 - File Extension: jpg
@@ -774,7 +773,6 @@ Artists:
 - Mark J. Hadley
 Duration: 3:51
 URLs:
-- https://homestuck.bandcamp.com/track/sburban-reversal-2
 - https://youtu.be/R-ujyDvr0ps
 Track Artwork:
 - Artists:
@@ -814,7 +812,6 @@ Artists:
 - Tensei
 Duration: 3:28
 URLs:
-- https://homestuck.bandcamp.com/track/white-host-green-room-2
 - https://youtu.be/oL3r83dPcMs
 Track Artwork:
 - Artists:

--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -1405,8 +1405,10 @@ MIDI Project Files:
 ---
 Track: Black Hole / Green Sun
 Additional Names:
-- Name: Black Hole - Green Sun
-  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20200331160531/https://homestuck.bandcamp.com/track/black-hole-green-sun-2)
+- Name: >-
+    Black Hole - Green Sun
+  Annotation: >-
+    [Bandcamp compilation release](https://web.archive.org/web/20200331160531/https://homestuck.bandcamp.com/track/black-hole-green-sun-2)
 Artists:
 - Malcolm Brown
 - Toby Fox

--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -1404,6 +1404,9 @@ MIDI Project Files:
   - 'Cascade (Beta) - Unknown.mid'
 ---
 Track: Black Hole / Green Sun
+Additional Names:
+- Name: Black Hole - Green Sun
+  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20200331160531/https://homestuck.bandcamp.com/track/black-hole-green-sun-2)
 Artists:
 - Malcolm Brown
 - Toby Fox

--- a/album/homestuck-vol-8.yaml
+++ b/album/homestuck-vol-8.yaml
@@ -3,7 +3,7 @@ Directory Suffix: vol8
 Date: October 25, 2011
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-7-8-with-cherubim
+- https://homestuck.bandcamp.com/album/homestuck-vol-8
 - https://www.youtube.com/watch?v=-cIpWboujY4
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFa9Ssz0RANELG8eSoUeOQiC
 Cover Artists:
@@ -60,11 +60,11 @@ Commentary: |-
 
     That's it for now. More announcements soon.
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20111026195824/https://homestuck.bandcamp.com/album/homestuck-vol-8))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/homestuck-vol-8))
 
     37 tracks. 4 bonus tracks, including the [[Cascade (Beta)|first]] and [[Black Hole / Green Sun|final parts]] of [[Cascade]] as individual files. Also includes full-size versions of all track art!
 
-    <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20111026195824/https://homestuck.bandcamp.com/album/homestuck-vol-8))
+    <i>Homestuck:</i> ([Bandcamp about blurb](https://homestuck.bandcamp.com/album/homestuck-vol-8))
 
     Includes material by:
 
@@ -117,7 +117,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 3:38
 URLs:
-- https://homestuck.bandcamp.com/track/calamity-2
+- https://homestuck.bandcamp.com/track/calamity
 - https://youtu.be/oNeKbfEVi0g
 Cover Artists:
 - Tavia Morra
@@ -173,7 +173,7 @@ Artists:
 - Malcolm Brown
 Duration: 4:28
 URLs:
-- https://homestuck.bandcamp.com/track/do-you-remem8er-me-2
+- https://homestuck.bandcamp.com/track/do-you-remem8er-me
 - https://youtu.be/x8mLKTY5TWM
 Cover Artists:
 - Richard Gung
@@ -259,7 +259,7 @@ Artists:
 - Clark Powell
 Duration: 3:03
 URLs:
-- https://homestuck.bandcamp.com/track/flare-2
+- https://homestuck.bandcamp.com/track/flare
 - https://youtu.be/ktuDYYtbs2s
 Cover Artists:
 - Richard Gung
@@ -286,7 +286,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:36
 URLs:
-- https://homestuck.bandcamp.com/track/galactic-cancer-2
+- https://homestuck.bandcamp.com/track/galactic-cancer
 - https://youtu.be/ByBpRkrg9SA
 Cover Artists:
 - Lauren Ross
@@ -310,7 +310,7 @@ Artists:
 - Clark Powell
 Duration: 5:05
 URLs:
-- https://homestuck.bandcamp.com/track/serenade-2
+- https://homestuck.bandcamp.com/track/serenade
 - https://youtu.be/iQyr0eYN7hI
 Cover Artists:
 - clorinspats
@@ -334,7 +334,7 @@ Artists:
 - Erik Scheele
 Duration: 3:18
 URLs:
-- https://homestuck.bandcamp.com/track/frog-forager-2
+- https://homestuck.bandcamp.com/track/frog-forager
 - https://youtu.be/5KihK9orAi0
 Cover Artists:
 - Kaymurph
@@ -362,7 +362,7 @@ Artists:
 - Toby Fox
 Duration: 1:58
 URLs:
-- https://homestuck.bandcamp.com/track/love-you-feferis-theme-2
+- https://homestuck.bandcamp.com/track/love-you-feferis-theme
 - https://youtu.be/cmXzwEixV4s
 Cover Artists:
 - wodnesse
@@ -381,7 +381,7 @@ Contributors:
 - Tavia Morra
 Duration: 3:12
 URLs:
-- https://homestuck.bandcamp.com/track/ocean-stars-falling-2
+- https://homestuck.bandcamp.com/track/ocean-stars-falling
 - https://youtu.be/QmEZzp7o8i8
 Cover Artists:
 - Richard Gung
@@ -416,7 +416,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 2:58
 URLs:
-- https://homestuck.bandcamp.com/track/escape-pod-2
+- https://homestuck.bandcamp.com/track/escape-pod
 - https://youtu.be/GJo7ZH6p6wA
 Cover Artists:
 - Paige Turner
@@ -445,7 +445,7 @@ Artists:
 - Toby Fox
 Duration: 1:41
 URLs:
-- https://homestuck.bandcamp.com/track/davesprite-2
+- https://homestuck.bandcamp.com/track/davesprite
 - https://youtu.be/Iy5fKp-aV4o
 Cover Artists:
 - P-RO
@@ -476,7 +476,7 @@ Artists:
 - rj lake
 Duration: 4:50
 URLs:
-- https://homestuck.bandcamp.com/track/airtime-2
+- https://homestuck.bandcamp.com/track/airtime
 - https://youtu.be/HXPviQw2n7Q
 Cover Artists:
 - Tavia Morra
@@ -510,7 +510,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 4:15
 URLs:
-- https://homestuck.bandcamp.com/track/frog-hunt-2
+- https://homestuck.bandcamp.com/track/frog-hunt
 - https://youtu.be/VkYB3Fw4bLw
 Cover Artists:
 - Tavia Morra
@@ -552,7 +552,7 @@ Contributors:
 - Thomas Ferkol (electric guitar)
 Duration: 4:35
 URLs:
-- https://homestuck.bandcamp.com/track/terraform-2
+- https://homestuck.bandcamp.com/track/terraform
 - https://youtu.be/bWp5uUxarAQ
 Cover Artists:
 - Richard Gung
@@ -581,7 +581,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:54
 URLs:
-- https://homestuck.bandcamp.com/track/unite-synchronization-2
+- https://homestuck.bandcamp.com/track/unite-synchronization
 - https://youtu.be/uHmXe2eY6Kg
 Cover Artists:
 - Rebecca Harding
@@ -695,7 +695,7 @@ Artists:
 - Hilary Troiano
 Duration: 4:28
 URLs:
-- https://homestuck.bandcamp.com/track/homefree-2
+- https://homestuck.bandcamp.com/track/homefree
 - https://youtu.be/7aYso7j8wsw
 Cover Artists:
 - Killian Ng
@@ -733,7 +733,7 @@ Artists:
 - Mark J. Hadley
 Duration: 2:54
 URLs:
-- https://homestuck.bandcamp.com/track/galaxy-hearts-2
+- https://homestuck.bandcamp.com/track/galaxy-hearts
 - https://youtu.be/YQX0TWA_x6Q
 Cover Artists:
 - Rachel Weiss
@@ -750,7 +750,7 @@ Artists:
 - Erik Scheele
 Duration: 2:50
 URLs:
-- https://homestuck.bandcamp.com/track/scourge-sisters-2
+- https://homestuck.bandcamp.com/track/scourge-sisters
 - https://youtu.be/srAkO5O1QaM
 Cover Artists:
 - Rebecca Harding
@@ -765,7 +765,7 @@ Artists:
 - rj lake
 Duration: 2:56
 URLs:
-- https://homestuck.bandcamp.com/track/arcade-thunder-2
+- https://homestuck.bandcamp.com/track/arcade-thunder
 - https://youtu.be/2JJJTSs_JeA
 Cover Artists:
 - Maf
@@ -791,7 +791,7 @@ Artists:
 - rj lake
 Duration: 2:50
 URLs:
-- https://homestuck.bandcamp.com/track/pyrocumulus-sicknasty-2
+- https://homestuck.bandcamp.com/track/pyrocumulus-sicknasty
 - https://youtu.be/4BqRC-ZPovM
 Cover Artists:
 - celestialKarakul
@@ -809,7 +809,7 @@ Artists:
 - Clark Powell
 Duration: 2:44
 URLs:
-- https://homestuck.bandcamp.com/track/kingside-castle-2
+- https://homestuck.bandcamp.com/track/kingside-castle
 - https://youtu.be/qYKxzWbrZ0c
 Cover Artists:
 - Nic Carey
@@ -822,7 +822,7 @@ Artists:
 - rj lake
 Duration: 3:37
 URLs:
-- https://homestuck.bandcamp.com/track/temporary-2
+- https://homestuck.bandcamp.com/track/temporary
 - https://youtu.be/CYh1OlRWzp4
 Cover Artists:
 - Chaz Canterbury
@@ -844,7 +844,7 @@ Contributors:
 - Clark Powell (additional sequencing)
 Duration: 4:17
 URLs:
-- https://homestuck.bandcamp.com/track/gust-of-heir-2
+- https://homestuck.bandcamp.com/track/gust-of-heir
 - https://youtu.be/pGlTekY3qZI
 Cover Artists:
 - Fibug
@@ -872,7 +872,7 @@ Artists:
 - rj lake
 Duration: 3:00
 URLs:
-- https://homestuck.bandcamp.com/track/afraid-of-the-darko-2
+- https://homestuck.bandcamp.com/track/afraid-of-the-darko
 - https://youtu.be/PSbPXcKGYto
 Cover Artists:
 - rj lake
@@ -886,7 +886,7 @@ Artists:
 - Tavia Morra
 Duration: 4:08
 URLs:
-- https://homestuck.bandcamp.com/track/even-in-death-tmorras-belly-mix-2
+- https://homestuck.bandcamp.com/track/even-in-death-tmorras-belly-mix
 - https://youtu.be/9MdltybiL00
 Cover Artists:
 - Tavia Morra
@@ -931,7 +931,7 @@ Artists:
 - Thomas Ferkol
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/bargaining-with-the-beast-2
+- https://homestuck.bandcamp.com/track/bargaining-with-the-beast
 - https://youtu.be/2HT5FcjHt1s
 Track Artwork:
 - Artists:
@@ -964,7 +964,7 @@ Contributors:
 - Marcy Nabors (flute)
 Duration: 3:51
 URLs:
-- https://homestuck.bandcamp.com/track/frostbite-2
+- https://homestuck.bandcamp.com/track/frostbite
 - https://youtu.be/Gdb_nZs6plw
 Cover Artists:
 - Nic Carey
@@ -983,7 +983,7 @@ Artists:
 - Toby Fox
 Duration: 2:54
 URLs:
-- https://homestuck.bandcamp.com/track/the-lost-child-2
+- https://homestuck.bandcamp.com/track/the-lost-child
 - https://youtu.be/-OFQHEy5TDw
 Cover Artists:
 - Sarah Fu
@@ -1001,7 +1001,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:13
 URLs:
-- https://homestuck.bandcamp.com/track/questants-lament-2
+- https://homestuck.bandcamp.com/track/questants-lament
 - https://youtu.be/ILt6Qyxc1bw
 Cover Artists:
 - Fibug
@@ -1018,7 +1018,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:46
 URLs:
-- https://homestuck.bandcamp.com/track/hussie-hunt-2
+- https://homestuck.bandcamp.com/track/hussie-hunt
 - https://youtu.be/oz4UOqdFQEA
 Cover Artists:
 - Hanni Brosh
@@ -1046,7 +1046,7 @@ Artists:
 - Svix
 Duration: 2:35
 URLs:
-- https://homestuck.bandcamp.com/track/havoc-2
+- https://homestuck.bandcamp.com/track/havoc
 - https://youtu.be/Wq0SjupReyA
 Cover Artists:
 - Emi
@@ -1072,7 +1072,7 @@ Contributors:
 - Toby Fox (climax drum programming)
 Duration: 3:22
 URLs:
-- https://homestuck.bandcamp.com/track/drift-into-the-sun-2
+- https://homestuck.bandcamp.com/track/drift-into-the-sun
 - https://youtu.be/f5BP2W9a93U
 Cover Artists:
 - Zilon
@@ -1099,7 +1099,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:20
 URLs:
-- https://homestuck.bandcamp.com/track/infinity-mechanism-2
+- https://homestuck.bandcamp.com/track/infinity-mechanism
 - https://youtu.be/I3S8LNG4aNo
 Cover Artists:
 - VickyBit
@@ -1127,7 +1127,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 2:33
 URLs:
-- https://homestuck.bandcamp.com/track/revered-return-2
+- https://homestuck.bandcamp.com/track/revered-return
 - https://youtu.be/x3ruWSdc1Vo
 Cover Artists:
 - Noot
@@ -1164,7 +1164,7 @@ Contributors:
 - Noel Sadwin (violin)
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/judgment-day-2
+- https://homestuck.bandcamp.com/track/judgment-day
 - https://youtu.be/MD2TLTtyfDE
 # https://lazili.tumblr.com/post/11921886689/also-did-track-art-for-judgement-day-woo
 Cover Artists:
@@ -1182,7 +1182,7 @@ Artists:
 - Seth Peelle
 Duration: 4:05
 URLs:
-- https://homestuck.bandcamp.com/track/lotus-bloom-2
+- https://homestuck.bandcamp.com/track/lotus-bloom
 - https://youtu.be/RrIofwv86HM
 Cover Artists:
 - myluckyseven
@@ -1202,7 +1202,7 @@ Contributors:
 - Toby Fox (editing)
 Duration: 13:14
 URLs:
-- https://homestuck.bandcamp.com/track/cascade-2
+- https://homestuck.bandcamp.com/track/cascade
 - https://youtu.be/Ckr6KyZoS58
 Referenced Tracks:
 - Cascade (Beta)
@@ -1243,7 +1243,7 @@ Artists:
 - David Ko
 Duration: 2:50
 URLs:
-- https://homestuck.bandcamp.com/track/im-a-member-of-the-midnight-crew-acapella-2
+- https://homestuck.bandcamp.com/track/im-a-member-of-the-midnight-crew-acapella
 - https://youtu.be/Br294PLbHBA
 Cover Artists:
 - Killian Ng
@@ -1321,7 +1321,6 @@ Contributors:
 - David Ko (backup vocals)
 Duration: 3:23
 URLs:
-- https://homestuck.bandcamp.com/track/how-do-i-live-d8-night-version-2
 - https://youtu.be/tJWO4WaQh_Y
 Cover Artists:
 - Victoria Grace Elliott
@@ -1388,7 +1387,6 @@ Artists:
 - Tensei
 Duration: 4:06
 URLs:
-- https://homestuck.bandcamp.com/track/cascade-beta-2
 - https://youtu.be/Svy9DBBZKpk
 Referenced Tracks:
 - Descend2 (11/24)
@@ -1414,7 +1412,6 @@ Contributors:
 - Noel Sadwin (violin)
 Duration: 2:30
 URLs:
-- https://homestuck.bandcamp.com/track/black-hole-green-sun-2
 - https://youtu.be/B6e2XacZSIs
 Referenced Tracks:
 - Black Rose / Green Sun
@@ -1433,7 +1430,6 @@ Artists:
 - Mark J. Hadley
 Duration: 2:08
 URLs:
-- https://homestuck.bandcamp.com/track/carefree-action-2
 - https://youtu.be/saFRtTDSVKQ
 Cover Artists:
 - 8bitkitten

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -2,7 +2,7 @@ Album: Homestuck Vol. 9
 Date: June 12, 2012
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-9-10-with-s-collide-and-act-7
+- https://homestuck.bandcamp.com/album/homestuck-vol-9
 - https://www.youtube.com/watch?v=n1BVIEipjwk
 - https://www.youtube.com/playlist?list=PLy5UGIMKOXpOfcXVfECYjb09aHc2uSEUv
 Cover Artists:
@@ -54,11 +54,11 @@ Commentary: |-
 
     There are plans for more albums [[album:symphony-impossible-to-play|later]] [[album:one-year-older|this]] [[album:genesis-frog|summer]]. You may begin anticipating them starting exactly now.
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20120615174232/https://homestuck.bandcamp.com/album/homestuck-vol-9))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/homestuck-vol-9))
 
     Also contains large-sized track art images for the tracks with art larger than 350x350.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120615174232/https://homestuck.bandcamp.com/album/homestuck-vol-9))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/homestuck-vol-9))
 
     Contains material by:
 
@@ -104,7 +104,7 @@ Artists:
 - Riki Tsuji
 Duration: 5:13
 URLs:
-- https://homestuck.bandcamp.com/track/crystalmethequins-2
+- https://homestuck.bandcamp.com/track/crystalmethequins
 - https://youtu.be/r8rWfPPrKJ0
 Cover Artists:
 - Richard Gung
@@ -139,7 +139,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:19
 URLs:
-- https://homestuck.bandcamp.com/track/anbroids-v20-2
+- https://homestuck.bandcamp.com/track/anbroids-v20
 - https://youtu.be/AVPmUpN_W3o
 Cover Artists:
 - Jonathan Griffiths
@@ -224,7 +224,7 @@ Artists:
 - Svix
 Duration: 3:52
 URLs:
-- https://homestuck.bandcamp.com/track/trepidation-2
+- https://homestuck.bandcamp.com/track/trepidation
 - https://youtu.be/WxLtO42_AJQ
 Cover Artists:
 - Kiko B.
@@ -247,7 +247,7 @@ Artists:
 - Buzinkai
 Duration: 1:08
 URLs:
-- https://homestuck.bandcamp.com/track/firefly-2
+- https://homestuck.bandcamp.com/track/firefly
 - https://youtu.be/KC9v0nOnDK8
 Track Artwork:
 - File Extension: gif
@@ -268,7 +268,7 @@ Artists:
 - rj lake
 Duration: 3:59
 URLs:
-- https://homestuck.bandcamp.com/track/whistling-jackhammer-2
+- https://homestuck.bandcamp.com/track/whistling-jackhammer
 - https://youtu.be/a9ExRM4xlw8
 Track Artwork:
 - File Extension: gif
@@ -297,7 +297,7 @@ Artists:
 - rj lake
 Duration: 3:22
 URLs:
-- https://homestuck.bandcamp.com/track/ugly-betty-2
+- https://homestuck.bandcamp.com/track/ugly-betty
 - https://youtu.be/EdCZ1kKzb8A
 Cover Artists:
 - Tavia Morra
@@ -326,7 +326,7 @@ Contributors:
 - Azami (laughter)
 Duration: 2:53
 URLs:
-- https://homestuck.bandcamp.com/track/hate-you-2
+- https://homestuck.bandcamp.com/track/hate-you
 - https://youtu.be/2gU_54ibyKM
 Track Artwork:
 - Artists:
@@ -374,7 +374,7 @@ Artists:
 - Malcolm Brown
 Duration: 3:54
 URLs:
-- https://homestuck.bandcamp.com/track/pumpkin-party-in-sea-hitlers-water-apocalypse-2
+- https://homestuck.bandcamp.com/track/pumpkin-party-in-sea-hitlers-water-apocalypse
 - https://youtu.be/LgG8lAVh-EA
 Cover Artists:
 - Sylladexter
@@ -444,7 +444,7 @@ Artists:
 - Mark J. Hadley
 Duration: 2:33
 URLs:
-- https://homestuck.bandcamp.com/track/skaianet-2
+- https://homestuck.bandcamp.com/track/skaianet
 - https://youtu.be/QLdoDAn290A
 Cover Artists:
 - Linnet
@@ -469,7 +469,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 4:39
 URLs:
-- https://homestuck.bandcamp.com/track/another-jungle-2
+- https://homestuck.bandcamp.com/track/another-jungle
 - https://youtu.be/upRmDHMcREg
 Cover Artists:
 - Richard Gung
@@ -514,7 +514,7 @@ Contributors:
 - Tavia Morra (vocals)
 Duration: 3:29
 URLs:
-- https://homestuck.bandcamp.com/track/gamegrl-original-1993-mix-2
+- https://homestuck.bandcamp.com/track/gamegrl-original-1993-mix
 - https://youtu.be/4kdVpq3bnuY
 Cover Artists:
 - Tavia Morra
@@ -658,7 +658,7 @@ Artists:
 - Toby Fox
 Duration: 2:21
 URLs:
-- https://homestuck.bandcamp.com/track/assault-2
+- https://homestuck.bandcamp.com/track/assault
 - https://youtu.be/4u_Gk9bH5_4
 Cover Artists:
 - Maf
@@ -673,7 +673,7 @@ Artists:
 Duration: 2:19
 Cover Art File Extension: jpg
 URLs:
-- https://homestuck.bandcamp.com/track/a-little-fight-mewsic-2
+- https://homestuck.bandcamp.com/track/a-little-fight-mewsic
 - https://youtu.be/O-EtZR02vGA
 Cover Artists:
 - Amethyst Barron
@@ -693,7 +693,7 @@ Artists:
 - Clark Powell
 Duration: 3:43
 URLs:
-- https://homestuck.bandcamp.com/track/austin-atlantis-2
+- https://homestuck.bandcamp.com/track/austin-atlantis
 - https://youtu.be/wPfUy4j9V7c
 Track Artwork:
 - File Extension: jpg
@@ -739,7 +739,7 @@ Commentary: |-
 
     Additional fun fact: the entire song is played off key, detuned into the spaces between quartertones. The piano itself is significantly flat. This surprised me in how far it went toward making the song sound "sunken."
 
-    Just in case one or two of you might not know, this song and fifty other great Homestuck tunes are all released together on [Volume 9](https://homestuck.bandcamp.com/album/homestuck-vol-9-10-with-s-collide-and-act-7)!
+    Just in case one or two of you might not know, this song and fifty other great Homestuck tunes are all released together on [Volume 9](https://homestuck.bandcamp.com/album/homestuck-vol-9)!
 
     <i>Nic Carey:</i> (track artist, [Tumblr](https://tynic.tumblr.com/post/24964072895/full-version-of-the-track-art-i-did-for-clark), 6/12/2012)
 
@@ -759,7 +759,7 @@ Artists:
 - Erik Scheele
 Duration: 3:36
 URLs:
-- https://homestuck.bandcamp.com/track/despot-2
+- https://homestuck.bandcamp.com/track/despot
 - https://youtu.be/O7CI8okTWSg
 Cover Artists:
 - Tavia Morra
@@ -795,7 +795,7 @@ Artists:
 - Toby Fox
 Duration: 2:02
 URLs:
-- https://homestuck.bandcamp.com/track/stress-2
+- https://homestuck.bandcamp.com/track/stress
 - https://youtu.be/RZGdkT96JDs
 Cover Artists:
 - P-RO
@@ -841,7 +841,7 @@ Contributors:
 - Tavia Morra (vocals)
 Duration: 2:47
 URLs:
-- https://homestuck.bandcamp.com/track/minihoofs-adventure-2
+- https://homestuck.bandcamp.com/track/minihoofs-adventure
 - https://youtu.be/KMyh7F9cyrE
 Cover Artists:
 - Tavia Morra
@@ -877,7 +877,7 @@ Artists:
 - Malcolm Brown
 Duration: 3:09
 URLs:
-- https://homestuck.bandcamp.com/track/encore-2
+- https://homestuck.bandcamp.com/track/encore
 - https://youtu.be/d8R1N5h3Mzc
 Cover Artists:
 - Bea
@@ -937,7 +937,7 @@ Artists:
 - Mark J. Hadley
 Duration: 2:29
 URLs:
-- https://homestuck.bandcamp.com/track/expedition-2
+- https://homestuck.bandcamp.com/track/expedition
 - https://youtu.be/UjUpiHOtjWs
 Cover Artists:
 - EsfiArt
@@ -966,7 +966,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 2:39
 URLs:
-- https://homestuck.bandcamp.com/track/elephant-gun-2
+- https://homestuck.bandcamp.com/track/elephant-gun
 - https://youtu.be/60Qjl1iyZ4U
 Track Artwork:
 - Artists:
@@ -1014,7 +1014,7 @@ Artists:
 - Nick Smalley
 Duration: 3:20
 URLs:
-- https://homestuck.bandcamp.com/track/miasmajesty-2
+- https://homestuck.bandcamp.com/track/miasmajesty
 - https://youtu.be/cfzEta7PCkk
 Cover Artists:
 - Tavia Morra
@@ -1032,7 +1032,7 @@ Artists:
 - rj lake
 Duration: 3:43
 URLs:
-- https://homestuck.bandcamp.com/track/jane-dargason-2
+- https://homestuck.bandcamp.com/track/jane-dargason
 - https://youtu.be/jSczYjYAaUY
 Cover Artists:
 - Dawn Davis
@@ -1054,7 +1054,7 @@ Commentary: |-
     First let me say that [[artist:rj-lake|RJ Lake]] is a joy to work with. We sent Jane Dargason back and forth between us, remixing each other's remixes until the track was in its final state. For reference:
 
     - The original sketch put together by RJ [[track:jane-dragon|sounded like this]].
-    - By the end of the process, things had [evolved quite a bit](https://homestuck.bandcamp.com/track/jane-dargason-2).
+    - By the end of the process, things had [evolved quite a bit](https://homestuck.bandcamp.com/track/jane-dargason).
 
     I also want to take a moment to say that my good friend [[artist:dawn-davis|Dawn]] did a spectacular job on the track art! She has a wondrous way with colors, and her drawings of the Homestuck kids have a childlike optimism about them. Nothing could have been a more perfect match for a track like this one!
 ---
@@ -1063,7 +1063,7 @@ Artists:
 - rj lake
 Duration: 4:27
 URLs:
-- https://homestuck.bandcamp.com/track/before-the-beginning-and-after-the-end-2
+- https://homestuck.bandcamp.com/track/before-the-beginning-and-after-the-end
 - https://youtu.be/Nab_SoEy8rk
 Cover Artists:
 - Tavia Morra
@@ -1085,7 +1085,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:35
 URLs:
-- https://homestuck.bandcamp.com/track/bridge-of-stars-2
+- https://homestuck.bandcamp.com/track/bridge-of-stars
 - https://youtu.be/yQSb3LMPk0Q
 Cover Artists:
 - 8bitkitten
@@ -1106,7 +1106,7 @@ Contributors:
 - Clark Powell (cello)
 Duration: 3:11
 URLs:
-- https://homestuck.bandcamp.com/track/cumulating-dreams-2
+- https://homestuck.bandcamp.com/track/cumulating-dreams
 - https://youtu.be/80ZicKue9yM
 Cover Artists:
 - Nyanface
@@ -1120,7 +1120,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 3:25
 URLs:
-- https://homestuck.bandcamp.com/track/busting-makes-me-feel-good-2
+- https://homestuck.bandcamp.com/track/busting-makes-me-feel-good
 - https://youtu.be/ObxMP2v6ke8
 Cover Artists:
 - Victoria Grace Elliott
@@ -1173,7 +1173,7 @@ Artists:
 - rj lake
 Duration: 3:06
 URLs:
-- https://homestuck.bandcamp.com/track/everything-is-something-to-somebody-2
+- https://homestuck.bandcamp.com/track/everything-is-something-to-somebody
 - https://youtu.be/reSPRXEtVmg
 Cover Artists:
 - Tavia Morra
@@ -1198,7 +1198,7 @@ Contributors:
 - Thomas Ferkol (electric guitar)
 Duration: 1:41
 URLs:
-- https://homestuck.bandcamp.com/track/irrrrrrrreconcila8le-2
+- https://homestuck.bandcamp.com/track/irrrrrrrreconcila8le
 - https://youtu.be/IyVUutdaP8E
 Cover Artists:
 - 8bitkitten
@@ -1227,7 +1227,7 @@ Contributors:
 - Marcy Nabors (theremin & accordion)
 Duration: 3:50
 URLs:
-- https://homestuck.bandcamp.com/track/im-a-member-of-the-midnight-crew-post-punk-version-2
+- https://homestuck.bandcamp.com/track/im-a-member-of-the-midnight-crew-post-punk-version
 - https://youtu.be/nU9YXh_0L4Y
 Cover Artists:
 - Cari Garafalo
@@ -1305,7 +1305,7 @@ Artists:
 - Erik Scheele
 Duration: 3:28
 URLs:
-- https://homestuck.bandcamp.com/track/three-in-the-morning-aftermath-2
+- https://homestuck.bandcamp.com/track/three-in-the-morning-aftermath
 - https://youtu.be/nkRwwNcIkEw
 Cover Artists:
 - Dawn Davis
@@ -1337,7 +1337,7 @@ Artists:
 - Clark Powell
 Duration: 3:51
 URLs:
-- https://homestuck.bandcamp.com/track/lancer-2
+- https://homestuck.bandcamp.com/track/lancer
 - https://youtu.be/C1L6GAcqAVE
 Track Artwork:
 - Artists:
@@ -1391,7 +1391,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:27
 URLs:
-- https://homestuck.bandcamp.com/track/threes-a-crowd-2
+- https://homestuck.bandcamp.com/track/threes-a-crowd
 - https://youtu.be/hBnCIpVQTls
 Cover Artists:
 - ari
@@ -1420,7 +1420,7 @@ Artists:
 - Kalibration
 Duration: 3:05
 URLs:
-- https://homestuck.bandcamp.com/track/break-shot-2
+- https://homestuck.bandcamp.com/track/break-shot
 - https://youtu.be/E07s837gHWE
 Track Artwork:
 - File Extension: jpg
@@ -1438,7 +1438,7 @@ Artists:
 - Solatrus
 Duration: 4:13
 URLs:
-- https://homestuck.bandcamp.com/track/portrait-2
+- https://homestuck.bandcamp.com/track/portrait
 - https://youtu.be/qkF5HxMd1LA
 Cover Artists:
 - Kate Holden
@@ -1478,7 +1478,7 @@ Artists:
 - Svix
 Duration: 2:36
 URLs:
-- https://homestuck.bandcamp.com/track/negative-aperture-2
+- https://homestuck.bandcamp.com/track/negative-aperture
 - https://youtu.be/x15fE5XGk1g
 Track Artwork:
 - File Extension: gif
@@ -1495,7 +1495,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:19
 URLs:
-- https://homestuck.bandcamp.com/track/sweet-dreams-timaeus-2
+- https://homestuck.bandcamp.com/track/sweet-dreams-timaeus
 - https://youtu.be/GhVCvz1sRdw
 Cover Artists:
 - Killian Ng
@@ -1516,7 +1516,7 @@ Artists:
 - Samm Neiland (composing assistance)
 Duration: 3:10
 URLs:
-- https://homestuck.bandcamp.com/track/red-miles-2
+- https://homestuck.bandcamp.com/track/red-miles
 - https://youtu.be/_7ulwTrNnTE
 Track Artwork:
 - Artists:
@@ -1567,7 +1567,7 @@ Artists:
 - Thomas Ferkol
 Duration: 4:12
 URLs:
-- https://homestuck.bandcamp.com/track/the-changing-game-2
+- https://homestuck.bandcamp.com/track/the-changing-game
 - https://youtu.be/a7UeOYYKrxg
 Track Artwork:
 - Artists:
@@ -1584,7 +1584,7 @@ Artists:
 - Clark Powell
 Duration: 4:32
 URLs:
-- https://homestuck.bandcamp.com/track/requited-2
+- https://homestuck.bandcamp.com/track/requited
 - https://youtu.be/k3QzERACr-Q
 Cover Artists:
 - dodostad
@@ -1611,7 +1611,7 @@ Commentary: |-
 
     For the artwork on this track I asked my chum [[artist:dodostad|Dodostad]] to draw something up. Her style of whimsical, faded character art seemed the perfect match for the song, and she did a magnificent job.
 
-    And of course, you can find Requited published on [Homestuck Volume 9](https://homestuck.bandcamp.com/album/homestuck-vol-9-10-with-s-collide-and-act-7).
+    And of course, you can find Requited published on [Homestuck Volume 9](https://homestuck.bandcamp.com/album/homestuck-vol-9).
 
     <i>dodostad:</i> (track artist, [Tumblr](https://dodostad.tumblr.com/post/24961331999/track-art-for-requited-by-clark-plazmataz-on), 6/13/2012)
 
@@ -1622,7 +1622,7 @@ Artists:
 - Clark Powell
 Duration: 2:12
 URLs:
-- https://homestuck.bandcamp.com/track/princess-of-helium-2
+- https://homestuck.bandcamp.com/track/princess-of-helium
 - https://youtu.be/mAgr3UH7ywo
 Cover Artists:
 - Tavia Morra
@@ -1654,7 +1654,7 @@ Contributors:
 - Clark Powell (cello)
 Duration: 2:21
 URLs:
-- https://homestuck.bandcamp.com/track/moonsetter-2
+- https://homestuck.bandcamp.com/track/moonsetter
 - https://youtu.be/75kJb_aAvKY
 Cover Artists:
 - Hanni Brosh
@@ -1700,7 +1700,7 @@ Contributors:
 - Alex Rosetti (mixing)
 Duration: 2:28
 URLs:
-- https://homestuck.bandcamp.com/track/candles-and-clockwork-alpha-version-2
+- https://homestuck.bandcamp.com/track/candles-and-clockwork-alpha-version
 - https://youtu.be/0aPJVZMW4xI
 Track Artwork:
 - Artists:
@@ -1797,7 +1797,7 @@ Artists:
 - Alex Rosetti
 Duration: 4:17
 URLs:
-- https://homestuck.bandcamp.com/track/coursing-2
+- https://homestuck.bandcamp.com/track/coursing
 - https://youtu.be/yzfiSLL9vOo
 Cover Artists:
 - Zilleniose
@@ -1818,7 +1818,7 @@ Artists:
 - Thomas Ferkol
 Duration: 3:43
 URLs:
-- https://homestuck.bandcamp.com/track/cairo-overcoat-2
+- https://homestuck.bandcamp.com/track/cairo-overcoat
 - https://youtu.be/PLYF-Zlfd2c
 Cover Artists:
 - Lauren Ross
@@ -1845,7 +1845,7 @@ Artists:
 - Kalibration
 Duration: 3:40
 URLs:
-- https://homestuck.bandcamp.com/track/battle-against-an-unfathomable-enemy-2
+- https://homestuck.bandcamp.com/track/battle-against-an-unfathomable-enemy
 - https://youtu.be/xtCo--GAAnA
 Cover Artists:
 - Molly Gur
@@ -1859,7 +1859,7 @@ Artists:
 - David Ellis
 Duration: 5:08
 URLs:
-- https://homestuck.bandcamp.com/track/noirscape-2
+- https://homestuck.bandcamp.com/track/noirscape
 - https://youtu.be/dG5BjK4194A
 Track Artwork:
 - Artists:
@@ -1931,7 +1931,7 @@ Commentary: |-
 
     <i>Kendle Iulus:</i> ([Tumblr](https://tzepesh.tumblr.com/post/24963148538/album-art-for-noirscape-which-you-can-listen-to), 6/12/2012)
 
-    album art for noirscape, which you can listen to [here](https://homestuck.bandcamp.com/track/noirscape-2)
+    album art for noirscape, which you can listen to [here](https://homestuck.bandcamp.com/track/noirscape)
 
     here is the reversed side
 ---
@@ -1947,7 +1947,7 @@ Contributors:
 - Ian White (trumpet & bass)
 Duration: 3:40
 URLs:
-- https://homestuck.bandcamp.com/track/dogfight-2
+- https://homestuck.bandcamp.com/track/dogfight
 - https://youtu.be/t7jg87kn5ps
 Cover Artists:
 - Molly Gur
@@ -1967,7 +1967,7 @@ Artists:
 - Seth Peelle
 Duration: 8:24
 URLs:
-- https://homestuck.bandcamp.com/track/a-taste-for-adventure-2
+- https://homestuck.bandcamp.com/track/a-taste-for-adventure
 - https://youtu.be/S4kIfIUSV6o
 Cover Artists:
 - minty
@@ -1989,7 +1989,7 @@ Artists:
 - Nick Smalley
 Duration: 1:24
 URLs:
-- https://homestuck.bandcamp.com/track/stargaze-2
+- https://homestuck.bandcamp.com/track/stargaze
 - https://youtu.be/ZTkdO7c4MEE
 Cover Artists:
 - Tavia Morra
@@ -2031,7 +2031,6 @@ Artists:
 - Michael Guy Bowman
 Duration: 1:20
 URLs:
-- https://homestuck.bandcamp.com/track/another-countdown-2
 - https://youtu.be/e71naCnOdwo
 Cover Artists:
 - Emery Ferguson
@@ -2068,7 +2067,6 @@ Artists:
 - Toby Fox
 Duration: 2:47
 URLs:
-- https://www.youtube.com/watch?v=om3VC6ru4yk
 - https://youtu.be/om3VC6ru4yk
 Track Artwork:
 - File Extension: jpg

--- a/album/medium.yaml
+++ b/album/medium.yaml
@@ -4,7 +4,7 @@ Artists:
 Date: April 14, 2011
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/symphony-impossible-to-play-with-medium
+- https://homestuck.bandcamp.com/album/medium
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFbC1xuvRB20jiuYub941wiM
 Cover Artists:
 - Cindy Dominguez
@@ -41,7 +41,7 @@ Commentary: |-
 
     This one's very cool. Clark has a great ambient sound, and her idea for the album was to musically express the Medium's planets, through both their elements and themes. I think she nailed it. Cover art was tag-teamed by me and Cindy (the lady who touches all your WP shirts).
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110418193336/https://homestuck.bandcamp.com/album/medium))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/medium))
 
     Cover art by [[artist:cindy-dominguez]] and [[artist:andrew-hussie]]
 ---
@@ -49,19 +49,19 @@ Track: Light
 Suffix Directory: true
 Duration: 5:36
 URLs:
-- https://homestuck.bandcamp.com/track/light-4
+- https://homestuck.bandcamp.com/track/light-2
 - https://youtu.be/WEVS8j6bcvI
 ---
 Track: Shade
 Duration: 5:46
 URLs:
-- https://homestuck.bandcamp.com/track/shade-2
+- https://homestuck.bandcamp.com/track/shade
 - https://youtu.be/uptvTul6I3Q
 ---
 Track: Rain
 Duration: 6:34
 URLs:
-- https://homestuck.bandcamp.com/track/rain-2
+- https://homestuck.bandcamp.com/track/rain
 - https://youtu.be/WWSphawicMY
 Referenced Tracks:
 - Skies of Skaia
@@ -69,20 +69,20 @@ Referenced Tracks:
 Track: Frogs
 Duration: 5:06
 URLs:
-- https://homestuck.bandcamp.com/track/frogs-2
+- https://homestuck.bandcamp.com/track/frogs
 - https://youtu.be/PI785pDsR88
 ---
 Track: Frost
 Suffix Directory: true
 Duration: 5:54
 URLs:
-- https://homestuck.bandcamp.com/track/frost-4
+- https://homestuck.bandcamp.com/track/frost-2
 - https://youtu.be/1Puozp2uaaM
 ---
 Track: Clockwork
 Duration: 5:13
 URLs:
-- https://homestuck.bandcamp.com/track/clockwork-2
+- https://homestuck.bandcamp.com/track/clockwork
 - https://youtu.be/AeUNnQ0ZkvA
 Referenced Tracks:
 - Westminster Quarters
@@ -91,7 +91,7 @@ Referenced Tracks:
 Track: Heat
 Duration: 5:12
 URLs:
-- https://homestuck.bandcamp.com/track/heat-2
+- https://homestuck.bandcamp.com/track/heat
 - https://youtu.be/l_ITpDhYvaI
 Sheet Music Files:
 - Title: Violin score by Liliumus
@@ -105,7 +105,7 @@ MIDI Project Files:
 Track: Wind
 Duration: 8:03
 URLs:
-- https://homestuck.bandcamp.com/track/wind-2
+- https://homestuck.bandcamp.com/track/wind
 - https://www.youtube.com/watch?v=lhLLRlt_bYQ
 Referenced Tracks:
 - Polovtsian Dances

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -3,7 +3,7 @@ Directory Suffix: mc-dd
 Date: February 4 2010
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-1-4-with-midnight-crew-drawing-dead
+- https://homestuck.bandcamp.com/album/midnight-crew-drawing-dead-2
 - https://www.youtube.com/watch?v=JQBK41qzhR4
 - https://www.youtube.com/playlist?list=PL83FE65DF950D7072
 Cover Artists:
@@ -95,7 +95,7 @@ Track Artwork:
   - Snowman
 Duration: 2:49
 URLs:
-- https://homestuck.bandcamp.com/track/three-in-the-morning-3
+- https://homestuck.bandcamp.com/track/three-in-the-morning
 - https://youtu.be/zSg6talwzbU
 Sheet Music Files:
 - Title: Sheet music by EuniverseCat
@@ -126,7 +126,7 @@ Track Artwork:
   - DD
 Duration: 0:55
 URLs:
-- https://homestuck.bandcamp.com/track/blue-noir-2
+- https://homestuck.bandcamp.com/track/blue-noir
 - https://youtu.be/YvMyo3opDOY
 Referenced Tracks:
 - Vagabounce
@@ -143,7 +143,7 @@ Track Artwork:
   - Alternia
 Duration: 2:17
 URLs:
-- https://homestuck.bandcamp.com/track/dead-shuffle-2
+- https://homestuck.bandcamp.com/track/dead-shuffle
 - https://youtu.be/jTIQhTdy4ZU
 Commentary: |-
     <i>Mark J. Hadley:</i> (via [[media:misc/commentary-collection.txt|early commentary collection]])
@@ -163,7 +163,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:12
 URLs:
-- https://homestuck.bandcamp.com/track/hearts-flush-2
+- https://homestuck.bandcamp.com/track/hearts-flush
 - https://youtu.be/nb7PoT9w6Tc
 Commentary: |-
     <i>Mark J. Hadley:</i> (via [[media:misc/commentary-collection.txt|early commentary collection]])
@@ -197,7 +197,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 1:10
 URLs:
-- https://homestuck.bandcamp.com/track/knives-and-ivory-2
+- https://homestuck.bandcamp.com/track/knives-and-ivory
 - https://youtu.be/D1C7y1u2K5M
 ---
 Track: Liquid Negrocity
@@ -214,7 +214,7 @@ Track Artwork:
   - Wasps
 Duration: 2:10
 URLs:
-- https://homestuck.bandcamp.com/track/liquid-negrocity-2
+- https://homestuck.bandcamp.com/track/liquid-negrocity
 - https://youtu.be/r8sBtl3WYZo
 Referenced Tracks:
 - track:liquid-negrocity-original
@@ -250,7 +250,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:24
 URLs:
-- https://homestuck.bandcamp.com/track/hollow-suit-2
+- https://homestuck.bandcamp.com/track/hollow-suit
 - https://youtu.be/k7El193pVkM
 Commentary: |-
     <i>Alex Rosetti:</i> ([Tumblr](https://albatrossthesoup.tumblr.com/post/46685117866/looking-back-at-midnight-crew-drawing-dead), excerpt)
@@ -278,7 +278,7 @@ Track Artwork:
   - Biscuits
 Duration: 2:33
 URLs:
-- https://homestuck.bandcamp.com/track/ante-matter-2
+- https://homestuck.bandcamp.com/track/ante-matter
 - https://youtu.be/2uYFtCSxoPk
 Commentary: |-
     <i>Mark J. Hadley:</i> (via [[media:misc/commentary-collection.txt|early commentary collection]])
@@ -297,7 +297,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 1:48
 URLs:
-- https://homestuck.bandcamp.com/track/the-ballad-of-jack-noir-2
+- https://homestuck.bandcamp.com/track/the-ballad-of-jack-noir
 - https://youtu.be/EAlt8IgOgPQ
 Referenced Tracks:
 - track:the-ballad-of-jack-noir-original
@@ -321,7 +321,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:59
 URLs:
-- https://homestuck.bandcamp.com/track/lunar-eclipse-2
+- https://homestuck.bandcamp.com/track/lunar-eclipse
 - https://youtu.be/06SVUSwu8Xk
 Commentary: |-
     <i>Michael Guy Bowman:</i> ([Music and Stuff](https://web.archive.org/web/20110326020456/http://www.iambowman.com/music.html))
@@ -351,7 +351,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 2:16
 URLs:
-- https://homestuck.bandcamp.com/track/hauntjam-2
+- https://homestuck.bandcamp.com/track/hauntjam
 - https://youtu.be/K9s0vr15Gvw
 Referenced Tracks:
 - track:haunt-andrew-hussie
@@ -392,7 +392,7 @@ Track Artwork:
   - DD
 Duration: 2:56
 URLs:
-- https://homestuck.bandcamp.com/track/carbon-nadsat-cuestick-genius-2
+- https://homestuck.bandcamp.com/track/carbon-nadsat-cuestick-genius
 - https://youtu.be/g5jyNbOePJ8
 Commentary: |-
     <i>rj lake:</i> ([[album:stuckhome-syndrome-part-one-v1|Stuckhome Syndrome]] [pre-order announcement](https://www.tumblr.com/spellmynamewithabang/140367744668/ok-actual-stuckhome-syndrome-big-post-and-whatever), excerpt, 3/2/2016)
@@ -409,7 +409,7 @@ Track Artwork:
   - Die
 Duration: 6:29
 URLs:
-- https://homestuck.bandcamp.com/track/ace-of-trump-2
+- https://homestuck.bandcamp.com/track/ace-of-trump
 - https://youtu.be/Leb48RHyrWs
 Commentary: |-
     <i>Hilary Troiano:</i> ([Tumblr](https://jaydeis.tumblr.com/post/19609363685/someone-sent-me-a-pm-asking-for-some-commentary), 3/19/2012)
@@ -450,7 +450,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:39
 URLs:
-- https://homestuck.bandcamp.com/track/moonshine-2
+- https://homestuck.bandcamp.com/track/moonshine
 - https://youtu.be/W5p7sEFMYHE
 Sheet Music Files:
 - Title: Sheet music by Gamehunter
@@ -482,7 +482,7 @@ Track Artwork:
   - Jack Noir
 Duration: 1:33
 URLs:
-- https://homestuck.bandcamp.com/track/tall-dark-and-loathsome-2
+- https://homestuck.bandcamp.com/track/tall-dark-and-loathsome
 - https://youtu.be/DxsUKjGirKc
 Sheet Music Files:
 - Title: Sheet music by Nocturne
@@ -499,7 +499,7 @@ Track Artwork:
   - Itchy
 Duration: 2:16
 URLs:
-- https://homestuck.bandcamp.com/track/jokers-wild-2
+- https://homestuck.bandcamp.com/track/jokers-wild
 - https://youtu.be/MDaWJUfxFCM
 Referenced Tracks:
 - Harlequin
@@ -516,7 +516,7 @@ Track Artwork:
   - Die
 Duration: 2:00
 URLs:
-- https://homestuck.bandcamp.com/track/livin-it-up-2
+- https://homestuck.bandcamp.com/track/livin-it-up
 - https://youtu.be/HPad4cPmEVI
 ---
 Track: Hauntjelly
@@ -533,7 +533,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:02
 URLs:
-- https://homestuck.bandcamp.com/track/hauntjelly-2
+- https://homestuck.bandcamp.com/track/hauntjelly
 - https://youtu.be/MccD13jZSTU
 Referenced Tracks:
 - track:hauntjam

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -382,6 +382,8 @@ Commentary: |-
 ---
 Track: Carbon Nadsat/Cuestick Genius
 Additional Names:
+- Name: Carbon Nadsat-Cuestick Genius
+  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20200707060737/https://homestuck.bandcamp.com/track/carbon-nadsat-cuestick-genius-2)
 - jazzjazzjazzthejazzatronjazzer (early name)
 Artists:
 - rj lake

--- a/album/midnight-crew-drawing-dead.yaml
+++ b/album/midnight-crew-drawing-dead.yaml
@@ -382,8 +382,10 @@ Commentary: |-
 ---
 Track: Carbon Nadsat/Cuestick Genius
 Additional Names:
-- Name: Carbon Nadsat-Cuestick Genius
-  Annotation: [Bandcamp compilation release](https://web.archive.org/web/20200707060737/https://homestuck.bandcamp.com/track/carbon-nadsat-cuestick-genius-2)
+- Name: >-
+    Carbon Nadsat-Cuestick Genius
+  Annotation: >-
+    [Bandcamp compilation release](https://web.archive.org/web/20200707060737/https://homestuck.bandcamp.com/track/carbon-nadsat-cuestick-genius-2)
 - jazzjazzjazzthejazzatronjazzer (early name)
 Artists:
 - rj lake

--- a/album/mobius-trip-and-hadron-kaleido.yaml
+++ b/album/mobius-trip-and-hadron-kaleido.yaml
@@ -37,7 +37,7 @@ Additional Files:
   Files:
   - banner.jpg
 Commentary: |-
-    <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20110603145529/https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido))
+    <i>Homestuck:</i> ([Bandcamp about blurb](https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido))
 
     *Mobius Trip and Hadron Kaleido, agents of Prospit and Derse. They once fought on the battlefield as their respective nemeses, only to be united by a common epiphany - the truth behind the Ultimate Riddle. Gazing upon the Skaian clouds, the secrets of the past, present, and future are now well guarded by these strange sentinels who spread enlightenment through their cryptic music and dance. Together, they hope their songs may be a beacon to all those who undertake the Riddle.*
 
@@ -111,7 +111,7 @@ Commentary: |-
 
     "What were your main inspirations for Mobius Trip and Hadron Kaleido?" I talked about that a little bit, of course Bowie comes to mind again. At the time I was really listening to BT, Brian Transeau - I think that's how you pronounce his last name - and he is a trance music pioneer. I'd been listening to This Binary Universe, and that was a really great album of instrumental electronic music. And then it had a wonderful follow-up album, that was called These Hopeful Machines, and I loved both those albums a lot. I think they were really... I refrain from saying eye-opening... because they were ear-opening.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110603145529/https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/mobius-trip-and-hadron-kaleido))
 
     Album art by [[artist:tavia-morra]] and [[artist:richard-gung]]
 ---

--- a/album/one-year-older.yaml
+++ b/album/one-year-older.yaml
@@ -56,7 +56,7 @@ Commentary: |-
 
     I knew that the album would be about John, so Jit and I agreed on this image of Dad Egbert celebrating John’s 13th birthday, and passing him this symbolic cake with the heir of breath symbol. I was really hoping to be able to write the album title on the cake itself but it kind of got pushed off onto the cake board, where it is barely visible in the thumbnail. Whoops!
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120818235214/https://homestuck.bandcamp.com/album/one-year-older))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/one-year-older))
 
     Composition and arrangement by [[artist:erik-scheele|Erik "Jit" Scheele]]
 

--- a/album/s-collide.yaml
+++ b/album/s-collide.yaml
@@ -3,7 +3,7 @@ Directory Suffix: collide
 Date: April 6, 2016
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-9-10-with-s-collide-and-act-7
+- https://homestuck.bandcamp.com/album/s-collide
 - https://www.youtube.com/watch?v=OcwqP0pMxGE
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFaNcNe2AtQUyDcLSJrzSQbe
 Cover Artists:
@@ -41,7 +41,7 @@ Art Tags:
 - LoPaN
 Duration: 1:56
 URLs:
-- https://homestuck.bandcamp.com/track/creata-canon-edit-2
+- https://homestuck.bandcamp.com/track/creata-canon-edit
 - https://youtu.be/43XGeVEiihM
 Referenced Tracks:
 - Creata
@@ -68,7 +68,7 @@ Contributors:
 - James Roach (editing, cheers)
 Duration: 5:39
 URLs:
-- https://homestuck.bandcamp.com/track/oppa-toby-style-2
+- https://homestuck.bandcamp.com/track/oppa-toby-style
 - https://youtu.be/bjAK8D5ytiU
 Referenced Tracks:
 - Rex English
@@ -111,7 +111,7 @@ Art Tags:
 - Dream Bubbles
 Duration: 3:34
 URLs:
-- https://homestuck.bandcamp.com/track/eternity-served-cold-canon-edit-2
+- https://homestuck.bandcamp.com/track/eternity-served-cold-canon-edit
 - https://youtu.be/Ow8PeoCrfcg
 Referenced Tracks:
 - Eternity Served Cold
@@ -132,7 +132,7 @@ Art Tags:
 - LoTaK
 Duration: 6:12
 URLs:
-- https://homestuck.bandcamp.com/track/heir-of-grief-2
+- https://homestuck.bandcamp.com/track/heir-of-grief
 - https://youtu.be/Es5mh7pBeec
 Referenced Tracks:
 - Heir of Grief

--- a/album/sburb.yaml
+++ b/album/sburb.yaml
@@ -21,7 +21,7 @@ Art Tags:
 - Jade
 - Skaia
 Commentary: |-
-    <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20110717121342/https://homestuck.bandcamp.com/album/sburb))
+    <i>Homestuck:</i> ([Bandcamp about blurb](https://homestuck.bandcamp.com/album/sburb))
 
     *Presenting Homestuck's first solo piano album! Also comes with sheet music for all tracks.*
 
@@ -33,7 +33,7 @@ Commentary: |-
 
     Are you running out of room on your ipod yet? You might have to start deleting some of that crappy non-HS music soon.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110717121342/https://homestuck.bandcamp.com/album/sburb))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/sburb))
 
     Composed by [[artist:james-dever]], performed by [[artist:erik-scheele|Erik "Jit" Scheele]]
 

--- a/album/showtime-svix-mix.yaml
+++ b/album/showtime-svix-mix.yaml
@@ -32,10 +32,10 @@ Commentary: |-
 
     <i>Svix:</i> ([FurAffinity description](https://www.furaffinity.net/view/2768815/), continued from above)
 
-    Remix of the battle theme from Homestuck, an amazingly quirky and hilarious story based on old text input adventure games. Original can be found [here](https://homestuck.bandcamp.com/track/showtime-original-mix-3).
+    Remix of the battle theme from Homestuck, an amazingly quirky and hilarious story based on old text input adventure games. Original can be found [here](https://homestuck.bandcamp.com/track/showtime-original-mix-2).
 
     <3 Chiptune.
 Crediting Sources: |-
     <i>Svix:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120425114028/http://svix.bandcamp.com/track/showtime-svix-mix))
 
-    Original by [[artist:malcolm-brown]]: [homestuck.bandcamp.com/track/showtime-original-mix](https://homestuck.bandcamp.com/track/showtime-original-mix-3)
+    Original by [[artist:malcolm-brown]]: [homestuck.bandcamp.com/track/showtime-original-mix](https://homestuck.bandcamp.com/track/showtime-original-mix-2)

--- a/album/song-of-skaia.yaml
+++ b/album/song-of-skaia.yaml
@@ -31,7 +31,7 @@ Commentary: |-
 
     On that note, I'll make an announcement about plans for the next album shortly. Preemptive tl;dr - it will be a contest. Details soon.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120103115600/https://homestuck.bandcamp.com/album/song-of-skaia))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/song-of-skaia))
 
     Created by [[artist:mark-j-hadley|Mark Hadley]]
 

--- a/album/squiddles.yaml
+++ b/album/squiddles.yaml
@@ -2,6 +2,7 @@ Album: Squiddles!
 Date: August 26, 2010
 Date Added: November 15, 2019
 URLs:
+- https://homestuck.bandcamp.com/album/squiddles
 - https://www.youtube.com/playlist?list=PLy5UGIMKOXpONMExgI7lVYFwQa54QFp_H
 Cover Artists:
 - Cindy Dominguez
@@ -81,11 +82,11 @@ Commentary: |-
 
     Lost to the sands of time! The Squiddles album. I'm not familiar with the entire history of how the art team's work went, but I do know a bit about the Squiddles album, and their association with it - which was that they made the Squiddles! cartoon intro, and wanted to do this whole, like, oh, we're going to figure out a way to make a Squiddles spinoff pilot. I wish that it'd really gone somewhere. I think we did a good job establishing the kind of, like, on the surface, you know, show for babies thing - um, that was actually secretly some... satanic eldritch horror thing. But I played it completely straight on all of my pieces for it.
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20100828115437/https://homestuck.bandcamp.com/album/squiddles))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/squiddles))
 
     COOL BONUSES INCLUDED: Squiddles animation (in .swf format) and PDF booklet with lyrics and credits!
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20100828115437/https://homestuck.bandcamp.com/album/squiddles))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/squiddles))
 
     Album by these fine musicians:<br>
     [[artist:alex-rosetti|Alexander Rosetti]]<br>
@@ -123,6 +124,7 @@ Artists:
 - Alex Rosetti
 Duration: 2:54
 URLs:
+- https://homestuck.bandcamp.com/track/squiddles
 - https://youtu.be/fXo6q-jENfE
 Lyrics: |-
     Squeedle dee dee
@@ -210,6 +212,7 @@ Contributors:
 - Alex Rosetti (remix)
 Duration: 1:10
 URLs:
+- https://homestuck.bandcamp.com/track/rainbow-valley
 - https://youtu.be/MrOqTjNrB2Q
 ---
 Track: Squiddle Parade
@@ -217,6 +220,7 @@ Artists:
 - artist:ian-taylor
 Duration: 0:50
 URLs:
+- https://homestuck.bandcamp.com/track/squiddle-parade
 - https://youtu.be/gqd8XTRwzoI
 Referenced Tracks:
 - Homestuck Anthem
@@ -232,6 +236,7 @@ Artists:
 - Erik Scheele
 Duration: 1:09
 URLs:
+- https://homestuck.bandcamp.com/track/squiddle-march
 - https://youtu.be/6l7shCvDXUU
 - https://soundcloud.com/erikscheele/squidmarch
 Commentary: |-
@@ -244,6 +249,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 4:15
 URLs:
+- https://homestuck.bandcamp.com/track/tangled-waltz
 - https://youtu.be/3KdAsyPq4UM
 Commentary: |-
     <i>Michael Guy Bowman:</i> ([Music and Stuff](https://web.archive.org/web/20110326020456/http://www.iambowman.com/music.html))
@@ -259,6 +265,7 @@ Artists:
 - Alex Rosetti
 Duration: 1:41
 URLs:
+- https://homestuck.bandcamp.com/track/sun-speckled-squiddly-afternoon
 - https://youtu.be/faRVzG1TZus
 Referenced Tracks:
 - Squiddles!
@@ -268,6 +275,7 @@ Artists:
 - Erik Scheele
 Duration: 5:16
 URLs:
+- https://homestuck.bandcamp.com/track/squiddles-campfire
 - https://youtu.be/sBi2kKCDDCk
 Sheet Music Files:
 - Title: Sheet music by Goatmon
@@ -279,6 +287,7 @@ Artists:
 - Seth Peelle
 Duration: 3:43
 URLs:
+- https://homestuck.bandcamp.com/track/friendship-is-paramount
 - https://youtu.be/X0DmGl7AJIU
 Referenced Tracks:
 - Squiddles!
@@ -299,6 +308,7 @@ Artists:
 - Steve Everson
 Duration: 1:15
 URLs:
+- https://homestuck.bandcamp.com/track/lazybones
 - https://youtu.be/15iiMuYvA_Q
 ---
 Track: Tentacles
@@ -306,6 +316,7 @@ Artists:
 - rj lake
 Duration: 1:57
 URLs:
+- https://homestuck.bandcamp.com/track/tentacles
 - https://youtu.be/LMfO0Z_E878
 Lyrics: |-
     (Hey, Squiddle G.)
@@ -355,6 +366,7 @@ Artists:
 - rj lake
 Duration: 1:43
 URLs:
+- https://homestuck.bandcamp.com/track/squiddles-happytime-fun-go
 - https://youtu.be/uXBAl4pd7gA
 ---
 Track: The Sound of Pure Squid Giggles
@@ -364,6 +376,7 @@ Contributors:
 - Alex Rosetti (remix)
 Duration: 1:22
 URLs:
+- https://homestuck.bandcamp.com/track/the-sound-of-pure-squid-giggles
 - https://youtu.be/9tOJOpn1UD0
 ---
 Track: Squiddle Samba
@@ -371,6 +384,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 3:05
 URLs:
+- https://homestuck.bandcamp.com/track/squiddle-samba
 - https://youtu.be/U1H0Q6FjGyc
 Commentary: |-
     <i>Michael Guy Bowman:</i> ([new Homestuck album!](https://web.archive.org/web/20100618035217/http://www.iambowman.com/), 06/13/2010)
@@ -388,6 +402,7 @@ Contributors:
 - Alex Rosetti (Squiddle voices)
 Duration: 4:11
 URLs:
+- https://homestuck.bandcamp.com/track/squiddles-in-paradise
 - https://youtu.be/2YG_6ke8X0o
 Referenced Tracks:
 - Squiddles!
@@ -479,6 +494,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:00
 URLs:
+- https://homestuck.bandcamp.com/track/squiddidle
 - https://youtu.be/gyqSztKs_6o
 ---
 Track: Catchyegrabber (Skipper Plumbthroat's Song)
@@ -488,6 +504,7 @@ Contributors:
 - Toby Fox (Skipper Plumbthroat)
 Duration: 4:33
 URLs:
+- https://homestuck.bandcamp.com/track/catchyegrabber-skipper-plumbthroats-song
 - https://youtu.be/S3bsomR8W_w
 Lyrics: |-
     They call me Skipper Plumbthroat
@@ -558,6 +575,7 @@ Contributors:
 - Toby Fox (Skipper Plumbthroat)
 Duration: 2:51
 URLs:
+- https://homestuck.bandcamp.com/track/plumbthroat-gives-chase
 - https://youtu.be/4PfZu1AWTWI
 Referenced Tracks:
 - Catchyegrabber (Skipper Plumbthroat's Song)
@@ -586,6 +604,7 @@ Artists:
 - Toby Fox
 Duration: 1:51
 URLs:
+- https://homestuck.bandcamp.com/track/squiddles-the-movie-trailer-the-day-the-unicorns-couldnt-play
 - https://youtu.be/9lWRGynBNVs
 Referenced Tracks:
 - Squiddles!
@@ -601,6 +620,7 @@ Artists:
 - Alex Rosetti
 Duration: 2:16
 URLs:
+- https://homestuck.bandcamp.com/track/carefree-princess-berryboo
 - https://youtu.be/_Z8qT1GBhds
 Referenced Tracks:
 - track:carefree-action
@@ -614,6 +634,7 @@ Contributors:
 - Tavia Morra (additional vocals)
 Duration: 4:27
 URLs:
+- https://homestuck.bandcamp.com/track/mister-bowman-tells-you-about-the-squiddles
 - https://youtu.be/09eVHqwHWYM
 Lyrics: |-
     (Mister Bowman, can you tell us about the Squiddles?)
@@ -699,6 +720,7 @@ Artists:
 - Mark J. Hadley
 Duration: 2:09
 URLs:
+- https://homestuck.bandcamp.com/track/ocean-stars
 - https://youtu.be/gFWWC9vmSzQ
 MIDI Project Files:
 - Title: MIDI by IronInvoker47 (piano)
@@ -722,6 +744,7 @@ Artists:
 - rj lake
 Duration: 5:06
 URLs:
+- https://homestuck.bandcamp.com/track/let-the-squiddles-sleep-end-theme
 - https://youtu.be/mpn7lahHvEc
 Referenced Tracks:
 - Squiddles!

--- a/album/strife.yaml
+++ b/album/strife.yaml
@@ -5,6 +5,7 @@ Date: February 16, 2011
 Date Added: November 15, 2019
 URLs:
 - https://tenseimusic.bandcamp.com/album/homestuck-strife
+- https://homestuck.bandcamp.com/album/strife
 - https://www.youtube.com/watch?v=Oz2a5VxQZME
 - https://www.youtube.com/playlist?list=PLy5UGIMKOXpMJhJ_NDnOG3_3kzoa48HPM
 - https://open.spotify.com/album/0iHvPD8rM3hQa0qeVtPQ3t
@@ -28,11 +29,11 @@ Commentary: |-
 
     Speaking of sick, check the cover art by Tauhid. The dude can draw. If I ever stopped doing Homestuck, the whole enterprise could be kept aloft by the prepsterous amount of talent which appears to orbit me.
 
-    <i>Homestuck:</i> ([Bandcamp download blurb](https://web.archive.org/web/20110219143705/https://homestuck.bandcamp.com/album/strife))
+    <i>Homestuck:</i> ([Bandcamp download blurb](https://homestuck.bandcamp.com/album/strife))
 
     Album download also includes a hidden bonus track, plus PDF-format guitar and bass tabs for [[Heir Conditioning]]!
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110219143705/https://homestuck.bandcamp.com/album/strife))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/strife))
 
     Music by [[artist:tensei|Joren "Tensei" de Bruin]]
 
@@ -55,6 +56,7 @@ Track Artwork:
 Duration: 0:46
 URLs:
 - https://tenseimusic.bandcamp.com/track/stormspirit
+- https://homestuck.bandcamp.com/track/stormspirit
 - https://youtu.be/OxHcK4AJFmw
 - https://open.spotify.com/track/2ikfMrshmbKFQBtYYQnbFN
 Sheet Music Files:
@@ -71,6 +73,7 @@ Track Artwork:
 Duration: 3:53
 URLs:
 - https://tenseimusic.bandcamp.com/track/heir-conditioning
+- https://homestuck.bandcamp.com/track/heir-conditioning
 - https://youtu.be/vwUc_apgdo0
 - https://open.spotify.com/track/5fqROOwxqBNQCRepcjggRN
 Referenced Tracks:
@@ -95,6 +98,7 @@ Track Artwork:
 Duration: 4:01
 URLs:
 - https://tenseimusic.bandcamp.com/track/dance-of-thorns
+- https://homestuck.bandcamp.com/track/dance-of-thorns
 - https://youtu.be/3dKRKDn9ZJk
 - https://open.spotify.com/track/0vDWFzvLFRC6Ceh4Mxnq7H
 Referenced Tracks:
@@ -131,6 +135,7 @@ Track Artwork:
 Duration: 3:28
 URLs:
 - https://tenseimusic.bandcamp.com/track/time-on-my-side
+- https://homestuck.bandcamp.com/track/time-on-my-side
 - https://youtu.be/_zfOKIREJX8
 - https://open.spotify.com/track/7lgxvFZWOPgBJ0wh2TEvTQ
 Referenced Tracks:
@@ -186,6 +191,7 @@ Track Artwork:
 Duration: 4:20
 URLs:
 - https://tenseimusic.bandcamp.com/track/atomic-bonsai
+- https://homestuck.bandcamp.com/track/atomic-bonsai
 - https://youtu.be/ncLsScNc4ZY
 - https://open.spotify.com/track/1uALiYcM3gH8WDdxkAZotg
 Referenced Tracks:
@@ -211,6 +217,7 @@ Track Artwork:
 Duration: 4:05
 URLs:
 - https://tenseimusic.bandcamp.com/track/knifes-edge
+- https://homestuck.bandcamp.com/track/knifes-edge
 - https://youtu.be/eYdneOkIvvc
 - https://open.spotify.com/track/1FAzSLZ9oGXEEKJatuJ4IQ
 Referenced Tracks:

--- a/album/symphony-impossible-to-play.yaml
+++ b/album/symphony-impossible-to-play.yaml
@@ -5,7 +5,7 @@ Artists:
 Date: August 1, 2012
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/symphony-impossible-to-play-with-medium
+- https://homestuck.bandcamp.com/album/symphony-impossible-to-play
 - https://www.youtube.com/watch?v=CGj-hDDFktI
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFbZGlJ_NhUuG0yPfBRzFpfv
 Cover Artists:
@@ -55,7 +55,7 @@ Commentary: |-
 
     First album of the month: Symphony Impossible to Play by [[artist:clark-powell|Clark Powell]], who was also responsible for the album [[album:medium|"Medium"]], [["Homestuck Anthem"]] and quite a few other HS tracks. [[album:one-year-older|Next solo album coming in a couple weeks.]]
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20120802173203/https://homestuck.bandcamp.com/album/symphony-impossible-to-play))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/symphony-impossible-to-play))
 
     Cover art by [[artist:tavia-morra]]
 
@@ -68,7 +68,7 @@ Track: I - Overture
 Directory: overture
 Duration: 7:00
 URLs:
-- https://homestuck.bandcamp.com/track/i-overture-2
+- https://homestuck.bandcamp.com/track/i-overture
 - https://youtu.be/Fi311fNF09w
 Referenced Tracks:
 - Endless Climb
@@ -89,7 +89,7 @@ Contributors:
 - Erik Scheele (piano)
 Duration: 2:36
 URLs:
-- https://homestuck.bandcamp.com/track/ii-sarabande-2
+- https://homestuck.bandcamp.com/track/ii-sarabande
 - https://youtu.be/iADicSzT0VE
 Referenced Tracks:
 - track:sarabande-vol5
@@ -99,7 +99,7 @@ Directory: serenade
 Suffix Directory: true
 Duration: 5:44
 URLs:
-- https://homestuck.bandcamp.com/track/iii-serenade-2
+- https://homestuck.bandcamp.com/track/iii-serenade
 - https://youtu.be/wjvxf4QiHfU
 Referenced Tracks:
 - Serenade
@@ -109,7 +109,7 @@ Track: IV - Anthem
 Directory: anthem
 Duration: 3:48
 URLs:
-- https://homestuck.bandcamp.com/track/iv-anthem-2
+- https://homestuck.bandcamp.com/track/iv-anthem
 - https://youtu.be/FaT8T3030mA
 Referenced Tracks:
 - Homestuck Anthem

--- a/album/the-felt.yaml
+++ b/album/the-felt.yaml
@@ -2,7 +2,7 @@ Album: The Felt
 Date: December 2 2010
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/homestuck-vol-5-6-with-the-felt
+- https://homestuck.bandcamp.com/album/the-felt
 - https://www.youtube.com/watch?v=o76TAd1ExFE
 - https://www.youtube.com/playlist?list=PLlGklfYAdslavhtb5kUefK1V_ki5NvbVu
 Cover Artists:
@@ -49,7 +49,7 @@ Commentary: |-
 
     Self-titled debut album of the criminal, and now musical, archrivals of the Midnight Crew. The Felt's ever-present temporal machinations are here in full force, resulting in an orchestral creation quite unlike anything else you've heard.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20101206141645/https://homestuck.bandcamp.com/album/the-felt))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/the-felt))
 
     Music by:<br>
     [[artist:thomas-ferkol|Thomas "EidolonOrpheus" Ferkol]]<br>
@@ -75,7 +75,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 3:27
 URLs:
-- https://homestuck.bandcamp.com/track/jade-dragon-2
+- https://homestuck.bandcamp.com/track/jade-dragon
 - https://youtu.be/et0432j4c5s
 Referenced Tracks:
 - Viva la Vida
@@ -91,7 +91,7 @@ Track Artwork:
   - Clocks
 Duration: 5:58
 URLs:
-- https://homestuck.bandcamp.com/track/swing-of-the-clock-2
+- https://homestuck.bandcamp.com/track/swing-of-the-clock
 - https://youtu.be/kEGailT_BHs
 Referenced Tracks:
 - Three in the Morning
@@ -165,7 +165,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 3:54
 URLs:
-- https://homestuck.bandcamp.com/track/rhapsody-in-green-2
+- https://homestuck.bandcamp.com/track/rhapsody-in-green
 - https://youtu.be/O4x3DKbvi1Y
 ---
 Track: Humphrey's Lullaby
@@ -180,7 +180,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:06
 URLs:
-- https://homestuck.bandcamp.com/track/humphreys-lullaby-2
+- https://homestuck.bandcamp.com/track/humphreys-lullaby
 - https://youtu.be/N_Iddbz7p-k
 ---
 Track: Clockwork Reversal
@@ -195,7 +195,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 1:41
 URLs:
-- https://homestuck.bandcamp.com/track/clockwork-reversal-2
+- https://homestuck.bandcamp.com/track/clockwork-reversal
 - https://youtu.be/b9BtuKqfPkY
 Referenced Tracks:
 - Clockwork Apocalypse
@@ -222,7 +222,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 4:57
 URLs:
-- https://homestuck.bandcamp.com/track/chartreuse-rewind-2
+- https://homestuck.bandcamp.com/track/chartreuse-rewind
 - https://youtu.be/TBsDTu-NOkA
 Sheet Music Files:
 - Title: Sheet music by almostsix
@@ -269,7 +269,7 @@ Track Artwork:
   - Magic 8 Ball
 Duration: 3:10
 URLs:
-- https://homestuck.bandcamp.com/track/the-broken-clock-2
+- https://homestuck.bandcamp.com/track/the-broken-clock
 - https://youtu.be/Mmzhi4T6wtM
 MIDI Project Files:
 - Title: MIDI by Miff
@@ -291,7 +291,7 @@ Track Artwork:
   - Doze
 Duration: 2:51
 URLs:
-- https://homestuck.bandcamp.com/track/apocryphal-antithesis-2
+- https://homestuck.bandcamp.com/track/apocryphal-antithesis
 - https://youtu.be/PTd8rhHHyEs
 Referenced Tracks:
 - Endless Climb
@@ -308,7 +308,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 2:29
 URLs:
-- https://homestuck.bandcamp.com/track/trails-2
+- https://homestuck.bandcamp.com/track/trails
 - https://youtu.be/rzL0-oyDy7s
 Commentary: |-
     <i>Mark J. Hadley:</i> (via [[media:misc/commentary-collection.txt|early commentary collection]])
@@ -327,7 +327,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 4:06
 URLs:
-- https://homestuck.bandcamp.com/track/baroqueback-bowtier-scratchs-lament-2
+- https://homestuck.bandcamp.com/track/baroqueback-bowtier-scratchs-lament
 - https://youtu.be/leIKuIH2FIg
 Sheet Music Files:
 - Title: Sheet music by Kyntello
@@ -349,7 +349,7 @@ Track Artwork:
   - Scratch's apartment
 Duration: 3:10
 URLs:
-- https://homestuck.bandcamp.com/track/scratch-2
+- https://homestuck.bandcamp.com/track/scratch
 - https://youtu.be/3OVpWgisy0o
 Referenced Tracks:
 - Toccata and Fugue in D minor
@@ -397,7 +397,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 3:32
 URLs:
-- https://homestuck.bandcamp.com/track/omelette-sandwich-2
+- https://homestuck.bandcamp.com/track/omelette-sandwich
 - https://youtu.be/a1FivIzXv48
 MIDI Project Files:
 - Title: MIDI by Unknown
@@ -420,7 +420,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 3:49
 URLs:
-- https://homestuck.bandcamp.com/track/temporal-piano-2
+- https://homestuck.bandcamp.com/track/temporal-piano
 - https://youtu.be/rzNIMmObP3k
 ---
 Track: Time Paradox
@@ -438,7 +438,7 @@ Track Artwork:
   - 'cw: corpse'
 Duration: 3:06
 URLs:
-- https://homestuck.bandcamp.com/track/time-paradox-2
+- https://homestuck.bandcamp.com/track/time-paradox
 - https://youtu.be/96HRN6bFYqU
 Referenced Tracks:
 - Westminster Quarters
@@ -462,7 +462,7 @@ Track Artwork:
   - Felt Mansion
 Duration: 2:02
 URLs:
-- https://homestuck.bandcamp.com/track/eldritch-2
+- https://homestuck.bandcamp.com/track/eldritch
 - https://youtu.be/6hDMo_pcaD8
 Sheet Music Files:
 - Title: Piano score by almostsix
@@ -482,7 +482,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 3:30
 URLs:
-- https://homestuck.bandcamp.com/track/english-2
+- https://homestuck.bandcamp.com/track/english
 - https://youtu.be/6zMnNCDaKuE
 Sheet Music Files:
 - Title: Piano score by almostsix
@@ -509,7 +509,7 @@ Track Artwork:
   - 'cw: blood'
 Duration: 6:03
 URLs:
-- https://homestuck.bandcamp.com/track/variations-2
+- https://homestuck.bandcamp.com/track/variations
 - https://youtu.be/M966V66lLuE
 Referenced Tracks:
 - Rhapsody in Green

--- a/album/the-grubbles.yaml
+++ b/album/the-grubbles.yaml
@@ -4,7 +4,7 @@ Artists:
 Date: September 14, 2017 00:00:04
 Date Added: November 15, 2019
 URLs:
-- https://homestuck.bandcamp.com/album/hiveswap-act-1-ost-with-the-grubbles
+- https://homestuck.bandcamp.com/album/the-grubbles
 - https://www.youtube.com/playlist?list=PLo6jbRGXGrtjQOs-3_TbJ6SvFBUEhztgj
 Cover Artists:
 - The Grubbels
@@ -20,7 +20,7 @@ Contributors:
 - Jeff Liu (guitar)
 - Cohen Edenfield (lyrics)
 URLs:
-- https://homestuck.bandcamp.com/track/broom-temperature
+- https://homestuck.bandcamp.com/track/broom-temperature-2
 - https://youtu.be/HmPs0DNemyg
 Lyrics: |-
     [Drop to your knees, but come back up swingin'<br>Not just a broom but the truth that we're slingin'<br>Low and diiiirtyyy<br>Show y'all how to bring the hurt we<br>Have been hurt oftennnn
@@ -43,7 +43,7 @@ Contributors:
 - Jeff Liu (guitar)
 - Cohen Edenfield (lyrics)
 URLs:
-- https://homestuck.bandcamp.com/track/frondly-warning
+- https://homestuck.bandcamp.com/track/frondly-warning-2
 - https://youtu.be/5Bp4v_w5Y0o
 MIDI Project Files:
 - Title: MIDI by IronInvoker47 (piano)
@@ -64,7 +64,7 @@ Commentary: |-
 Track: Ghost Mound
 Duration: 2:02
 URLs:
-- https://homestuck.bandcamp.com/track/ghost-mound
+- https://homestuck.bandcamp.com/track/ghost-mound-2
 - https://youtu.be/QqJhLGGHqCk
 MIDI Project Files:
 - Title: MIDI by IronInvoker47 (piano)
@@ -74,7 +74,7 @@ MIDI Project Files:
 Track: Every Single Grievance
 Duration: 1:11
 URLs:
-- https://homestuck.bandcamp.com/track/every-single-grievance
+- https://homestuck.bandcamp.com/track/every-single-grievance-2
 - https://youtu.be/D8N_53-cjGU
 MIDI Project Files:
 - Title: MIDI by IronInvoker47 (piano)
@@ -84,7 +84,7 @@ MIDI Project Files:
 Track: Get The Horns
 Duration: 2:15
 URLs:
-- https://homestuck.bandcamp.com/track/get-the-horns
+- https://homestuck.bandcamp.com/track/get-the-horns-2
 - https://youtu.be/ZZbFo1W1TjQ
 Referenced Tracks:
 - Filthy Nuclear Bunker

--- a/album/the-wanderers.yaml
+++ b/album/the-wanderers.yaml
@@ -2,6 +2,7 @@ Album: The Wanderers
 Date: July 14, 2011
 Date Added: November 15, 2019
 URLs:
+- https://homestuck.bandcamp.com/album/the-wanderers
 - https://www.youtube.com/playlist?list=PLF3092FD8EA59F218
 Cover Artists:
 - Lauren Ross
@@ -17,7 +18,7 @@ Art Tags:
 - WK
 - Ruined Earth
 Commentary: |-
-    <i>Homestuck:</i> ([Bandcamp about blurb](https://web.archive.org/web/20110717121349/https://homestuck.bandcamp.com/album/the-wanderers))
+    <i>Homestuck:</i> ([Bandcamp about blurb](https://homestuck.bandcamp.com/album/the-wanderers))
 
     *413 years in the future, all is devastation. Great lakes are now empty pits, sprawling cities are now rubble, and humanity is now extinct, fossilized under the endless blanket of sand that covers the Earth.*
 
@@ -43,7 +44,7 @@ Commentary: |-
 
     This is something else I didn't get around to recording, but there's actually another lost Homestuck album. It was called The Wanderers. It was a compilation that I had two songs on. One was called [[Aimless Morning Gold]]. The other is [[Ruins Rising]]. [...] I really liked the whole desert-punk vibe of this record. If you feel like tracking this one down, be my guest - it's a really great record and I wish it were still up there.
 
-    <i>Homestuck:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20110717121349/https://homestuck.bandcamp.com/album/the-wanderers))
+    <i>Homestuck:</i> ([Bandcamp credits blurb](https://homestuck.bandcamp.com/album/the-wanderers))
 
     Includes music by:<br>
     [[artist:seth-peelle|Seth "Beatfox" Peelle]]<br>
@@ -93,6 +94,7 @@ Artists:
 - Seth Peelle
 Duration: 7:20
 URLs:
+- https://homestuck.bandcamp.com/track/carapacian-dominion
 - https://youtu.be/bhG6zJpC60c
 Cover Artists:
 - Sarah Fu
@@ -108,6 +110,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 3:48
 URLs:
+- https://homestuck.bandcamp.com/track/aimless-morning-gold
 - https://youtu.be/KrimTgZi5uk
 Cover Artists:
 - Leondra
@@ -121,6 +124,7 @@ Artists:
 - Erik Scheele
 Duration: 5:59
 URLs:
+- https://homestuck.bandcamp.com/track/endless-expanse
 - https://youtu.be/TktueKyYBKs
 Cover Artists:
 - Carla Bravo
@@ -137,6 +141,7 @@ Artists:
 - Solatrus
 Duration: 4:00
 URLs:
+- https://homestuck.bandcamp.com/track/gilded-sands
 - https://youtu.be/i5gsRSo3sMo
 Cover Artists:
 - Nyanface
@@ -170,6 +175,7 @@ Artists:
 - rj lake
 Duration: 4:35
 URLs:
+- https://homestuck.bandcamp.com/track/years-in-the-future
 - https://youtu.be/CadBaY2j6pE
 Cover Artists:
 - Shad Andrews
@@ -204,6 +210,7 @@ Artists:
 - Toby Fox
 Duration: 3:20
 URLs:
+- https://homestuck.bandcamp.com/track/mayor-maynot
 - https://youtu.be/d9KVN4WfHHc
 Cover Artists:
 - Shad Andrews
@@ -236,6 +243,7 @@ Artists:
 - Steve Everson
 Duration: 2:42
 URLs:
+- https://homestuck.bandcamp.com/track/we-walk
 - https://youtu.be/0DILZ3Qi_Wg
 Cover Artists:
 - Emi
@@ -264,6 +272,7 @@ Artists:
 - Solatrus (production)
 Duration: 2:01
 URLs:
+- https://homestuck.bandcamp.com/track/requiem-for-an-exile
 - https://youtu.be/aAphwUVKFm4
 Cover Artists:
 - Zilleniose
@@ -287,6 +296,7 @@ Artists:
 - Alex Rosetti
 Duration: 3:28
 URLs:
+- https://homestuck.bandcamp.com/track/raggy-looking-dance
 - https://youtu.be/kHSVHbxBEHU
 - https://albatrosssoup.bandcamp.com/track/raggy-looking-dance
 Cover Artists:
@@ -303,6 +313,7 @@ Artists:
 - Toby Fox
 Duration: 2:20
 URLs:
+- https://homestuck.bandcamp.com/track/riches-to-ruins-movements-i-ii
 - https://youtu.be/K7WRrBG6BM8
 Cover Artists:
 - Khoroshonov
@@ -316,6 +327,7 @@ Artists:
 - Malcolm Brown
 Duration: 5:00
 URLs:
+- https://homestuck.bandcamp.com/track/litrichean-rioghail
 - https://youtu.be/RtzNs4pH11Y
 Cover Artists:
 - Hanni Brosh
@@ -351,6 +363,7 @@ Artists:
 - Michael Guy Bowman
 Duration: 5:00
 URLs:
+- https://homestuck.bandcamp.com/track/ruins-rising
 - https://youtu.be/pDYCL68d3wI
 Track Artwork:
 - Artists:
@@ -392,6 +405,7 @@ Artists:
 - Alex Rosetti
 Duration: 2:46
 URLs:
+- https://homestuck.bandcamp.com/track/what-a-daring-dream
 - https://youtu.be/qtt0o-v2yco
 Track Artwork:
 - Artists:
@@ -462,6 +476,7 @@ Artists:
 - Malcolm Brown
 Duration: 4:13
 URLs:
+- https://homestuck.bandcamp.com/track/nightmare
 - https://youtu.be/CVxTL43Czuc
 Cover Artists:
 - wodnesse

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -206,7 +206,13 @@ Content: |-
     - added character tags: [[tag:ethan-adminstuck]], [[tag:jackson-adminstuck]], [[tag:jane-dave-janestuck]], [[tag:jane-jade-janestuck]], [[tag:jane-john-janestuck]], [[tag:jane-rose-janestuck]], [[tag:jane-roxy-janestuck]], [[tag:jordan-adminstuck]], [[tag:matt-adminstuck]] (thanks, Lan, Lilith!)
     <!-- additional name additions -->
     - added additional names to tracks: (thanks, Lan, Jackie, Whisper, Lilith!)
+        - [[track:carbon-nadsat-cuestick-genius]] (Bandcamp compilation release)
+        - [[track:bed-of-roses-dreams-of-derse]] (Bandcamp compilation release)
         - [[track:squiddle-march]] (SoundCloud)
+        - [[track:bl1nd-just1c3-1nv3st1g4t1on]] (Bandcamp compilation release)
+        - [[track:black-rose-green-sun]] (Bandcamp compilation release)
+        - [[track:john-sleeps-skaian-magicant]] (Bandcamp compilation release)
+        - [[track:black-hole-green-sun]] (Bandcamp compilation release)
         - [[track:under-the-hat]] (Tumblr filename)
         - [[track:capricious-mistress]] (Bandcamp, YouTube, SoundCloud)
         - [[track:fuchsia-ruler]] (Bandcamp)
@@ -220,12 +226,35 @@ Content: |-
     - added artist's lyrics to [[track:i-love-hussie]] and revised wiki lyrics (thanks, MoreEpicThanYou747, Geese, Whisper!)
     - added in-game lyrics to [[track:oh-one-true-love]] and [[track:oh-dungeon]] (thanks, ruby!)
     <!-- link additions -->
-    - added official Bandcamp listening links for solo albums [[album:mobius-trip-and-hadron-kaleido]], [[album:sburb]], [[album:prospit-and-derse]], [[album:song-of-skaia]], [[album:one-year-older]], and [[album:genesis-frog]] (thanks, Lan!)
+    - added official Bandcamp listening links for team & solo albums [[album:squiddles]], [[album:strife]], [[album:mobius-trip-and-hadron-kaleido]], [[album:sburb]], [[album:the-wanderers]], [[album:prospit-and-derse]], [[album:song-of-skaia]], [[album:one-year-older]], and [[album:genesis-frog]] (thanks, Lan, Lilith!)
     - added SoundCloud listening link for [[track:squiddle-march]] (thanks, Lilith, Lan!)
     - added SoundCloud listening link for [[track:heir-seer-knight-witch]] (thanks, Lilith, Lan!)
     - added Apple Music listening links for [[album:agents-of-reality]] (thanks, Lan!)
     - added Tumblr listening link to [[track:catscratch]] (thanks, Lilith, Lan!)
     - added Nintendo Music listening links across [[album:pokemon-sword-shield-super-music-collection]], and to [[track:bomb-rush-blush]], [[track:calamari-inkantation]], [[track:death-mountain-theme]], [[track:destiny-ablaze]], [[track:ending-theme-the-legend-of-zelda]], [[track:game-a-b-start-duck-hunt]], [[track:game-c-start-duck-hunt]], [[track:game-over-duck-hunt]], [[track:game-over-the-legend-of-zelda]], [[track:game-start-donkey-kong]], [[track:game-start-donkey-kong-jr]], [[track:ganon-is-defeated]], [[track:golden-hammer-wrecking-crew]], [[track:got-a-duck-duck-hunt]], [[track:hammer-bgm-donkey-kong]], [[track:hurry-up-donkey-kong]], [[track:id-purpose]], [[track:light-plane]], [[track:miss-duck-hunt]], [[track:now-or-never-splatoon]], [[track:opening-splatoon]], [[track:overworld-theme-the-legend-of-zelda]], [[track:perfect-duck-hunt]], [[track:phase-bgm-wrecking-crew]], [[track:prelude-ablaze]], [[track:round-1-and-2-clear-donkey-kong]], [[track:round-1-bgm-donkey-kong]], [[track:round-1-bgm-donkey-kong-jr]], [[track:round-1-clear-donkey-kong-jr]], [[track:round-3-clear-donkey-kong]], [[track:round-3-bgm-donkey-kong]], [[track:round-4-bgm-donkey-kong-jr]], [[track:round-4-clear-all-clear-donkey-kong-jr]], [[track:seaskape]], [[track:splattack]], [[track:tide-goes-out]], [[track:title-bgm-duck-hunt]], [[track:title-theme-the-legend-of-zelda]], and [[track:underworld-theme]] (thanks, ruby!)
+    - replaced 2019 Bandcamp compilation listening links with 2025 un-rerelease listening links for [[group:official]]! (thanks, Lilith!)
+        - replaced Bandcamp listening links for [[album:homestuck-vol-1]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-2]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-3]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-4]]!
+        - replaced Bandcamp listening links for [[album:midnight-crew-drawing-dead]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-5]]!
+        - replaced Bandcamp listening links for [[album:alternia]]!
+        - replaced Bandcamp listening links for [[album:the-felt]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-6]]!
+        - replaced Bandcamp listening links for [[album:alterniabound]]!
+        - replaced Bandcamp listening links for [[album:medium]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-7]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-1-4]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-8]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-9]]!
+        - replaced Bandcamp listening links for [[album:symphony-impossible-to-play]]!
+        - replaced Bandcamp listening links for [[album:cherubim]]!
+        - replaced Bandcamp listening links for [[album:s-collide]]!
+        - replaced Bandcamp listening links for [[album:act-7]]!
+        - replaced Bandcamp listening links for [[album:homestuck-vol-10]]!
+        - replaced Bandcamp listening links for [[album:the-grubbles]]!
+        - replaced Bandcamp listening links for [[album:hiveswap-act-1-ost]]!
     - replaced YouTube listening link for [[track:orange-hat]] with artist's upload (thanks, Lilith, Lan!)
     - replaced YouTube listening links for [[track:solar-voyage]] and [[track:renewed-return]] with artist's uploads (thanks, wertercatt, Lan!)
     - replaced Spotify listening links for [[track:celestial]], [[album:rakka-wake-01-opening-me]], and [[album:rakka-sp1-outside-2]] with link to single, rather than track (thanks, Lan, Whisper!)
@@ -298,6 +327,8 @@ Content: |-
     <!-- general removals -->
     - removed "(…) - Single" additional names automatically enforced on Apple Music and iTunes platforms, affecting [[track:black-richaadeb]], [[track:heir-of-grief-richaadeb]], [[track:dance-of-thorns-richaadeb]], [[track:oppa-toby-style]] (all [[artist:richaadeb]]), and [[album:dreamers-diarchy]] (thanks, Whisper, ruby!)
     - removed dead link in commentary for [[track:threxecute]] (thanks, Lilith!)
+    - removed dead Bandcamp listening links for [[track:the-thirteenth-hour]], [[track:theme]], [[track:walls-covered-in-blood-dx]], [[track:trollcops-radio-play]], [[track:catapult-capuchin]], [[track:science-seahorse]], [[track:a-fairy-battle]], [[track:the-blind-prophet]], [[track:alterniabound]], [[track:you-won-a-combat]], [[track:rest-a-while]], [[track:maplehoofs-adventure]], [[track:sburban-reversal]], [[track:white-host-green-room]], [[track:doctor-original-loop]], [[track:how-do-i-live-d8-night-version]], [[track:cascade-beta]], [[track:black-hole-green-sun]], [[track:carefree-action]], and [[track:another-countdown]]! (thanks, Lilith!)
+    - removed duplicate YouTube listening link for [[track:frustracean]] (thanks, Lilith!)
     - removed dead Bandcamp listening links across [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed dead Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     - removed dead SoundCloud listening link for [[track:bloodsucker-brawl]] (thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -206,13 +206,7 @@ Content: |-
     - added character tags: [[tag:ethan-adminstuck]], [[tag:jackson-adminstuck]], [[tag:jane-dave-janestuck]], [[tag:jane-jade-janestuck]], [[tag:jane-john-janestuck]], [[tag:jane-rose-janestuck]], [[tag:jane-roxy-janestuck]], [[tag:jordan-adminstuck]], [[tag:matt-adminstuck]] (thanks, Lan, Lilith!)
     <!-- additional name additions -->
     - added additional names to tracks: (thanks, Lan, Jackie, Whisper, Lilith!)
-        - [[track:carbon-nadsat-cuestick-genius]] (Bandcamp compilation release)
-        - [[track:bed-of-roses-dreams-of-derse]] (Bandcamp compilation release)
         - [[track:squiddle-march]] (SoundCloud)
-        - [[track:bl1nd-just1c3-1nv3st1g4t1on]] (Bandcamp compilation release)
-        - [[track:black-rose-green-sun]] (Bandcamp compilation release)
-        - [[track:john-sleeps-skaian-magicant]] (Bandcamp compilation release)
-        - [[track:black-hole-green-sun]] (Bandcamp compilation release)
         - [[track:under-the-hat]] (Tumblr filename)
         - [[track:capricious-mistress]] (Bandcamp, YouTube, SoundCloud)
         - [[track:fuchsia-ruler]] (Bandcamp)
@@ -226,35 +220,12 @@ Content: |-
     - added artist's lyrics to [[track:i-love-hussie]] and revised wiki lyrics (thanks, MoreEpicThanYou747, Geese, Whisper!)
     - added in-game lyrics to [[track:oh-one-true-love]] and [[track:oh-dungeon]] (thanks, ruby!)
     <!-- link additions -->
-    - added official Bandcamp listening links for team & solo albums [[album:squiddles]], [[album:strife]], [[album:mobius-trip-and-hadron-kaleido]], [[album:sburb]], [[album:the-wanderers]], [[album:prospit-and-derse]], [[album:song-of-skaia]], [[album:one-year-older]], and [[album:genesis-frog]] (thanks, Lan, Lilith!)
+    - added official Bandcamp listening links for solo albums [[album:mobius-trip-and-hadron-kaleido]], [[album:sburb]], [[album:prospit-and-derse]], [[album:song-of-skaia]], [[album:one-year-older]], and [[album:genesis-frog]] (thanks, Lan!)
     - added SoundCloud listening link for [[track:squiddle-march]] (thanks, Lilith, Lan!)
     - added SoundCloud listening link for [[track:heir-seer-knight-witch]] (thanks, Lilith, Lan!)
     - added Apple Music listening links for [[album:agents-of-reality]] (thanks, Lan!)
     - added Tumblr listening link to [[track:catscratch]] (thanks, Lilith, Lan!)
     - added Nintendo Music listening links across [[album:pokemon-sword-shield-super-music-collection]], and to [[track:bomb-rush-blush]], [[track:calamari-inkantation]], [[track:death-mountain-theme]], [[track:destiny-ablaze]], [[track:ending-theme-the-legend-of-zelda]], [[track:game-a-b-start-duck-hunt]], [[track:game-c-start-duck-hunt]], [[track:game-over-duck-hunt]], [[track:game-over-the-legend-of-zelda]], [[track:game-start-donkey-kong]], [[track:game-start-donkey-kong-jr]], [[track:ganon-is-defeated]], [[track:golden-hammer-wrecking-crew]], [[track:got-a-duck-duck-hunt]], [[track:hammer-bgm-donkey-kong]], [[track:hurry-up-donkey-kong]], [[track:id-purpose]], [[track:light-plane]], [[track:miss-duck-hunt]], [[track:now-or-never-splatoon]], [[track:opening-splatoon]], [[track:overworld-theme-the-legend-of-zelda]], [[track:perfect-duck-hunt]], [[track:phase-bgm-wrecking-crew]], [[track:prelude-ablaze]], [[track:round-1-and-2-clear-donkey-kong]], [[track:round-1-bgm-donkey-kong]], [[track:round-1-bgm-donkey-kong-jr]], [[track:round-1-clear-donkey-kong-jr]], [[track:round-3-clear-donkey-kong]], [[track:round-3-bgm-donkey-kong]], [[track:round-4-bgm-donkey-kong-jr]], [[track:round-4-clear-all-clear-donkey-kong-jr]], [[track:seaskape]], [[track:splattack]], [[track:tide-goes-out]], [[track:title-bgm-duck-hunt]], [[track:title-theme-the-legend-of-zelda]], and [[track:underworld-theme]] (thanks, ruby!)
-    - replaced 2019 Bandcamp compilation listening links with 2025 un-rerelease listening links for [[group:official]]! (thanks, Lilith!)
-        - replaced Bandcamp listening links for [[album:homestuck-vol-1]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-2]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-3]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-4]]!
-        - replaced Bandcamp listening links for [[album:midnight-crew-drawing-dead]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-5]]!
-        - replaced Bandcamp listening links for [[album:alternia]]!
-        - replaced Bandcamp listening links for [[album:the-felt]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-6]]!
-        - replaced Bandcamp listening links for [[album:alterniabound]]!
-        - replaced Bandcamp listening links for [[album:medium]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-7]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-1-4]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-8]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-9]]!
-        - replaced Bandcamp listening links for [[album:symphony-impossible-to-play]]!
-        - replaced Bandcamp listening links for [[album:cherubim]]!
-        - replaced Bandcamp listening links for [[album:s-collide]]!
-        - replaced Bandcamp listening links for [[album:act-7]]!
-        - replaced Bandcamp listening links for [[album:homestuck-vol-10]]!
-        - replaced Bandcamp listening links for [[album:the-grubbles]]!
-        - replaced Bandcamp listening links for [[album:hiveswap-act-1-ost]]!
     - replaced YouTube listening link for [[track:orange-hat]] with artist's upload (thanks, Lilith, Lan!)
     - replaced YouTube listening links for [[track:solar-voyage]] and [[track:renewed-return]] with artist's uploads (thanks, wertercatt, Lan!)
     - replaced Spotify listening links for [[track:celestial]], [[album:rakka-wake-01-opening-me]], and [[album:rakka-sp1-outside-2]] with link to single, rather than track (thanks, Lan, Whisper!)
@@ -327,8 +298,6 @@ Content: |-
     <!-- general removals -->
     - removed "(…) - Single" additional names automatically enforced on Apple Music and iTunes platforms, affecting [[track:black-richaadeb]], [[track:heir-of-grief-richaadeb]], [[track:dance-of-thorns-richaadeb]], [[track:oppa-toby-style]] (all [[artist:richaadeb]]), and [[album:dreamers-diarchy]] (thanks, Whisper, ruby!)
     - removed dead link in commentary for [[track:threxecute]] (thanks, Lilith!)
-    - removed dead Bandcamp listening links for [[track:the-thirteenth-hour]], [[track:theme]], [[track:walls-covered-in-blood-dx]], [[track:trollcops-radio-play]], [[track:catapult-capuchin]], [[track:science-seahorse]], [[track:a-fairy-battle]], [[track:the-blind-prophet]], [[track:alterniabound]], [[track:you-won-a-combat]], [[track:rest-a-while]], [[track:maplehoofs-adventure]], [[track:sburban-reversal]], [[track:white-host-green-room]], [[track:doctor-original-loop]], [[track:how-do-i-live-d8-night-version]], [[track:cascade-beta]], [[track:black-hole-green-sun]], [[track:carefree-action]], and [[track:another-countdown]]! (thanks, Lilith!)
-    - removed duplicate YouTube listening link for [[track:frustracean]] (thanks, Lilith!)
     - removed dead Bandcamp listening links across [[album:the-strider-mixtape]] (thanks, Geese, Lilith!)
     - removed dead Bandcamp listening links for [[track:ascending-strife]], [[track:avarice-paradox-music-team]], [[track:candlelit-contemplation-beta]], [[track:deception-paradox-music-team]], [[track:proletariat-paradox-music-team]], [[track:spritely-gardener-beta]], [[track:vexation-paradox-music-team]], and [[track:wilyesp-remix-attempt-wip]] (thanks, Lilith!)
     - removed dead SoundCloud listening link for [[track:bloodsucker-brawl]] (thanks, Lan!)


### PR DESCRIPTION
### As of September 26, 2025, the official discography Bandcamp URLs are no longer compilations! (sans coloUrs and mayhem, but they're working on it)

So, as a result, all of the compilation URLs had to be updated... so many of them... but

### THE WANDERERS AND SQUIDDLES ARE BACK YEAH BABY WOO WOOOOOOOO EVERYPONY REJOICE!!!!!!!

right, here's the details:
- [The Wanderers](https://homestuck.bandcamp.com/album/the-wanderers) and [Squiddles!](https://homestuck.bandcamp.com/album/squiddles) now have Bandcamp URLs!
- Strife! has official discography Bandcamp URLs as well, standing alongside its Tensei Bandcamp URLs

replaced Bandcamp compilation URLs with Bandcamp non-rerelease URLs for:
- Midnight Crew: Drawing Dead
- Homestuck Vol. 5
- Alternia
- The Felt
- Homestuck Vol. 6: Heir Transparent
- AlterniaBound
- Medium
- Homestuck Vol. 7: At the Price of Oblivion
- Homestuck Vol. 1-4 (separate volumes bandcamp URLs replaced as well)
- Homestuck Vol. 8
- Homestuck Vol. 9
- Symphony Impossible to Play
- Cherubim
- [S] Collide.
- Act 7
- Homestuck Vol. 10
- THE GRUBBLES
- HIVESWAP ACT 1 OST

removed duplicate YouTube URL for Frustracean

removed dead Bandcamp URLs for:
- The Thirteenth Hour
- Theme
- Walls Covered in Blood DX
- Trollcops (Radio Play)
- Catapult Capuchin
- Science Seahorse
- A Fairy Battle
- The Blind Prophet
- AlterniaBound
- You Won A Combat
- Rest A While
- Maplehoof's Adventure
- Sburban Reversal
- White Host, Green Room
- Doctor (Original Loop)
- How Do I Live (D8 Night Version)
- Cascade (Beta)
- Black Hole / Green Sun
- Carefree Action
- Another Countdown

added remaining (I hope) former Bandcamp compilation additional names to:
- Carbon Nadsat/Cuestick Genius
- Bed of Rose's / Dreams of Derse
- BL1ND JUST1C3 : 1NV3ST1G4T1ON !!
- John Sleeps / Skaian Magicant
- Black Hole / Green Sun
