### PR TITLE
Album addition: PMT Classic Selection by The Paradox Music Team!

### DIFF
--- a/album/alternate-hues-and-melodies.yaml
+++ b/album/alternate-hues-and-melodies.yaml
@@ -281,5 +281,4 @@ Duration: 7:25
 URLs:
 - https://youtu.be/YWeUniNRwXI
 Referenced Tracks:
-- Duodecim Diis Resurgemus (Part 1)
 - Rex Duodecim Angelus

--- a/album/alternate-hues-and-melodies.yaml
+++ b/album/alternate-hues-and-melodies.yaml
@@ -281,4 +281,5 @@ Duration: 7:25
 URLs:
 - https://youtu.be/YWeUniNRwXI
 Referenced Tracks:
+- Duodecim Diis Resurgemus (Part 1)
 - Rex Duodecim Angelus

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -3381,6 +3381,15 @@ Artists:
 - Rowyn Berlan
 Duration: 3:46
 ---
+Track: Brobot Scrimmage (original)
+Artists:
+- Pascal van den Bos
+Duration: 2:12
+URLs:
+- https://media.hsmusic.wiki/misc/archive/Brobot_Scrimmage.mp3
+Referenced Tracks:
+- track:heir-of-grief
+---
 Track: Candlelit Contemplation (Beta)
 Artists:
 - Rowyn Berlan

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -3431,6 +3431,16 @@ Commentary: |-
     its also a soundtest song<br>
     was later turned into [[collapse reprise]] from umspaf 5 i think
 ---
+Track: Graceful Twilight
+Artists:
+- Pascal van den Bos
+---
+Track: Gratification
+Directory: gratification-paradox-music-team
+Always Reference By Directory: true
+Artists:
+- Pascal van den Bos
+---
 Track: Kuprum's Theme
 Artists:
 - Pascal van den Bos

--- a/album/pmt-classic-selection.yaml
+++ b/album/pmt-classic-selection.yaml
@@ -17,16 +17,11 @@ Commentary: |-
 
     A compilation album of classic PMT songs that are currently either unavailable, or were not originally published by The PMT. This compilation includes songs from the following albums:
 
-    -[[album:stlap]]<br>
-    (Delisted)<br>
-    -[[album:alternate-hues-and-melodies]]<br>
-    (Delisted)<br>
-    -[[album:stlap2]]<br>
-    (Delisted)<br>
-    -[[album:the-strider-mixtape]]<br>
-    (Delisted)<br>
-    -PMT Soundtest 2<br>
-    (Unreleased)<br>
+    -[[album:stlap]]<br>(Delisted)<br>
+    -[[album:alternate-hues-and-melodies]]<br>(Delisted)<br>
+    -[[album:stlap2]]<br>(Delisted)<br>
+    -[[album:the-strider-mixtape]]<br>(Delisted)<br>
+    -PMT Soundtest 2<br>(Unreleased)<br>
     -Through Green Doors<br>
     -[[album:desynced-vol-1]]<br>
     -[[album:desynced-vol-2]]<br>
@@ -105,6 +100,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/duodecim-diis-resurgemus-part-1
 - https://open.spotify.com/track/6aGKAbcZeer9zYmmqTDtHv
 Referenced Tracks:
+- Duodecim Diis Resurgemus
 - Rex Duodecim Angelus
 ---
 Track: Versus Remix
@@ -190,11 +186,16 @@ URLs:
 - https://open.spotify.com/track/0wFbrvuZVTz5GmoReXcjLy
 ---
 Track: Brobot Scrimmage
-Main Release: track:brobot-scrimmage
+Artists:
+- Pascal van den Bos
 Duration: 2:16
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/brobot-scrimmage-3
 - https://open.spotify.com/track/1lpFDjw0JQFXws5f9EkO0k
+Previous Productions:
+- track:brobot-scrimmage
+Referenced Tracks:
+- track:heir-of-grief
 ---
 Track: Waveform Showdown
 Main Release: track:waveform-showdown
@@ -349,7 +350,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/arrival
 - https://open.spotify.com/track/3SsfrzDbFqYutfAqGgIgsA
 ---
-Track: Set​-​Course Praerept​ŏ​r
+Track: Set-Course Praereptŏr
 Directory: set-course-praereptor
 Main Release: track:set-course-praereptor
 Duration: 4:05

