### PR TITLE
Album addition: Ghost Writer by Cerulean, from Deconreconstruction!

### DIFF
--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -1,0 +1,129 @@
+Album: Ghost Writer
+Date: December 28, 2021
+Color: '#82ffd8'
+URLs:
+- https://vasterror.bandcamp.com/album/ghost-writer
+Artists:
+- Cerulean
+Cover Artists:
+- Cerulean
+Cover Art File Extension: png
+Track Art File Extension: png
+Groups:
+- Deconreconstruction
+- Fandom
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/album/ghost-writer), excerpt)
+
+    Originally released on the DCRC Music Site as an EP on 12/28/2021.
+---
+Section: Main album
+---
+Track: Ghost Writer
+Artists:
+- Cerulean
+- Circlejourney (featuring)
+- Veritas Unae (featuring)
+Contributors:
+- Circlejourney (vocals)
+- Veritas Unae (lyrics)
+Duration: 5:57
+URLs:
+- https://vasterror.bandcamp.com/track/ghost-writer
+Lyrics: |-
+    A book to be read
+    Story that's spun
+    Each thread entangled together make one
+
+    A play with no acts
+    A film on a reel
+    That catches alight when forced through the wheel
+
+    I'm your ghost writer
+    Every stare
+    Looks right through
+    Call me ghost writer
+    Let me say
+    My words too
+
+    I'm your ghost writer
+    Play my tape
+    If you would
+    Call me ghost writer
+    Lost to time
+    Gone for good
+
+    How long has it been
+    The wices* and the days
+    Does each look remind you of his gaze
+
+    I've faces to choose
+    But each is the same
+    When i am the mirror of your pain
+
+    Each glance that i take
+    Is stolen with fear
+    One look and i might just disappear
+
+    Call me ghost writer
+    Call me ghost writer
+    Call me ghost writer
+    Call me ghost writer
+
+    I'm your ghost writer
+    Every stare
+    Looks right through
+    Call me ghost writer
+    Let me say
+    My words too
+
+    I'm your ghost writer
+    Play my tape
+    If you would
+    Call me ghost writer
+    Lost to time
+    Gone for good
+Commentary: |-
+    <i>Vast Error:</i> ([DCRC Music Site](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer))
+
+    𝒏𝒐𝒕 𝒔𝒖𝒓𝒆 𝒊𝒇 𝒚𝒐𝒖'𝒗𝒆 𝒏𝒐𝒕𝒊𝒄𝒆𝒅...𝒕𝒉𝒆𝒓𝒆'𝒔 𝒋𝒖𝒔𝒕 𝒎𝒆.
+---
+Track: Ghost Writer - Paradice Lost
+Cover Artists:
+- Vast Error
+Duration: 3:02
+URLs:
+- https://vasterror.bandcamp.com/track/ghost-writer-paradice-lost
+Referenced Tracks:
+- Ghost Writer
+Lyrics: |-
+    A book to be read
+    Story that's spun
+    Each thread entangled together make one
+
+    A play with no acts
+    A film on a reel
+    That catches alight when forced through the wheel
+
+    How long has it been
+    The wices* and the days
+    Does each look remind you of his gaze
+
+    I've faces to choose
+    But each is the same
+    When I am the mirror of your pain
+
+    Each glance that I take
+    Is stolen with fear
+    One look and I might just disappear
+Commentary: |-
+    <i>Vast Error:</i> ([DCRC Music Site](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer))
+
+    𝒊𝒔𝒏'𝒕 𝒕𝒉𝒂𝒕 𝒕𝒉𝒆 𝒃𝒆𝒂𝒖𝒕𝒚 𝒐𝒇 𝒇𝒓𝒆𝒆 𝒘𝒊𝒍𝒍?
+---
+Track: Ghost Writer - Instrumental
+Duration: 6:05
+URLs:
+- https://vasterror.bandcamp.com/track/ghost-writer-instrumental
+Referenced Tracks:
+- Ghost Writer

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -13,7 +13,7 @@ Groups:
 - Deconreconstruction
 - Fandom
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/album/ghost-writer), excerpt)
+    @@ [Bandcamp about blurb, excerpt](https://vasterror.bandcamp.com/album/ghost-writer)
 
     Originally released on the DCRC Music Site as an EP on 12/28/2021.
 ---
@@ -84,7 +84,7 @@ Lyrics: |-
     Lost to time
     Gone for good
 Commentary: |-
-    <i>Vast Error:</i> ([DCRC Music Site](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer))
+    @@ [DCRC Music Site](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer)
 
     𝒏𝒐𝒕 𝒔𝒖𝒓𝒆 𝒊𝒇 𝒚𝒐𝒖'𝒗𝒆 𝒏𝒐𝒕𝒊𝒄𝒆𝒅...𝒕𝒉𝒆𝒓𝒆'𝒔 𝒋𝒖𝒔𝒕 𝒎𝒆.
 ---
@@ -117,7 +117,7 @@ Lyrics: |-
     Is stolen with fear
     One look and I might just disappear
 Commentary: |-
-    <i>Vast Error:</i> ([DCRC Music Site](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer))
+    @@ [DCRC Music Site](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer)
 
     𝒊𝒔𝒏'𝒕 𝒕𝒉𝒂𝒕 𝒕𝒉𝒆 𝒃𝒆𝒂𝒖𝒕𝒚 𝒐𝒇 𝒇𝒓𝒆𝒆 𝒘𝒊𝒍𝒍?
 ---

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -17,6 +17,8 @@ Commentary: |-
 
     We also have a brand new, on-site music player now! It was developed by VEMT member Cerulean a long while back, but recently finalized for release over the past few weeks.
 
+    <img src="media/misc/ghost-writer-musicplayer.png" width="940">
+
     Every track from every VE album can be directly downloaded and seamlessly streamed with no replay limit however you want, whenever you want! We'll also be using this platform to occasionally release SINGLES from upcoming albums and SMALLER EP'S that just wouldn't have looked as good on Bandcamp. Which isn't going away anytime soon! It's just going to be an alternative platform.
 
     Our most recent release is an EP drop of an upcoming [[album:vast-error-vol-5-side-2|Vol. 5]] track titled 'GHOST WRITER'. A nearly six minute look into the twisted mind of everyone's favorite metaphysical sub-narrator, Mimesis. It was ALSO done by Cerulean, with lyrics written by [[artist:veritas-unae|VeritasUnae]] and vocals by [[artist:circlejourney|CircleJourney]]! The song took months to do, and it was time very well spent. A chill remix and the track's instrumental are also up!

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -41,7 +41,7 @@ Duration: 5:57
 URLs:
 - https://vasterror.bandcamp.com/track/ghost-writer
 Lyrics: |-
-    <i>Cerulean:</i> (artist's lyrics)
+    @@ [DCRC Music Site lyrics](https://web.archive.org/web/20220104074005/https://music.deconreconstruction.com/albums/ghost-writer)
 
     -Intro-
     A book to be read

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -28,6 +28,8 @@ Commentary: |-
 Section: Main album
 ---
 Track: Ghost Writer
+Additional Names:
+- ghost_writer.mp3 (DCRC Music Site release, filename)
 Artists:
 - Cerulean
 - Circlejourney (featuring)
@@ -97,8 +99,11 @@ Commentary: |-
     𝒏𝒐𝒕 𝒔𝒖𝒓𝒆 𝒊𝒇 𝒚𝒐𝒖'𝒗𝒆 𝒏𝒐𝒕𝒊𝒄𝒆𝒅...𝒕𝒉𝒆𝒓𝒆'𝒔 𝒋𝒖𝒔𝒕 𝒎𝒆.
 ---
 Track: Ghost Writer - Paradice Lost
+Additional Names:
+- ghost_writer_chill_master.mp3 (DCRC Music Site release, filename)
 Cover Artists:
 - Vast Error
+Cover Art Dimensions: 3000x2988
 Duration: 3:02
 URLs:
 - https://vasterror.bandcamp.com/track/ghost-writer-paradice-lost
@@ -130,6 +135,8 @@ Commentary: |-
     𝒊𝒔𝒏'𝒕 𝒕𝒉𝒂𝒕 𝒕𝒉𝒆 𝒃𝒆𝒂𝒖𝒕𝒚 𝒐𝒇 𝒇𝒓𝒆𝒆 𝒘𝒊𝒍𝒍?
 ---
 Track: Ghost Writer - Instrumental
+Additional Names:
+- gh_instru.mp3 (DCRC Music Site release, filename)
 Duration: 6:05
 URLs:
 - https://vasterror.bandcamp.com/track/ghost-writer-instrumental

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -13,6 +13,14 @@ Groups:
 - Deconreconstruction
 - Fandom
 Commentary: |-
+    <i>Austinado:</i> ([DCRC news post](https://web.archive.org/web/20220104004613/https://deconreconstruction.com/), 1/2/2022)
+
+    We also have a brand new, on-site music player now! It was developed by VEMT member Cerulean a long while back, but recently finalized for release over the past few weeks.
+
+    Every track from every VE album can be directly downloaded and seamlessly streamed with no replay limit however you want, whenever you want! We'll also be using this platform to occasionally release SINGLES from upcoming albums and SMALLER EP'S that just wouldn't have looked as good on Bandcamp. Which isn't going away anytime soon! It's just going to be an alternative platform.
+
+    Our most recent release is an EP drop of an upcoming [[album:vast-error-vol-5-side-2|Vol. 5]] track titled 'GHOST WRITER'. A nearly six minute look into the twisted mind of everyone's favorite metaphysical sub-narrator, Mimesis. It was ALSO done by Cerulean, with lyrics written by [[artist:veritas-unae|VeritasUnae]] and vocals by [[artist:circlejourney|CircleJourney]]! The song took months to do, and it was time very well spent. A chill remix and the track's instrumental are also up!
+    
     @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/album/ghost-writer)
 
     Originally released on the DCRC Music Site as an EP on 12/28/2021.

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -171,7 +171,6 @@ Additional Names:
 - ghost_writer_chill_master.mp3 (DCRC Music Site release, filename)
 Cover Artists:
 - Vast Error
-Cover Art Dimensions: 3000x2988
 Duration: 3:02
 URLs:
 - https://vasterror.bandcamp.com/track/ghost-writer-paradice-lost

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -41,6 +41,72 @@ Duration: 5:57
 URLs:
 - https://vasterror.bandcamp.com/track/ghost-writer
 Lyrics: |-
+    <i>Cerulean:</i> (artist's lyrics)
+
+    -Intro-
+    A book to be read
+    Story that's spun
+    Each thread entangled together make one
+
+    A play with no acts
+    A film on a reel
+    That catches alight when forced through the wheel
+
+    -Break-
+
+    -Chorus-
+    I'm your ghost writer
+    Every stare
+    Looks right through
+    Call me ghost writer
+    Let me say
+    My words too
+
+    I'm your ghost writer
+    Play my tape
+    If you would
+    Call me ghost writer
+    Lost to time
+    Gone for good
+    -End of chorus-
+
+    How long has it been
+    The wices* and the days
+    Does each look remind you of his gaze
+
+    I've faces to choose
+    But each is the same
+    When i am the mirror of your pain
+
+    Each glance that i take
+    Is stolen with fear
+    One look and i might just disappear
+
+    Call me ghost writer
+    Call me ghost writer
+    Call me ghost writer
+    Call me ghost writer
+
+    I'm your ghost writer
+    Every stare
+    Looks right through
+    Call me ghost writer
+    Let me say
+    My words too
+
+    I'm your ghost writer
+    Play my tape
+    If you would
+    Call me ghost writer
+    Lost to time
+    Gone for good
+
+    🎹 Synth solo 🎸
+
+    The future.
+
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
     A book to be read
     Story that's spun
     Each thread entangled together make one
@@ -69,11 +135,11 @@ Lyrics: |-
 
     I've faces to choose
     But each is the same
-    When i am the mirror of your pain
+    When I am the mirror of your pain
 
-    Each glance that i take
+    Each glance that I take
     Is stolen with fear
-    One look and i might just disappear
+    One look and I might just disappear
 
     Call me ghost writer
     Call me ghost writer
@@ -110,6 +176,8 @@ URLs:
 Referenced Tracks:
 - Ghost Writer
 Lyrics: |-
+    <i>Lilithtreasure:</i> (wiki lyrics)
+
     A book to be read
     Story that's spun
     Each thread entangled together make one

--- a/album/ghost-writer.yaml
+++ b/album/ghost-writer.yaml
@@ -13,7 +13,7 @@ Groups:
 - Deconreconstruction
 - Fandom
 Commentary: |-
-    @@ [Bandcamp about blurb, excerpt](https://vasterror.bandcamp.com/album/ghost-writer)
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/album/ghost-writer)
 
     Originally released on the DCRC Music Site as an EP on 12/28/2021.
 ---

--- a/album/vast-error-vol-5-side-2.yaml
+++ b/album/vast-error-vol-5-side-2.yaml
@@ -70,6 +70,9 @@ Cover Artists:
 - expirequiem
 URLs:
 - https://vasterror.bandcamp.com/track/ghost-writer-extended
+Referenced Tracks:
+- Ghost Writer
+- Ghost Writer - Paradice Lost
 Lyrics: |-
     A book to be read
     Story that's spun

--- a/groups.yaml
+++ b/groups.yaml
@@ -895,6 +895,7 @@ Series:
   - Faux Dramatica
   - Fighting Further
   - Duodenary
+  - Ghost Writer
 Description: |-
     Studio consisting of many creators from the Homestuck fan community and beyond, responsible for [Vast Error](https://www.deconreconstruction.com/vasterror/1), [its spinoffs](https://deconreconstruction.itch.io/snowbound-blood), and other projects.
     <hr class="split">

--- a/groups.yaml
+++ b/groups.yaml
@@ -892,10 +892,10 @@ Series:
   - Repiton
   - Reminders Of You [Beta]
   - Empyreal Rhapsody
+  - Ghost Writer
   - Faux Dramatica
   - Fighting Further
   - Duodenary
-  - Ghost Writer
 Description: |-
     Studio consisting of many creators from the Homestuck fan community and beyond, responsible for [Vast Error](https://www.deconreconstruction.com/vasterror/1), [its spinoffs](https://deconreconstruction.itch.io/snowbound-blood), and other projects.
     <hr class="split">

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -80,6 +80,8 @@ Content: |-
     <h3>album additions</h3>
     - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus <<Jebb:album presentation help>>, <<Lilith:URL fix, bonus track artwork data>>, <<Cello:bonus track artwork help>>, <<Makin:URLs & bonus track artwork crediting help>>, <<Monckat:track duration fix>>!)
         - added [[album:kindred-souls]]!
+    - added latest release from [[group:deconrecon]]! (thanks, <<Lilith:album data, presentation, research>>!)
+        - added [[album:ghost-writer]] by [[artist:cerulean]]!
     - added latest release from [[group:studio-june]]! (thanks, <<Lilith:album data, presentation, research>>, plus <<ruby:References Beyond Homestuck help>>, <<articulatelyComposed:artwork crediting help>>!)
         - added [[album:friendsim-2-volume-2]]!
     - added albums from [[group:cheezquest]]! (thanks, <<Jebb:album data, presentation, research>>, <<Lan:data review, additional research>>, plus <<Josh:research help>>, <<Dust:research help>>, <<t2k:artwork referencing help>>!)
@@ -333,6 +335,7 @@ Content: |-
     - fixed [[track:gold-mage-playtime-is-over-mix]] referencing [[track:gold-mage]] instead of [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
+    - fixed [[track:ghost-writer-extended]] not referencing [[track:ghost-writer]] and [[track:ghost-writer-paradice-lost]]! (thanks, Lilith!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
         - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]] (original single)
         - fixed [[track:it-really-doesnt-matter]] not referencing [[track:it-really-doesnt-matter-original]] (original single)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -80,8 +80,6 @@ Content: |-
     <h3>album additions</h3>
     - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus <<Jebb:album presentation help>>, <<Lilith:URL fix, bonus track artwork data>>, <<Cello:bonus track artwork help>>, <<Makin:URLs & bonus track artwork crediting help>>, <<Monckat:track duration fix>>!)
         - added [[album:kindred-souls]]!
-    - added latest release from [[group:deconrecon]]! (thanks, <<Lilith:album data, presentation, research>>!)
-        - added [[album:ghost-writer]] by [[artist:cerulean]]!
     - added latest release from [[group:studio-june]]! (thanks, <<Lilith:album data, presentation, research>>, plus <<ruby:References Beyond Homestuck help>>, <<articulatelyComposed:artwork crediting help>>!)
         - added [[album:friendsim-2-volume-2]]!
     - added albums from [[group:cheezquest]]! (thanks, <<Jebb:album data, presentation, research>>, <<Lan:data review, additional research>>, plus <<Josh:research help>>, <<Dust:research help>>, <<t2k:artwork referencing help>>!)
@@ -154,6 +152,7 @@ Content: |-
     - added [[album:the-heist]] and [[album:thanks-for-listening]] by [[artist:serialsymphony]]! (thanks, Lilith, Lan!)
     - added [[album:adminstuck-volume-1]] and [[album:adminstuck-volume-2]]! (thanks, Lilith, Jackie!)
     - added [[album:the-mayview-mixtape]] (thanks, Lilith, Lan!)
+    - added [[album:ghost-writer]] by [[artist:cerulean]]! (thanks, <<Lilith:album data, presentation, research>>!)
     - added [[album:polymonstrology-act-1-ost]] by [[artist:gomaliel]]! (thanks, Jebb!)
     - added [[album:cognitive-coalescence]] by [[artist:witchs-cadence]]! (thanks, Lilith, Lan!)
     - added [[album:the-homestuck-music-experience]] by [[group:funk-mclovin]]! (thanks, <<Lilith:album data, presentation, research>>, <<Lan:data review, lyrics help, additional research>>!)


### PR DESCRIPTION
Adds the 2021 previously exclusive to the DCRC Music Site, [rereleased on Bandcamp](https://vasterror.bandcamp.com/album/ghost-writer) EP from Cerulean, from Deconreconstruction, Ghost Writer!

Also fixes [Ghost Writer (Extended)](https://hsmusic.wiki/track/ghost-writer-extended/) not referencing Ghost Writer and Ghost Writer - Paradice Lost.

Merge with: [hsmusic-media#173](https://github.com/hsmusic/hsmusic-media/pull/173)