### PR TITLE
Riches to Ruins Movements I & II full-size track art support + noirscape alt art commentary + corkscrew sundown (art) tumblr commentary + Kendle merger + Nick Tucker merger

### DIFF
--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -1876,7 +1876,7 @@ Track Artwork:
 - Label: Alternate artwork
   Directory: alternate
   Artists:
-  - straightfacedgriff
+  - Nick Tucker
   Tags:
   - Jack Noir
   - Carapacians
@@ -1886,6 +1886,12 @@ Track Artwork:
     [LOFAM2 "Art for the Project"](https://hsfanmusic.skaia.net/lofam2.html)
   Origin Details:
     Created while this track was slated for [[album:lofam2]]
+- Label: Full alternate artwork
+  Directory: alternate-full
+  Attach Above: true
+  Date: June 12, 2012
+  Source: >-
+    [Tumblr](https://irespectfrogs.tumblr.com/post/24962223388/this-was-going-to-be-track-art-for-the-lofam2)
 Referenced Tracks:
 - Liquid Negrocity
 - Crystalanthemums
@@ -1928,13 +1934,19 @@ Commentary: |-
 
     <b>Fun if somewhat nerdy fact:</b> The power down sound that leads into the guitar solo section is actually the sound made when the Hammond organ is switched off while holding down the last chord. The tonewheels inside the organ that generate the pitches start to slow down before the amplifier cuts out so you can hear the pitch lower before the sound stops.
 
-    After I posted Noirscape it got added to the tracklist for [[album:lofam2|LOFAM2]] and [[artist:straightfacedgriff|straightfacedgriff]] had actually started doing art for it before I had the chance to quietly let them know that it wasn't going to be on the album. The art pretty much sums up the scene the music was meant to be describing at the start though (assuming jack has a few more knives up his sleeve for the other guards) so I thought I'd include it here.
+    After I posted Noirscape it got added to the tracklist for [[album:lofam2|LOFAM2]] and [[artist:nick-tucker|straightfacedgriff]] had actually started doing art for it before I had the chance to quietly let them know that it wasn't going to be on the album. The art pretty much sums up the scene the music was meant to be describing at the start though (assuming jack has a few more knives up his sleeve for the other guards) so I thought I'd include it here.
 
     <i>Kendle Iulus:</i> ([Tumblr](https://tzepesh.tumblr.com/post/24963148538/album-art-for-noirscape-which-you-can-listen-to), 6/12/2012)
 
     album art for noirscape, which you can listen to [here](https://homestuck.bandcamp.com/track/noirscape)
 
     here is the reversed side
+
+    <i>Nick Tucker:</i> (artwork for [[album:lofam2]], [Tumblr](https://irespectfrogs.tumblr.com/post/26266953900/noirscape-homestuck-vol-9-track-commentary), 7/1/2012)
+
+    …And that’s pretty much how it all happened! The other track art looks <b>a lot</b> better than my crappy cellshade.
+
+    I was going to do a proper background, but I decided not to after the track was taken off [[album:lofam2|LOFAM2]].
 ---
 Track: Dogfight
 Artists:

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -1942,7 +1942,7 @@ Commentary: |-
 
     here is the reversed side
 
-    <i>Nick Tucker:</i> (artwork for [[album:lofam2]], [Tumblr](https://irespectfrogs.tumblr.com/post/26266953900/noirscape-homestuck-vol-9-track-commentary), 7/1/2012)
+    <i>Nick Tucker:</i> (artwork for [[album:lofam2]], [Tumblr reblog](https://irespectfrogs.tumblr.com/post/26266953900/noirscape-homestuck-vol-9-track-commentary), 7/1/2012)
 
     …And that’s pretty much how it all happened! The other track art looks <b>a lot</b> better than my crappy cellshade.
 

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -1886,7 +1886,7 @@ Track Artwork:
     [LOFAM2 "Art for the Project"](https://hsfanmusic.skaia.net/lofam2.html)
   Origin Details:
     Created while this track was slated for [[album:lofam2]]
-- Label: Full alternate artwork
+- Label: Full-size alternate artwork
   Directory: alternate-full
   Attach Above: true
   Source: >-

--- a/album/homestuck-vol-9.yaml
+++ b/album/homestuck-vol-9.yaml
@@ -1889,7 +1889,6 @@ Track Artwork:
 - Label: Full alternate artwork
   Directory: alternate-full
   Attach Above: true
-  Date: June 12, 2012
   Source: >-
     [Tumblr](https://irespectfrogs.tumblr.com/post/24962223388/this-was-going-to-be-track-art-for-the-lofam2)
 Referenced Tracks:

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -1836,7 +1836,7 @@ Track Artwork:
   Date: August 20, 2012
   Source: >-
     [Tumblr](https://irespectfrogs.tumblr.com/post/29846492656/corkscrew-sundown-by-trogg-i-started-completely)
-- Artists:
+  Artists:
   - Nick Tucker
   Tags:
   - Doc Scratch

--- a/album/lofam2.yaml
+++ b/album/lofam2.yaml
@@ -1824,16 +1824,33 @@ Duration: 4:14
 URLs:
 - https://unofficialmspafans.bandcamp.com/track/corkscrew-sundown
 - https://youtu.be/sJVzHZJBAhA
-Cover Artists:
-- straightfacedgriff
-Art Tags:
-- Doc Scratch
-- Green Sun
-- 'cw: body horror (abstract)'
+Track Artwork:
+- Artists:
+  - Nick Tucker
+  Tags:
+  - Doc Scratch
+  - Green Sun
+  - 'cw: body horror (abstract)'
+- Label: Alternate artwork
+  Directory: alt
+  Date: August 20, 2012
+  Source: >-
+    [Tumblr](https://irespectfrogs.tumblr.com/post/29846492656/corkscrew-sundown-by-trogg-i-started-completely)
+- Artists:
+  - Nick Tucker
+  Tags:
+  - Doc Scratch
+  - 'cw: body horror (abstract)'
 Commentary: |-
-    <i>straightfacedgriff:</i> (track artist, booklet commentary)
+    <i>Nick Tucker:</i> (track artist, booklet commentary)
 
     This is my favourite song on the album, and I ended up doing two track arts for it. This one is better, I think! I decided to use Doc Scratch because the song was about the Green Sun, and out of all the characters associated with it, I felt Doc Scratch best suited the song.
+
+    <i>Nick Tucker:</i> (track artist, [Tumblr](https://irespectfrogs.tumblr.com/post/29846492656/corkscrew-sundown-by-trogg-i-started-completely), 8/20/2012)
+
+    Corkscrew Sundown by [[artist:trent-west|Trogg]]
+
+    I started completely from scratch with my lofam2 track art. There are two versions that I couldn’t choose between, so I’ll let the lofam2 guys decide to use a yellow or green sun.
 ---
 Track: Doghead
 Artists:

--- a/album/the-wanderers.yaml
+++ b/album/the-wanderers.yaml
@@ -326,12 +326,26 @@ Duration: 2:20
 URLs:
 - https://homestuck.bandcamp.com/track/riches-to-ruins-movements-i-ii
 - https://youtu.be/K7WRrBG6BM8
-Cover Artists:
-- Khoroshonov
-Art Tags:
-- WK
-- Skaia
-- Prospit
+Track Artwork:
+- Artists:
+  - Kendle Iulus
+  Tags:
+  - WK
+  - Skaia
+  - Prospit
+- Label: Full-size artwork
+  Directory: full
+  Attach Above: true
+  Dimensions: 456x630
+  Date: May 18, 2011
+  Source: >-
+    [Tumblr](https://tzepesh.tumblr.com/post/5629867451/the-white-king-ponders-the-fate-of-his-world-while)
+Commentary: |-
+    <i>Kendle Iulus:</i> ([Tumblr](https://tzepesh.tumblr.com/post/5629867451/the-white-king-ponders-the-fate-of-his-world-while), 5/18/2011)
+
+    the white king ponders the fate of his world while i DESTROY YOUR EYESIGHT
+
+    i have the worst artblock ever grrr
 ---
 Track: Litrichean Rioghail
 Artists:

--- a/artists.yaml
+++ b/artists.yaml
@@ -10530,7 +10530,11 @@ Artist: Nick Smalley
 Artist: Nick Tucker
 Aliases:
 - Hierogriff
+- straightfacedgriff
 URLs:
+- https://irespectfrogs.tumblr.com/
+- https://linktr.ee/irespectfrogs
+Dead URLs:
 - https://hierogriff.tumblr.com/
 ---
 Artist: Nico J. Dolloso
@@ -14260,10 +14264,6 @@ URLs:
 Artist: The Story So Far
 ---
 Artist: StoryCorps
----
-Artist: straightfacedgriff
-URLs:
-- https://hierogriff.tumblr.com/
 ---
 Artist: Strawberry Flower
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -7827,6 +7827,7 @@ URLs:
 Artist: Kendle Iulus
 Aliases:
 - tzepesh
+- Khoroshonov
 - kendle bentley b!
 - electroluxx
 URLs:
@@ -7915,8 +7916,6 @@ URLs:
 - https://www.youtube.com/user/Kezinox
 ---
 Artist: Khonjin House
----
-Artist: Khoroshonov
 ---
 Artist: Kibbynbits
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -7826,10 +7826,10 @@ URLs:
 ---
 Artist: Kendle Iulus
 Aliases:
-- tzepesh
-- Khoroshonov
 - kendle bentley b!
+- tzepesh
 - electroluxx
+- Khoroshonov
 URLs:
 - https://tzepesh.tumblr.com
 - https://www.instagram.com/_tzepesh

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -498,8 +498,9 @@ Content: |-
     - fixed [[track:bad-apple-lovelight]] not crediting [[artist:nomico]] as a featured artist, and not crediting [[artist:harukapakapa]] for lyrics (thanks, Lan!)
     - fixed [[track:never-gonna-give-you-up]] crediting [[artist:stock-aitken-waterman]] as artist and [[artist:rick-astley]] as contributor, instead of the reverse (thanks, Lan!)
     <!-- merged artists -->
-    - fixed [[artist:kendle-iulus]] & [[artist:nick-tucker]] having some credits under other names (thanks, Lilith!)
     - fixed [[artist:domble]] having some credits under another name (thanks, Makin, Lan!)
+    - fixed [[artist:kendle-iulus]] having some credits under another name (thanks, Lilith!)
+    - fixed [[artist:nick-tucker]] having some credits under another name (thanks, Lilith!)
     <!-- track section fixes -->
     - fixed [[album:vast-error-vol-3]] missing a proper "Main album" section, and showing "Default Track Section" instead (thanks, Lilith!)
     - fixed [[track:the-ultimate-show]] being placed in [[album:references-beyond-homestuck]] under "Other music originating outside Homestuck", instead of under "Music from video games" (thanks, Lilith, Lavender!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -247,7 +247,7 @@ Content: |-
     - added missing paragraphs and structure to Tumblr commentary for [[track:dord-waltz]] (thanks, Lilith!)
     - added Tumblr commentary ([[date:7/15/2012]]) to [[track:ugly-betty]] (thanks, Lilith, Lan!)
     - added Tumblr commentary ([[artist:nick-tucker]]) to [[track:noirscape]] (thanks, Lilith!)
-    - added Tumblr commentary to [[track:corkscrew-sundown]] (thanks, Lilith!)
+    - added Tumblr commentary ([[artist:nick-tucker]]) to [[track:corkscrew-sundown]] (thanks, Lilith!)
     - added YouTube commentary to [[track:solar-voyage]] (thanks, wertercatt, Meulanie, Lan, Lavender!)
     - added SoundCloud commentary to [[track:heir-seer-knight-witch]] (thanks, Lan!)
     - added missing paragraphs to Tumblr album commentary for [[album:7th-gate-project]] (thanks, Lilith!)
@@ -498,7 +498,7 @@ Content: |-
     - fixed [[track:bad-apple-lovelight]] not crediting [[artist:nomico]] as a featured artist, and not crediting [[artist:harukapakapa]] for lyrics (thanks, Lan!)
     - fixed [[track:never-gonna-give-you-up]] crediting [[artist:stock-aitken-waterman]] as artist and [[artist:rick-astley]] as contributor, instead of the reverse (thanks, Lan!)
     <!-- merged artists -->
-    - fixed [[artist:kendle-iulus]] & [[artist:nick-tucker]] having some credits under another name (thanks, Lilith!)
+    - fixed [[artist:kendle-iulus]] & [[artist:nick-tucker]] having some credits under other names (thanks, Lilith!)
     - fixed [[artist:domble]] having some credits under another name (thanks, Makin, Lan!)
     <!-- track section fixes -->
     - fixed [[album:vast-error-vol-3]] missing a proper "Main album" section, and showing "Default Track Section" instead (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -238,6 +238,7 @@ Content: |-
     - added SoundCloud commentary to [[track:squiddle-march]] (thanks, Lilith, Lan!)
     - added YouTube commentary (Promstuck 2025) to [[track:sburban-jungle]] (thanks, Lan!)
     - added 2011 portfolio commentary to [[track:black]], [[track:sunsetter]], [[track:theme]], [[track:a-tender-moment]], [[track:karkats-theme]], [[track:darling-kanaya]], [[track:eridans-theme]], [[track:killed-by-br8k-spider]], [[track:catapult-capuchin]], [[track:earthsea-borealis]], [[track:mayor-maynot]], [[track:judgment-day]], [[track:do-the-homestuck-demo]], and [[track:lets-read-a-webcomic]] (thanks to an emailer and Lan!)
+    - added Tumblr commentary ([[artist:kendle-iulus]]) to [[track:riches-to-ruins-movements-i-and-ii]] (thanks, Lilith!)
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
     - added Tumblr commentary ([[artist:myotishi]]) to [[track:teal-hunter]] (thanks, Lan!)
     - added Tumblr commentary ([[artist:grue]]) to [[track:cobalt-corsair]] and [[track:spider8ite]] (thanks, Lan, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -262,6 +262,7 @@ Content: |-
     <!-- artwork additions -->
     - added full-size artworks to [[track:at-the-price-of-oblivion]], [[track:even-in-death]], [[track:trial-and-execution]], [[track:spider8reath]], [[track:lifdoff]], [[track:havoc-to-be-wrought]], and [[track:earthsea-borealis]] (thanks, Meulanie, Lan!)
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
+    - added full-size artwork to [[track:riches-to-ruins-movements-i-and-ii]] (thanks, Lilith!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
@@ -492,6 +493,7 @@ Content: |-
     - fixed [[track:bad-apple-lovelight]] not crediting [[artist:nomico]] as a featured artist, and not crediting [[artist:harukapakapa]] for lyrics (thanks, Lan!)
     - fixed [[track:never-gonna-give-you-up]] crediting [[artist:stock-aitken-waterman]] as artist and [[artist:rick-astley]] as contributor, instead of the reverse (thanks, Lan!)
     <!-- merged artists -->
+    - fixed [[artist:kendle-iulus]] having some credits under another name (thanks, Lilith!)
     - fixed [[artist:domble]] having some credits under another name (thanks, Makin, Lan!)
     <!-- track section fixes -->
     - fixed [[album:vast-error-vol-3]] missing a proper "Main album" section, and showing "Default Track Section" instead (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -246,6 +246,8 @@ Content: |-
     - added Tumblr WIP commentary for [[track:dord-waltz]] (thanks, Lilith!)
     - added missing paragraphs and structure to Tumblr commentary for [[track:dord-waltz]] (thanks, Lilith!)
     - added Tumblr commentary ([[date:7/15/2012]]) to [[track:ugly-betty]] (thanks, Lilith, Lan!)
+    - added Tumblr commentary ([[artist:nick-tucker]]) to [[track:noirscape]] (thanks, Lilith!)
+    - added Tumblr commentary to [[track:corkscrew-sundown]] (thanks, Lilith!)
     - added YouTube commentary to [[track:solar-voyage]] (thanks, wertercatt, Meulanie, Lan, Lavender!)
     - added SoundCloud commentary to [[track:heir-seer-knight-witch]] (thanks, Lan!)
     - added missing paragraphs to Tumblr album commentary for [[album:7th-gate-project]] (thanks, Lilith!)
@@ -264,7 +266,9 @@ Content: |-
     - added full-size artworks to [[track:at-the-price-of-oblivion]], [[track:even-in-death]], [[track:trial-and-execution]], [[track:spider8reath]], [[track:lifdoff]], [[track:havoc-to-be-wrought]], and [[track:earthsea-borealis]] (thanks, Meulanie, Lan!)
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added full-size artwork to [[track:riches-to-ruins-movements-i-and-ii]] (thanks, Lilith!)
+    - added full-size alternate artwork to [[track:noirscape]] (thanks, Lilith!)
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
+    - added alternate artwork to [[track:corkscrew-sundown]]! (thanks, Lilith!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
     - added higher-quality artwork to [[album:i-miss-you-earthbound-2012]] (thanks, Lilith!)
@@ -494,7 +498,7 @@ Content: |-
     - fixed [[track:bad-apple-lovelight]] not crediting [[artist:nomico]] as a featured artist, and not crediting [[artist:harukapakapa]] for lyrics (thanks, Lan!)
     - fixed [[track:never-gonna-give-you-up]] crediting [[artist:stock-aitken-waterman]] as artist and [[artist:rick-astley]] as contributor, instead of the reverse (thanks, Lan!)
     <!-- merged artists -->
-    - fixed [[artist:kendle-iulus]] having some credits under another name (thanks, Lilith!)
+    - fixed [[artist:kendle-iulus]] & [[artist:nick-tucker]] having some credits under another name (thanks, Lilith!)
     - fixed [[artist:domble]] having some credits under another name (thanks, Makin, Lan!)
     <!-- track section fixes -->
     - fixed [[album:vast-error-vol-3]] missing a proper "Main album" section, and showing "Default Track Section" instead (thanks, Lilith!)


### PR DESCRIPTION
Merges Kendle with the entry from the Wanderers; as it turns out Kendle is the same as- well, I found the full art of Riches to Ruins Movements I & II on kendle's blog! which means kendle is the same as the alias that was previously listed (Khoroshonov, but not only that, it even said Kendle on the about thingy on the archived khoroshonov blog)!

Also adds additional track art commentary from Nick Tucker's tumblr to Corkscrew Sundown; as well as additional track art commentary for the alternate Noirscape track art that was made for when it was slated for LOFAM2.

Merges Nick Tucker and straightfacedgriff, also.

merge with: [hsmusic-media#175](https://github.com/hsmusic/hsmusic-media/pull/175)