--- a/album/pmt-classic-selection.yaml
+++ b/album/pmt-classic-selection.yaml
@@ -17,18 +17,18 @@ Commentary: |-
 
     A compilation album of classic PMT songs that are currently either unavailable, or were not originally published by The PMT. This compilation includes songs from the following albums:
 
-    -[[album:stlap]]<br>(Delisted)<br>
-    -[[album:alternate-hues-and-melodies]]<br>(Delisted)<br>
-    -[[album:stlap2]]<br>(Delisted)<br>
-    -[[album:the-strider-mixtape]]<br>(Delisted)<br>
-    -PMT Soundtest 2<br>(Unreleased)<br>
-    -Through Green Doors<br>
-    -[[album:desynced-vol-1]]<br>
-    -[[album:desynced-vol-2]]<br>
-    -[[album:friendsymphony]]<br>
-    -[[album:s-press-play]]<br>
-    -Welcome to Doomtlis Vol. 1<br>
-    -[[album:lofam5]]
+    - [[album:stlap]] (Delisted)
+    - [[album:alternate-hues-and-melodies]] (Delisted)
+    - [[album:stlap2]] (Delisted)
+    - [[album:the-strider-mixtape]] (Delisted)
+    - PMT Soundtest 2 (Unreleased)
+    - Through Green Doors ([link](https://fantroll-friendsim.itch.io/through-green-doors))
+    - [[album:desynced-vol-1]]
+    - [[album:desynced-vol-2]]
+    - [[album:friendsymphony]]
+    - [[album:s-press-play]]
+    - Welcome to Doomtlis Vol. 1 ([link](https://wtdsoundtrack.bandcamp.com/album/wtd-album-vol-1))
+    - [[album:lofam5]]
 
 Crediting Sources: |-
     <i>The Paradox Music Team:</i> ([Bandcamp credits blurb](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection), excerpt)

--- a/album/pmt-classic-selection.yaml
+++ b/album/pmt-classic-selection.yaml
@@ -192,9 +192,8 @@ Duration: 2:16
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/brobot-scrimmage-3
 - https://open.spotify.com/track/1lpFDjw0JQFXws5f9EkO0k
-Previous Productions:
-- track:brobot-scrimmage
 Referenced Tracks:
+- track:brobot-scrimmage
 - track:heir-of-grief
 ---
 Track: Waveform Showdown

--- a/album/pmt-classic-selection.yaml
+++ b/album/pmt-classic-selection.yaml
@@ -1,0 +1,412 @@
+Album: PMT Classic Selection
+Suffix Track Directories: true
+Always Reference Tracks By Directory: true
+Date: October 17, 2025
+Color: '#56b0c9'
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection
+- https://open.spotify.com/album/3ZneXPBJ8Q2HY47lkwnzst
+Cover Artists:
+- KiddleScribbles
+Cover Art File Extension: png
+Groups:
+- The Paradox Music Team
+- Fandom
+Commentary: |-
+    <i>The Paradox Music Team:</i> ([Bandcamp about blurb](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection), excerpt)
+
+    A compilation album of classic PMT songs that are currently either unavailable, or were not originally published by The PMT. This compilation includes songs from the following albums:
+
+    -[[album:stlap]]<br>
+    (Delisted)<br>
+    -[[album:alternate-hues-and-melodies]]<br>
+    (Delisted)<br>
+    -[[album:stlap2]]<br>
+    (Delisted)<br>
+    -[[album:the-strider-mixtape]]<br>
+    (Delisted)<br>
+    -PMT Soundtest 2<br>
+    (Unreleased)<br>
+    -Through Green Doors<br>
+    -[[album:desynced-vol-1]]<br>
+    -[[album:desynced-vol-2]]<br>
+    -[[album:friendsymphony]]<br>
+    -[[album:s-press-play]]<br>
+    -Welcome to Doomtlis Vol. 1<br>
+    -[[album:lofam5]]
+
+Crediting Sources: |-
+    <i>The Paradox Music Team:</i> ([Bandcamp credits blurb](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection), excerpt)
+
+    Featured artists:
+
+    [[artist:pascal-van-den-bos]]<br>
+    [[artist:rowyn-berlan]]<br>
+    [[artist:caelan-kier]]<br>
+    [[artist:michael-frank]]<br>
+    [[artist:monobrow|monobrow]]<br>
+    [[artist:spad3s]]<br>
+    [[artist:beau-brian]]
+
+    Cover art:<br>
+    [[artist:kiddlescribbles]]
+
+    Album mastering:<br>
+    [[artist:pascal-van-den-bos]]
+---
+Section: Main album
+---
+Track: Solicide
+Main Release: Solicide
+Duration: 2:59
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/solicide-2
+- https://open.spotify.com/track/2dbMyHmTChJjuVMJzUrRXy
+---
+Track: Petrichor
+Main Release: Petrichor
+Duration: 3:06
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/petrichor-2
+- https://open.spotify.com/track/7zBk6uIKpLSyxj41wKFHJD
+---
+Track: D--> Break the Bow
+Additional Names:
+- Name: >-
+    Break the Bow
+  Annotation: >-
+    [Spotify](https://open.spotify.com/track/5XmOcfjEtpRhewOH9iSoGg)
+Directory: break-the-bow
+Main Release: track:break-the-bow
+Duration: 1:52
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/d-break-the-bow-2
+- https://open.spotify.com/track/5XmOcfjEtpRhewOH9iSoGg
+---
+Track: False Feathers
+Main Release: track:false-feathers
+Duration: 5:18
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/false-feathers-2
+- https://open.spotify.com/track/6hBJMH0RBHXNXldXHEVet8
+---
+Track: Duodecim Diis Resurgemus (Part 1)
+Suffix Directory: false
+Always Reference By Directory: false
+Additional Names:
+- Name: >-
+    Duodecim Diis Resurgemus Pt. 1
+  Annotation: >-
+    [Spotify](https://open.spotify.com/track/6aGKAbcZeer9zYmmqTDtHv)
+Artists:
+- Caelan Kier
+Duration: 4:40
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/duodecim-diis-resurgemus-part-1
+- https://open.spotify.com/track/6aGKAbcZeer9zYmmqTDtHv
+Referenced Tracks:
+- Rex Duodecim Angelus
+---
+Track: Versus Remix
+Main Release: track:versus-remix
+Additional Names:
+- Name: >-
+    Versus - Remix
+  Annotation: >-
+    [Spotify](https://open.spotify.com/track/5SokqME0LSSvzdSg80YlS0)
+Duration: 1:12
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/versus-remix-2
+- https://open.spotify.com/track/5SokqME0LSSvzdSg80YlS0
+---
+Track: Celestic Aviators
+Main Release: track:celestic-aviators
+Duration: 3:56
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/celestic-aviators-2
+- https://open.spotify.com/track/12HhjjzZiCVEDjeUTHuG3j
+---
+Track: Distortion Navigator
+Main Release: Distortion Navigator
+Duration: 4:14
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/distortion-navigator-2
+- https://open.spotify.com/track/1LnwDc63QzbkLpyPSeae2r
+---
+Track: Insurrection
+Main Release: track:insurrection-stlap2
+Duration: 4:04
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/insurrection-2
+- https://open.spotify.com/track/3l8M9D0Pyg0Dyo1tgC4jUx
+---
+Track: Black - Electro Swing Remix
+Main Release: track:black-electro-swing-remix
+Duration: 2:55
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/black-electro-swing-remix-2
+- https://open.spotify.com/track/6mAEPkIhLDnbJfDHPK54Sc
+---
+Track: Windwielder
+Main Release: Windwielder
+Duration: 4:34
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/windwielder-2
+- https://open.spotify.com/track/1UWmwC1g1F9rwSjWEBOXFv
+---
+Track: Play the Rain
+Main Release: track:play-the-rain
+Duration: 3:47
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/play-the-rain-2
+- https://open.spotify.com/track/5Ir3hDMwJl1sm7lq9SQK51
+---
+Track: Ascend x10 Combo
+Main Release: track:ascend-x10-combo
+Duration: 2:32
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/ascend-x10-combo-2
+- https://open.spotify.com/track/5WoOhzyJzsyashwnvsK01e
+---
+Track: Blankest Stare
+Main Release: track:blankest-stare
+Duration: 3:06
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/blankest-stare-2
+- https://open.spotify.com/track/1yt4Fm1BhgsrHenZnMtUwg
+---
+Track: Mr. Orange Creamsicles
+Main Release: track:mr-orange-creamsicles
+Duration: 1:55
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/mr-orange-creamsicles-2
+- https://open.spotify.com/track/4cnxNqLg2Tsx0WtcM9l8OK
+---
+Track: Heart Beat
+Main Release: track:heart-beat
+Duration: 2:49
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/heart-beat-2
+- https://open.spotify.com/track/0wFbrvuZVTz5GmoReXcjLy
+---
+Track: Brobot Scrimmage
+Main Release: track:brobot-scrimmage
+Duration: 2:16
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/brobot-scrimmage-3
+- https://open.spotify.com/track/1lpFDjw0JQFXws5f9EkO0k
+---
+Track: Waveform Showdown
+Main Release: track:waveform-showdown
+Duration: 1:26
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/waveform-showdown-2
+- https://open.spotify.com/track/231V7dON3B1QlQsWoPILeC
+---
+Track: MeGaLoVania (BeforusBound) DX
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 2:40
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/megalovania-beforusbound-dx
+- https://open.spotify.com/track/75Xd8CUqBMsKoYV1jOOVQb
+Referenced Tracks:
+- MeGaLoVania (BeforusBound)
+---
+Track: Paradox Pariah
+Main Release: track:paradox-pariah
+Duration: 2:34
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/paradox-pariah
+- https://open.spotify.com/track/3tEsw7BkmRb9Qvb507Y162
+---
+Track: Kaiyan's Theme
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 0:49
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/kaiyans-theme
+- https://open.spotify.com/track/2HagAO3RnQKscLu6ElI6ZG
+---
+Track: Bronze Comedian
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 2:01
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/bronze-comedian
+- https://open.spotify.com/track/4q6Cvb77VbcE51Bvo2QjUS
+---
+Track: Cornflower Ascension
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 1:52
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/cornflower-ascension
+- https://open.spotify.com/track/6ZMv9Ily8X7qRC63uT24Dz
+---
+Track: She's a Witch!
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 3:28
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/shes-a-witch
+- https://open.spotify.com/track/5xPOqhMFASmnQ28GrPvEUn
+Referenced Tracks:
+- Graceful Twilight
+- track:gratification-paradox-music-team
+---
+Track: Sunrise
+Main Release: track:sunrise-desynced
+Duration: 3:05
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/sunrise
+- https://open.spotify.com/track/36XBmEhikEDpLXttyY0D62
+---
+Track: Temporal Guardian
+Main Release: track:temporal-guardian
+Duration: 2:32
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/temporal-guardian
+- https://open.spotify.com/track/6jYZQtydAI4vHzxPbtAxzv
+---
+Track: Alpha Admission
+Main Release: track:alpha-admission
+Duration: 3:46
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/alpha-admission
+- https://open.spotify.com/track/2PNLTiaH8YYB60JWVjclHs
+---
+Track: We'll be Right Back
+Main Release: track:well-be-right-back
+Duration: 2:05
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/well-be-right-back
+- https://open.spotify.com/track/13cHq41UNIefRwnc3tYt6Y
+---
+Track: Noir
+Main Release: track:noir-desynced
+Duration: 2:13
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/noir
+- https://open.spotify.com/track/5kaoRj4LFfD8ITkFWPeAo8
+---
+Track: Lullaby for a Drifter
+Main Release: track:lullaby-for-a-drifter
+Duration: 2:26
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/lullaby-for-a-drifter
+- https://open.spotify.com/track/3Ofc4LXYiWpG7fVuMIdIy7
+---
+Track: Lunar Dance
+Main Release: track:lunar-dance
+Duration: 4:10
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/lunar-dance
+- https://open.spotify.com/track/7HSOLov3K7pjTTb0TtKn9i
+---
+Track: Heart of the Land
+Main Release: track:heart-of-the-land
+Duration: 1:42
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/heart-of-the-land
+- https://open.spotify.com/track/3MxMpT6hqD5kMHOM8vNpH3
+---
+Track: Town of Breath
+Main Release: track:town-of-breath
+Duration: 1:33
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/town-of-breath
+- https://open.spotify.com/track/25BY1AelePitJWPtPydFgI
+---
+Track: Rocket Power
+Main Release: track:rocket-power
+Duration: 2:28
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/rocket-power
+- https://open.spotify.com/track/6kJZtJ0oo47dqCH1JKFhXf
+---
+Track: Celestial Blaze
+Main Release: track:celestial-blaze
+Duration: 2:45
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/celestial-blaze
+- https://open.spotify.com/track/6kASXbzhUCe6ZBWtG4AFA7
+---
+Track: Arrival
+Main Release: track:arrival-desynced
+Duration: 6:56
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/arrival
+- https://open.spotify.com/track/3SsfrzDbFqYutfAqGgIgsA
+---
+Track: Set​-​Course Praerept​ŏ​r
+Directory: set-course-praereptor
+Main Release: track:set-course-praereptor
+Duration: 4:05
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/set-course-praerept-r
+- https://open.spotify.com/track/5eAZuEj2VzRPTz4Z44nb1m
+---
+Track: Diving Beatles
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 2:18
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/diving-beatles
+- https://open.spotify.com/track/62xDgBJIPHrphuGqMPqaLU
+---
+Track: Collapse Reprise
+Main Release: track:collapse-reprise
+Duration: 5:46
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/collapse-reprise
+- https://open.spotify.com/track/4rIxnVqIiGHIfUNBgySv10
+---
+Track: Tarolive Coast
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Pascal van den Bos
+Duration: 2:11
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/tarolive-coast-2
+- https://open.spotify.com/track/6HIFd2hxUXSVbUSI5crpHM
+---
+Track: Crimson Universe
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Caelan Kier (composition)
+- Pascal van den Bos (arrangement)
+Duration: 2:08
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/crimson-universe
+- https://open.spotify.com/track/5o5SYvN63yN4LQjLWGRLeV
+---
+Track: Pierce the Sky
+Suffix Directory: false
+Always Reference By Directory: false
+Artists:
+- Caelan Kier
+Duration: 2:16
+URLs:
+- https://pascalpotatovandenbos.bandcamp.com/track/pierce-the-sky
+- https://open.spotify.com/track/5a6dj7DT89FJsFLFIhkfLO
+Referenced Tracks:
+- Sunsetter
+- Sburban Jungle
+- Spider's Claw
+- All Alone
+- Distortion Navigator

--- a/album/pmt-classic-selection.yaml
+++ b/album/pmt-classic-selection.yaml
@@ -13,7 +13,7 @@ Groups:
 - The Paradox Music Team
 - Fandom
 Commentary: |-
-    <i>The Paradox Music Team:</i> ([Bandcamp about blurb](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection), excerpt)
+    @@ [Bandcamp about blurb, excerpt](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection)
 
     A compilation album of classic PMT songs that are currently either unavailable, or were not originally published by The PMT. This compilation includes songs from the following albums:
 
@@ -31,7 +31,7 @@ Commentary: |-
     - [[album:lofam5]]
 
 Crediting Sources: |-
-    <i>The Paradox Music Team:</i> ([Bandcamp credits blurb](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection), excerpt)
+    @@ [Bandcamp credits blurb, excerpt](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection)
 
     Featured artists:
 

--- a/album/pmt-classic-selection.yaml
+++ b/album/pmt-classic-selection.yaml
@@ -53,6 +53,8 @@ Section: Main album
 ---
 Track: Solicide
 Main Release: Solicide
+Artists:
+- Caelan Kier
 Duration: 2:59
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/solicide-2
@@ -60,6 +62,8 @@ URLs:
 ---
 Track: Petrichor
 Main Release: Petrichor
+Artists:
+- Caelan Kier
 Duration: 3:06
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/petrichor-2
@@ -73,6 +77,8 @@ Additional Names:
     [Spotify](https://open.spotify.com/track/5XmOcfjEtpRhewOH9iSoGg)
 Directory: break-the-bow
 Main Release: track:break-the-bow
+Artists:
+- Caelan Kier
 Duration: 1:52
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/d-break-the-bow-2
@@ -80,6 +86,8 @@ URLs:
 ---
 Track: False Feathers
 Main Release: track:false-feathers
+Artists:
+- Caelan Kier
 Duration: 5:18
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/false-feathers-2
@@ -110,6 +118,8 @@ Additional Names:
     Versus - Remix
   Annotation: >-
     [Spotify](https://open.spotify.com/track/5SokqME0LSSvzdSg80YlS0)
+Artists:
+- Michael Frank
 Duration: 1:12
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/versus-remix-2
@@ -117,6 +127,8 @@ URLs:
 ---
 Track: Celestic Aviators
 Main Release: track:celestic-aviators
+Artists:
+- Caelan Kier
 Duration: 3:56
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/celestic-aviators-2
@@ -124,6 +136,8 @@ URLs:
 ---
 Track: Distortion Navigator
 Main Release: Distortion Navigator
+Artists:
+- Caelan Kier
 Duration: 4:14
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/distortion-navigator-2
@@ -131,6 +145,8 @@ URLs:
 ---
 Track: Insurrection
 Main Release: track:insurrection-stlap2
+Artists:
+- Caelan Kier
 Duration: 4:04
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/insurrection-2
@@ -138,6 +154,8 @@ URLs:
 ---
 Track: Black - Electro Swing Remix
 Main Release: track:black-electro-swing-remix
+Artists:
+- Spad3s
 Duration: 2:55
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/black-electro-swing-remix-2
@@ -145,6 +163,8 @@ URLs:
 ---
 Track: Windwielder
 Main Release: Windwielder
+Artists:
+- Caelan Kier
 Duration: 4:34
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/windwielder-2
@@ -152,6 +172,8 @@ URLs:
 ---
 Track: Play the Rain
 Main Release: track:play-the-rain
+Artists:
+- Monobrow
 Duration: 3:47
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/play-the-rain-2
@@ -159,6 +181,8 @@ URLs:
 ---
 Track: Ascend x10 Combo
 Main Release: track:ascend-x10-combo
+Artists:
+- Pascal van den Bos
 Duration: 2:32
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/ascend-x10-combo-2
@@ -166,6 +190,8 @@ URLs:
 ---
 Track: Blankest Stare
 Main Release: track:blankest-stare
+Artists:
+- Pascal van den Bos
 Duration: 3:06
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/blankest-stare-2
@@ -173,6 +199,8 @@ URLs:
 ---
 Track: Mr. Orange Creamsicles
 Main Release: track:mr-orange-creamsicles
+Artists:
+- Pascal van den Bos
 Duration: 1:55
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/mr-orange-creamsicles-2
@@ -180,6 +208,8 @@ URLs:
 ---
 Track: Heart Beat
 Main Release: track:heart-beat
+Artists:
+- Pascal van den Bos
 Duration: 2:49
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/heart-beat-2
@@ -198,6 +228,8 @@ Referenced Tracks:
 ---
 Track: Waveform Showdown
 Main Release: track:waveform-showdown
+Artists:
+- Pascal van den Bos
 Duration: 1:26
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/waveform-showdown-2
@@ -217,6 +249,8 @@ Referenced Tracks:
 ---
 Track: Paradox Pariah
 Main Release: track:paradox-pariah
+Artists:
+- Caelan Kier
 Duration: 2:34
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/paradox-pariah
@@ -267,6 +301,8 @@ Referenced Tracks:
 ---
 Track: Sunrise
 Main Release: track:sunrise-desynced
+Artists:
+- Pascal van den Bos
 Duration: 3:05
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/sunrise
@@ -274,6 +310,8 @@ URLs:
 ---
 Track: Temporal Guardian
 Main Release: track:temporal-guardian
+Artists:
+- Pascal van den Bos
 Duration: 2:32
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/temporal-guardian
@@ -281,6 +319,8 @@ URLs:
 ---
 Track: Alpha Admission
 Main Release: track:alpha-admission
+Artists:
+- Pascal van den Bos
 Duration: 3:46
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/alpha-admission
@@ -288,6 +328,9 @@ URLs:
 ---
 Track: We'll be Right Back
 Main Release: track:well-be-right-back
+Artists:
+- Rowyn Berlan
+- Beau Brian
 Duration: 2:05
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/well-be-right-back
@@ -295,6 +338,8 @@ URLs:
 ---
 Track: Noir
 Main Release: track:noir-desynced
+Artists:
+- Pascal van den Bos
 Duration: 2:13
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/noir
@@ -302,6 +347,8 @@ URLs:
 ---
 Track: Lullaby for a Drifter
 Main Release: track:lullaby-for-a-drifter
+Artists:
+- Rowyn Berlan
 Duration: 2:26
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/lullaby-for-a-drifter
@@ -309,6 +356,8 @@ URLs:
 ---
 Track: Lunar Dance
 Main Release: track:lunar-dance
+Artists:
+- Pascal van den Bos
 Duration: 4:10
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/lunar-dance
@@ -316,6 +365,8 @@ URLs:
 ---
 Track: Heart of the Land
 Main Release: track:heart-of-the-land
+Artists:
+- Pascal van den Bos
 Duration: 1:42
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/heart-of-the-land
@@ -323,6 +374,8 @@ URLs:
 ---
 Track: Town of Breath
 Main Release: track:town-of-breath
+Artists:
+- Pascal van den Bos
 Duration: 1:33
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/town-of-breath
@@ -330,6 +383,8 @@ URLs:
 ---
 Track: Rocket Power
 Main Release: track:rocket-power
+Artists:
+- Pascal van den Bos
 Duration: 2:28
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/rocket-power
@@ -337,6 +392,8 @@ URLs:
 ---
 Track: Celestial Blaze
 Main Release: track:celestial-blaze
+Artists:
+- Pascal van den Bos
 Duration: 2:45
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/celestial-blaze
@@ -344,6 +401,8 @@ URLs:
 ---
 Track: Arrival
 Main Release: track:arrival-desynced
+Artists:
+- Pascal van den Bos
 Duration: 6:56
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/arrival
@@ -352,6 +411,8 @@ URLs:
 Track: Set-Course Praereptŏr
 Directory: set-course-praereptor
 Main Release: track:set-course-praereptor
+Artists:
+- Caelan Kier
 Duration: 4:05
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/set-course-praerept-r
@@ -369,6 +430,8 @@ URLs:
 ---
 Track: Collapse Reprise
 Main Release: track:collapse-reprise
+Artists:
+- Pascal van den Bos
 Duration: 5:46
 URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/collapse-reprise

--- a/album/the-strider-mixtape.yaml
+++ b/album/the-strider-mixtape.yaml
@@ -162,9 +162,8 @@ Art Tags:
 # - Twin M9 Berettas
 - Frog Temple
 - Earth
-Previous Productions:
-- track:brobot-scrimmage-original
 Referenced Tracks:
+- track:brobot-scrimmage-original
 - track:heir-of-grief
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)

--- a/album/the-strider-mixtape.yaml
+++ b/album/the-strider-mixtape.yaml
@@ -162,6 +162,8 @@ Art Tags:
 # - Twin M9 Berettas
 - Frog Temple
 - Earth
+Previous Productions:
+- track:brobot-scrimmage-original
 Referenced Tracks:
 - track:heir-of-grief
 Commentary: |-

--- a/groups.yaml
+++ b/groups.yaml
@@ -265,6 +265,7 @@ Series:
   - The Nobles
   - On the Rox
   - The Homestuck Strife Project Vol. 1 (Original Soundtrack)
+  - PMT Classic Selection
 - Name: Pokémon Unbound
   Albums:
   - 'GBA Pokémon Unbound: Super Music Collection'

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -334,7 +334,7 @@ Content: |-
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:secretz-barz]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:your-quest-bed]] not sampling [[track:your-bed]] (thanks, Lilith!)
-    - fixed [[track:duodecim-diis-resurgemus]] not referencing [[track:duodecim-diis-resurgemus-part-1]] (thanks, Lilith!)
+    - fixed [[track:brobot-scrimmage]] not referencing [[track:brobot-scrimmage-original]] (thanks, Lilith!)
     - fixed [[track:gold-mage-playtime-is-over-mix]] referencing [[track:gold-mage]] instead of [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -289,6 +289,8 @@ Content: |-
     - touched up commentary in [[track:showtime-svix-mix]] (thanks, Tangle!)
     - moved stuff from commentary into crediting and referencing sources in [[track:showtime-svix-mix]], [[track:versus-hardmode-remix]], [[track:the-showdown-single-version]], [[track:adventurous-ascent-single-version]], [[track:the-showdown-album-version]], [[track:adventurous-ascent-lofam5a2-version]], [[track:infinite-cataclysm]], [[track:vivid-spectrum]], [[track:old-world]], and [[track:losing-heart]] (thanks, Tangle, Lanolin!)
     - removed a bunch of commentary from [[track:adventurous-ascent-lofam5a2-version]] that was just duplicated from the LOFAM5A2 album booklet
+    <!-- new previous productions -->
+    - added [[track:brobot-scrimmage-original]] as a previous production for [[track:brobot-scrimmage]] (thanks, Lilith!)
     <!-- tracks newly marked as a secondary release -->
     - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
@@ -334,7 +336,6 @@ Content: |-
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:secretz-barz]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:your-quest-bed]] not sampling [[track:your-bed]] (thanks, Lilith!)
-    - fixed [[track:brobot-scrimmage]] not referencing [[track:brobot-scrimmage-original]] (thanks, Lilith!)
     - fixed [[track:gold-mage-playtime-is-over-mix]] referencing [[track:gold-mage]] instead of [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -80,6 +80,8 @@ Content: |-
     <h3>album additions</h3>
     - added latest release from [[group:unofficial-mspa-fans]]! (thanks, <<ruby:album data, presentation, research>>, plus <<Jebb:album presentation help>>, <<Lilith:URL fix, bonus track artwork data>>, <<Cello:bonus track artwork help>>, <<Makin:URLs & bonus track artwork crediting help>>, <<Monckat:track duration fix>>!)
         - added [[album:kindred-souls]]!
+    - added latest release from [[group:the-paradox-music-team]]! (thanks, <<Lilith:album data, presentation, research>>!)
+        - added [[album:pmt-classic-selection]]!
     - added latest release from [[group:studio-june]]! (thanks, <<Lilith:album data, presentation, research>>, plus <<ruby:References Beyond Homestuck help>>, <<articulatelyComposed:artwork crediting help>>!)
         - added [[album:friendsim-2-volume-2]]!
     - added albums from [[group:cheezquest]]! (thanks, <<Jebb:album data, presentation, research>>, <<Lan:data review, additional research>>, plus <<Josh:research help>>, <<Dust:research help>>, <<t2k:artwork referencing help>>!)
@@ -332,6 +334,7 @@ Content: |-
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:secretz-barz]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:your-quest-bed]] not sampling [[track:your-bed]] (thanks, Lilith!)
+    - fixed [[track:duodecim-diis-resurgemus]] not referencing [[track:duodecim-diis-resurgemus-part-1]] (thanks, Lilith!)
     - fixed [[track:gold-mage-playtime-is-over-mix]] referencing [[track:gold-mage]] instead of [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -289,8 +289,6 @@ Content: |-
     - touched up commentary in [[track:showtime-svix-mix]] (thanks, Tangle!)
     - moved stuff from commentary into crediting and referencing sources in [[track:showtime-svix-mix]], [[track:versus-hardmode-remix]], [[track:the-showdown-single-version]], [[track:adventurous-ascent-single-version]], [[track:the-showdown-album-version]], [[track:adventurous-ascent-lofam5a2-version]], [[track:infinite-cataclysm]], [[track:vivid-spectrum]], [[track:old-world]], and [[track:losing-heart]] (thanks, Tangle, Lanolin!)
     - removed a bunch of commentary from [[track:adventurous-ascent-lofam5a2-version]] that was just duplicated from the LOFAM5A2 album booklet
-    <!-- new previous productions -->
-    - added [[track:brobot-scrimmage-original]] as a previous production for [[track:brobot-scrimmage]] (thanks, Lilith!)
     <!-- tracks newly marked as a secondary release -->
     - marked [[track:maibasojen-lofam]] ([[album:lofam]]) newly as a secondary release (thanks, Lilith!)
     - marked [[track:denizen-lofam4]] ([[album:lofam4]]) newly as a secondary release (thanks, Jebb!)
@@ -336,6 +334,7 @@ Content: |-
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:secretz-barz]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:your-quest-bed]] not sampling [[track:your-bed]] (thanks, Lilith!)
+    - fixed [[track:brobot-scrimmage]] not referencing [[track:brobot-scrimmage-original]] (thanks, Lilith!)
     - fixed [[track:gold-mage-playtime-is-over-mix]] referencing [[track:gold-mage]] instead of [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)


### PR DESCRIPTION
The [long-awaited compilation](https://pascalpotatovandenbos.bandcamp.com/album/pmt-classic-selection) of delisted PMT tracks, not released on the PMT label tracks, and 7 not released at all tracks is finally here! (tracks stem from: STLaP, Alternate Hues and Melodies, STLaP 2, The Strider Mixtape, FriendSymphony, Desynced Vol. 1, Desynced Vol. 2, [S] Press Play., WTD ALBUM vol. 1 (not on wiki yet), and LoFaM 5!)

Also tweaks reference table of [Brobot Scrimmage](https://preview.hsmusic.wiki/track/brobot-scrimmage/).

Merge with: [hsmusic-media#176](https://github.com/hsmusic/hsmusic-media/pull/176)