### PR TITLE
PMT apple music links + fixed Safari Zone (night selection) main release

### DIFF
--- a/album/beforusbound.yaml
+++ b/album/beforusbound.yaml
@@ -246,6 +246,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/latulas-theme
 - https://youtu.be/w3dqIO1w3lg
 - https://open.spotify.com/track/6E9ENhli4FmS97sWKoYLG9
+- https://music.apple.com/song/latulas-theme/1555060469
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -272,6 +273,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dwelling-among-the-dream-bubbles
 - https://www.youtube.com/watch?v=5x4ZQcwwBzM
 - https://open.spotify.com/track/0c6RPK0Z01jckGtBG5VzRl
+- https://music.apple.com/song/dwelling-among-the-dreambubbles/1555060471
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -292,6 +294,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/lapis-arbalester
 - https://youtu.be/mUsT4gsZt9I
 - https://open.spotify.com/track/2QWBhkGdCRf6BjSQi9KaMt
+- https://music.apple.com/song/lapis-arbalester/1555060472
 Commentary: |-
     <i>Caelan Kier:</i> (composer, booklet commentary)
 
@@ -317,6 +320,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/final-darkness
 - https://youtu.be/5-ROuadDQKU
 - https://open.spotify.com/track/5GNhtVOEQiXz46xwmqWIx9
+- https://music.apple.com/song/final-darkness/1555060473
 Commentary: |-
     <i>Stacatto Force:</i> (composer, booklet commentary)
 
@@ -361,6 +365,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/vwhat-if-im-a-failure
 - https://youtu.be/J6zVuH0rrjY
 - https://open.spotify.com/track/6zapNyXIhFsgAsL0xzqlV7
+- https://music.apple.com/song/vwhat-if-im-a-failure/1555060474
 Commentary: |-
     <i>Pascal van den Bos:</i> (album team, booklet commentary)
 
@@ -387,6 +392,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/trident-thief
 - https://youtu.be/jVQwahj_lzw
 - https://open.spotify.com/track/67sP2zeo1rHqMDtlxn56b4
+- https://music.apple.com/song/trident-thief/1555060475
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -407,6 +413,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/spirited-euphoria
 - https://youtu.be/39NV32h4FJQ
 - https://open.spotify.com/track/4TYwYfwVzSabWaha2cxwma
+- https://music.apple.com/song/spirited-euphoria/1555060596
 Commentary: |-
     <i>Rowyn Berlan:</i> (composer, booklet commentary)
 
@@ -432,6 +439,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/center-stage
 - https://youtu.be/cOROnQ2kfPk
 - https://open.spotify.com/track/5czj5hiJuLU3oE9jZ8Ntfq
+- https://music.apple.com/song/center-stage/1555060597
 Commentary: |-
     <i>Rainy:</i> (composer, booklet commentary)
 
@@ -460,6 +468,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/indirectly-hate-you
 - https://youtu.be/TjT3w13DmeA
 - https://open.spotify.com/track/6DmexYrwHfCif8mC6qPJvl
+- https://music.apple.com/song/indirectly-hate-you/1555060598
 Commentary: |-
     <i>Stacatto Force:</i> (composer, booklet commentary)
 
@@ -485,6 +494,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/jaded-luminescence
 - https://youtu.be/iOhacYBoe54
 - https://open.spotify.com/track/7vVY1Ed3vFmgCjSlSJziBZ
+- https://music.apple.com/song/jaded-luminescence/1555060599
 Commentary: |-
     <i>Rowyn Berlan:</i> (composer, booklet commentary)
 
@@ -515,6 +525,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/mitunas-theme
 - https://youtu.be/bbgDLVZguPs
 - https://open.spotify.com/track/1xlUOuMgsXpT0UFe0f5t3J
+- https://music.apple.com/song/mitunas-theme/1555060600
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -536,6 +547,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/porrims-theme
 - https://youtu.be/O6Ch1Qq1XjQ
 - https://open.spotify.com/track/1rjvKDytsTN3UvAlvLwLJL
+- https://music.apple.com/song/porrims-theme/1555060602
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -561,6 +573,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/achieving-new-radical-heights
 - https://youtu.be/QVMHhizspqU
 - https://open.spotify.com/track/2U5vT3CQLQq1J9Hd6meRER
+- https://music.apple.com/song/achieving-new-radical-heights/1555060604
 Commentary: |-
     <i>Rowyn Berlan:</i> (composer, booklet commentary)
 
@@ -598,6 +611,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/purriferal-affections
 - https://youtu.be/br8KPWCd_c8
 - https://open.spotify.com/track/3Fh3LKS15NlJERW6n9T84t
+- https://music.apple.com/song/purriferal-affections/1555060605
 Commentary: |-
     <i>Beau Brian:</i> (composer, booklet commentary)
 
@@ -638,6 +652,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/reboot
 - https://youtu.be/GHfGuWAOqPk
 - https://open.spotify.com/track/1nEBNMSanb3EAvpB5XkdOT
+- https://music.apple.com/song/reboot/1555060607
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -658,6 +673,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/character-catastrophe
 - https://youtu.be/B_QTer0aB64
 - https://open.spotify.com/track/3LkQfNKqlZuFQALDfublI3
+- https://music.apple.com/song/character-catastrophe/1555060608
 Commentary: |-
     <i>Caelan Kier:</i> (composer, booklet commentary)
 
@@ -688,6 +704,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/nostalgic-landscapes
 - https://youtu.be/tgUtUyFuyE8
 - https://open.spotify.com/track/7f1FSb4cDTwVQrgIwX9rfJ
+- https://music.apple.com/song/nostalgic-landscapes/1555060609
 Commentary: |-
     <i>Rainy:</i> (composer, booklet commentary)
 
@@ -717,6 +734,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/megalovania-beforusbound
 - https://youtu.be/u0vY0wCPgFQ
 - https://open.spotify.com/track/7uH318toMQubf3ctuMle3Q
+- https://music.apple.com/song/megalovania-beforusbound/1555060611
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -741,6 +759,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/insufferable-sufferer
 - https://youtu.be/8Ge1YQNS-ok
 - https://open.spotify.com/track/7ctDWbQ3iOO1eEre0u95TN
+- https://music.apple.com/song/insufferable-sufferer/1555060613
 Commentary: |-
     <i>Rowyn Berlan:</i> (composer, booklet commentary)
 
@@ -764,6 +783,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/first-tumor-second-life
 - https://youtu.be/NcM09mRE3HQ
 - https://open.spotify.com/track/7JYmGcQAOwCXJBVhl2GiiV
+- https://music.apple.com/song/first-tumor-second-life/1555060614
 Commentary: |-
     <i>Beau Brian:</i> (composer, booklet commentary)
 
@@ -835,6 +855,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-future-we-could-never-have
 - https://youtu.be/T5f7_KWc9Wk
 - https://open.spotify.com/track/1Lt6vPU4DjXrT1clBNzJnv
+- https://music.apple.com/song/the-future-we-could-never-have/1555060615
 Commentary: |-
     <i>Rainy:</i> (composer, booklet commentary)
 
@@ -866,6 +887,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/beforusbound
 - https://youtu.be/B5kKx9Zqu3k
 - https://open.spotify.com/track/4PURFLhh81WIBDG3T3G7bM
+- https://music.apple.com/song/beforusbound/1555060616
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -890,6 +912,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/victory
 - https://youtu.be/zIsOBE6jcVM
 - https://open.spotify.com/track/2vOazi1l9wT13XPLgr3GPj
+- https://music.apple.com/song/victory/1555060617
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 
@@ -916,6 +939,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/time-to-rest
 - https://youtu.be/VftkrXu2DcM
 - https://open.spotify.com/track/2FuM06ukCFW5yPiFGUCZPv
+- https://music.apple.com/song/time-to-rest/1555060620
 Commentary: |-
     <i>Pascal van den Bos:</i> (composer, booklet commentary)
 

--- a/album/beforusbound.yaml
+++ b/album/beforusbound.yaml
@@ -22,6 +22,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/beforusbound
 - https://youtube.com/playlist?list=PLtcgklmZsk9BDyCXsNHeEBCJrZHrDmTcY
 - https://open.spotify.com/album/0yU3CESplqzOh0T0VKqvtk
+- https://music.apple.com/album/beforusbound/1555060454
 Groups:
 - The Paradox Music Team
 - Fandom
@@ -65,6 +66,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/all-alone
 - https://youtu.be/mPeoGtCzqnk
 - https://open.spotify.com/track/5czj5hiJuLU3oE9jZ8Ntfq
+- https://music.apple.com/song/all-alone/1555060462
 Commentary: |-
     <i>Rainy:</i> (composer, booklet commentary)
 
@@ -93,6 +95,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/phosphor-bronze
 - https://youtu.be/7cYfLT3okb0
 - https://open.spotify.com/track/08lgpIpro2XhCAsnmxHl4a
+- https://music.apple.com/song/phosphor-bronze/1555060464
 Commentary: |-
     <i>Caelan Kier:</i> (composer, booklet commentary)
 
@@ -122,6 +125,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/fate-of-the-heir
 - https://www.youtube.com/watch?v=JrwpRVvPaKk
 - https://open.spotify.com/track/4ne0NBd3MAxzjUYWL5ZKSk
+- https://music.apple.com/song/fate-of-the-heir/1555060465
 Commentary: |-
     <i>Rowyn Berlan:</i> (composer, booklet commentary)
 
@@ -149,6 +153,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/a-6elief-in-s9mething-higher
 - https://youtu.be/h-MSv_jnj2o
 - https://open.spotify.com/track/376sHRj9BdQcXYWnbhMoNM
+- https://music.apple.com/song/a-6elief-in-s9mething-higher/1555060466
 Commentary: |-
     <i>Beau Brian:</i> (composer, booklet commentary)
 
@@ -177,6 +182,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/hand-in-hand
 - https://youtu.be/2XsiY2qJefQ
 - https://open.spotify.com/track/7AuJAIW1sfoQ7sKaQeQhv4
+- https://music.apple.com/song/hand-in-hand/1555060467
 Commentary: |-
     <i>Rainy:</i> (composer, booklet commentary)
 
@@ -204,6 +210,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/gentle-heat
 - https://youtu.be/ZRSFpObn6nE
 - https://open.spotify.com/track/7uH318toMQubf3ctuMle3Q
+- https://music.apple.com/song/gentle-heat/1555060468
 Commentary: |-
     <i>Beau Brian:</i> (composer, booklet commentary)
 

--- a/album/midnight-jungle-type-1-5-vertigo-zone.yaml
+++ b/album/midnight-jungle-type-1-5-vertigo-zone.yaml
@@ -7,6 +7,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/midnight-jungle-type-15-vertigo-zone
 - https://youtube.com/playlist?list=PLtcgklmZsk9AmYycOkUQvjMObhhfVWl9C
 - https://open.spotify.com/album/0WC9LsadN1I3pUBgi8qqOn?si=1tkuawhkQ8u6xuP5MpFZ9Q
+- https://music.apple.com/album/midnight-jungle-type-1-5-vertigo-zone-%E7%9C%9F%E5%A4%9C%E4%B8%AD%E3%81%AE%E3%82%B8%E3%83%A3%E3%83%B3%E3%82%B0%E3%83%AB-%E7%9B%AE%E7%9C%A9%E3%82%BE%E3%83%BC%E3%83%B3/1757050256
 Artists:
 - Pascal van den Bos
 Cover Artists:
@@ -74,6 +75,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/neo-racing-roots-24-intro-feat-shirma-rouse
 - https://youtu.be/vM48XU6PYZU
 - https://open.spotify.com/track/50aRxFPsa7r1xEmBxHtcFx
+- https://music.apple.com/song/neo-racing-roots-24-intro/1757050257
 Lyrics: |-
     Race, go
     On the motorway
@@ -110,6 +112,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/as-you-choose-4th-main-menu
 - https://youtu.be/qV7DdlIkoDI
 - https://open.spotify.com/track/1Sgd2GnX6SxQUv9G8cJxdW
+- https://music.apple.com/song/as-you-choose-4th-main-menu/1757050258
 ---
 Track: EYES OPEN -machine select-
 Duration: '2:53'
@@ -117,6 +120,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/eyes-open-machine-select
 - https://youtu.be/mbmCur_aL78
 - https://open.spotify.com/track/7cnkwG8QDKO81pB2H1BhVt
+- https://music.apple.com/song/eyes-open-machine-select/1757050259
 ---
 Track: TAKE YOUR PLACE -course view-
 Additional Names:
@@ -128,6 +132,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/take-your-place-course-view-feat-gitgot
 - https://youtu.be/xVUQWlRaqpY
 - https://open.spotify.com/track/1cOzlil7oNgDnGlR5Sl4YM
+- https://music.apple.com/song/take-your-place-course-view-feat-gitgot/1757050260
 ---
 Track: 1ST HEAT
 Additional Names:
@@ -139,6 +144,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/1st-heat-feat-ywan
 - https://youtu.be/0GKa4eoVdls
 - https://open.spotify.com/track/0l002brYk04PwHE3XbRSFU
+- https://music.apple.com/song/1st-heat/1757050261
 ---
 Track: HI-SPEC
 Duration: '3:27'
@@ -146,6 +152,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/hi-spec
 - https://youtu.be/HxzycY00rRM
 - https://open.spotify.com/track/6r7lI9fGwFOzTlHVbXn4UR
+- https://music.apple.com/song/hi-spec/1757050262
 ---
 Track: FULL MOON/QUARTER MOON
 Duration: '3:03'
@@ -153,6 +160,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/full-moon-quarter-moon
 - https://youtu.be/yqFZSmvQDfk
 - https://open.spotify.com/track/1sOR8abxvmqsv9UOKPkoh1
+- https://music.apple.com/song/full-moon-quarter-moon/1757050263
 ---
 Track: VERTIGO ZONE
 Duration: '2:33'
@@ -162,6 +170,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/vertigo-zone
 - https://youtu.be/Em1S5w2H_qw
 - https://open.spotify.com/track/5AoQ6ujhOGCarUjEzHGakS
+- https://music.apple.com/song/vertigo-zone/1757050264
 ---
 Track: MIDNIGHT JUNGLE -the finish is so close-
 Duration: '4:10'
@@ -174,6 +183,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/midnight-jungle-the-finish-is-so-close
 - https://youtu.be/Bj8_dwfC5ls
 - https://open.spotify.com/track/0OFlU0zJQ2lnnHyqiUOR3b
+- https://music.apple.com/song/midnight-jungle-the-finish-is-so-close/1757050265
 ---
 Track: MIDNIGHT FM -interlude-
 Duration: '2:50'
@@ -183,6 +193,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/midnight-fm-interlude
 - https://youtu.be/ZO_Hvl7GDzc
 - https://open.spotify.com/track/7udLjlNcAAlnCHARaws53w
+- https://music.apple.com/song/midnight-fm-interlude/1757050266
 ---
 Track: 2ND HEAT
 Duration: '3:06'
@@ -194,6 +205,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/2nd-heat
 - https://youtu.be/tK-upqSPXjU
 - https://open.spotify.com/track/2W3LSF8AOoLYYXfJKX8SFC
+- https://music.apple.com/song/2nd-heat/1757050267
 ---
 Track: CONCRETE WASHING MACHINES
 Duration: '2:46'
@@ -201,6 +213,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/concrete-washing-machines
 - https://youtu.be/ODE6cj1GebY
 - https://open.spotify.com/track/3Edig2qcxB63ro6Jjqeh9D
+- https://music.apple.com/song/concrete-washing-machines/1757050268
 ---
 Track: SPIKED
 Suffix Directory: true
@@ -210,6 +223,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/spiked
 - https://youtu.be/tp_YqbhVrFs
 - https://open.spotify.com/track/1HwUolhj852T70hNWJULmu
+- https://music.apple.com/song/spiked/1757050269
 ---
 Track: CORROSION
 Suffix Directory: true
@@ -223,6 +237,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/corrosion-feat-v1ny4rd
 - https://youtu.be/M10m7wkKNTI
 - https://open.spotify.com/track/3NzYDfNuoh122UYOuaheOz
+- https://music.apple.com/song/corrosion/1757050270
 ---
 Track: MICHAELWAVE
 Artists:
@@ -235,6 +250,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/michaelwave
 - https://youtu.be/WPKzgNAdv9U
 - https://open.spotify.com/track/32BoIiw5iL1PIyP1mlzNZY
+- https://music.apple.com/song/michaelwave/1757050271
 ---
 Track: 404ME
 Artists:
@@ -247,6 +263,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/michaelwave
 - https://youtu.be/twLgNvBSrqI
 - https://open.spotify.com/track/2TzY8eWX4d6BSconHLcmXL
+- https://music.apple.com/song/404me/1757050272
 ---
 Track: EPILOGUE
 Directory: epilogue-midnight-jungle-type-1-5-vertigo-zone
@@ -258,6 +275,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/epilogue
 - https://youtu.be/kXD0faEA9lQ
 - https://open.spotify.com/track/5QK0MvDuWte9lhqeMGp6w8
+- https://music.apple.com/song/epilogue/1757050273
 ---
 Track: BO -finale-
 Duration: '1:51'
@@ -265,3 +283,4 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/bo-finale
 - https://youtu.be/t4hDhczYRsY
 - https://open.spotify.com/track/1fbm1RsF9JsGOw67pfT4Pd
+- https://music.apple.com/song/bo-finale/1757050274

--- a/album/midnight-jungle.yaml
+++ b/album/midnight-jungle.yaml
@@ -6,6 +6,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/midnight-jungle
 - https://youtube.com/playlist?list=PLtcgklmZsk9AgYgOgakpMRBXuHB_zh5JW
 - https://open.spotify.com/album/0VuAwLUPiZSPikvWxnOjWF
+- https://music.apple.com/album/midnight-jungle-%E7%9C%9F%E5%A4%9C%E4%B8%AD%E3%81%AE%E3%82%B8%E3%83%A3%E3%83%B3%E3%82%B0%E3%83%AB/1621329660
 Cover Artists:
 - Ayoki 
 - Caelan Kier
@@ -47,6 +48,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/midnight-jungle
 - https://youtu.be/RCzxs11QDGM
 - https://open.spotify.com/track/6DAype8VMriF6KZLVHBSXU
+- https://music.apple.com/song/midnight-jungle-%E7%9C%9F%E5%A4%9C%E4%B8%AD%E3%81%AE%E3%82%B8%E3%83%A3%E3%83%B3%E3%82%B0%E3%83%AB/1621329661
 ---
 Track: Data Mosh
 Artists:
@@ -56,6 +58,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/data-mosh
 - https://youtu.be/GGyxg5VgbJE
 - https://open.spotify.com/track/0RrY7qi1oXuJvcCnoWjWck
+- https://music.apple.com/song/data-mosh/1621329662
 ---
 Track: Got it Goin' On
 Artists:
@@ -65,6 +68,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/got-it-goin-on
 - https://youtu.be/2h1mMcIqDCM
 - https://open.spotify.com/track/43MOV2wkYThKQL9eNxLLjG
+- https://music.apple.com/song/got-it-goin-on/1621329665
 ---
 Track: Capital Freak
 Artists:
@@ -74,6 +78,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/capital-freak
 - https://youtu.be/EhUSXHqmVHY
 - https://open.spotify.com/track/4bXtb2YSGjsGJs6jCdVhpI
+- https://music.apple.com/song/capital-freak/1621329847
 ---
 Track: GearGrinders XXXL
 Artists:
@@ -83,6 +88,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/geargrinders-xxxl
 - https://youtu.be/n7Ajvlw4ypE
 - https://open.spotify.com/track/2EzQCNU9eNqEYJ9YEuxFfy
+- https://music.apple.com/song/geargrinders-xxxl/1621329848
 ---
 Track: Solder Burn
 Artists:
@@ -92,6 +98,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/solder-burn
 - https://youtu.be/A01a7pnZu3g
 - https://open.spotify.com/track/06sS4HfAlrH9qSrjpceP56
+- https://music.apple.com/song/solder-burn/1621329849
 ---
 Track: Skyscrape
 Artists:
@@ -101,6 +108,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/skyscrape
 - https://youtu.be/ani2gBvLJlY
 - https://open.spotify.com/track/3ywlae73S6dvAn0vYxC1Xd
+- https://music.apple.com/song/skyscrape/1621329850
 ---
 Track: マイクロセーフ
 Directory: maikurosefu
@@ -111,3 +119,4 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/-
 - https://youtu.be/PXFtB_mfjQg
 - https://open.spotify.com/track/4A9kZujlXzvrR1MWhmFJIp
+- https://music.apple.com/song/%E3%83%9E%E3%82%A4%E3%82%AF%E3%83%AD%E3%82%BB%E3%83%BC%E3%83%95/1621329851

--- a/album/on-the-rox.yaml
+++ b/album/on-the-rox.yaml
@@ -7,6 +7,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/on-the-rox
 - https://www.youtube.com/playlist?list=PLnVpmehyaOFbfOKwyda-pQ9Ikph4bBB9n
 - https://open.spotify.com/album/2LqaNe5NSXrfRHqIL9MxZv
+- https://music.apple.com/album/on-the-rox/1749393140
 Cover Artists:
 - Siedlag
 Wallpaper Artists:
@@ -52,6 +53,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/on-apocalyptic-shores-2
 - https://youtu.be/ny8c1evL8_g
 - https://open.spotify.com/track/1mAgLLKuY606L4ODHxzwde
+- https://music.apple.com/song/on-apocalyptic-shores/1749393141
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -72,6 +74,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/technostalgia
 - https://youtu.be/8Nzlgr4uhl4
 - https://open.spotify.com/track/0eAI8fmgBMS9qaCrWFYnnz
+- https://music.apple.com/song/technostalgia/1749393142
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -94,6 +97,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/a-city-of-black-and-white
 - https://youtu.be/vSHMtPCKeeU
 - https://open.spotify.com/track/1A0ttK8xSPME2rX8s7Whup
+- https://music.apple.com/song/a-city-of-black-and-white/1749393143
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -113,6 +117,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/through-the-looking-glass-2
 - https://youtu.be/kYR4WZsq4do
 - https://open.spotify.com/track/7kU6ymOEgWdAIfKauZZdRz
+- https://music.apple.com/song/through-the-looking-glass/1749393144
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -132,6 +137,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/broken-bottles-broken-dreams
 - https://youtu.be/NCk8HOO-jsU
 - https://open.spotify.com/track/2371T3piFKgq3FwjoB2aeN
+- https://music.apple.com/song/broken-bottles-broken-dreams/1749393145
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -150,6 +156,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/sleepwalker
 - https://youtu.be/R0X_7opJc98
 - https://open.spotify.com/track/5loOm9rW2LJbbUTRzhtmss
+- https://music.apple.com/song/sleepwalker/1749393146
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -170,6 +177,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/communing-with-fireflies
 - https://youtu.be/NuCn71XQLck
 - https://open.spotify.com/track/0w70ECtgzfIijczn3ca1JR
+- https://music.apple.com/song/communing-with-fireflies/1749393148
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -193,6 +201,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/saboteur
 - https://youtu.be/q-VIKJv6M3w
 - https://open.spotify.com/track/2fB2X4j3BPAkvmxmels9Rr
+- https://music.apple.com/song/saboteur/1749393150
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -222,6 +231,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/interlude
 - https://youtu.be/V0Dt1Nw5zvY
 - https://open.spotify.com/track/1owdXDqFuIuDZmcSVFKT3h
+- https://music.apple.com/song/interlude/1749393151
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -243,6 +253,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/neon-haze
 - https://youtu.be/PrumkMsHA2I
 - https://open.spotify.com/track/38XJYW8zyFiBcdURXPyxO2
+- https://music.apple.com/song/neon-haze/1749393152
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -269,6 +280,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/meditations-on-derse
 - https://youtu.be/P-LwoTcraZY
 - https://open.spotify.com/track/4mOIBWk08qWD1TdZFiFnHa
+- https://music.apple.com/song/meditations-on-derse/1749393153
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -287,6 +299,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/sole-survivor
 - https://youtu.be/CapQgind2GQ
 - https://open.spotify.com/track/15tdxJ5p9YnzHlguBfYhsR
+- https://music.apple.com/song/sole-survivor/1749393154
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -309,6 +322,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/choices
 - https://youtu.be/5SINT4SlQgU
 - https://open.spotify.com/track/1kgMlJxD3EOrjKr9QN69bt
+- https://music.apple.com/song/choices/1749393155
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -334,6 +348,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/a-future-worth-stealing
 - https://youtu.be/HzONuhbbOME
 - https://open.spotify.com/track/1HZfxAEhPOaqkSiT9Tajvm
+- https://music.apple.com/song/a-future-worth-stealing/1749393156
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -354,6 +369,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/reunion
 - https://youtu.be/C37B09VxKDc
 - https://open.spotify.com/track/5ps9TgE04DOexE6tDkTCjX
+- https://music.apple.com/song/reunion/1749393157
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -373,6 +389,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/from-the-void
 - https://youtu.be/0cFwdANtIiI
 - https://open.spotify.com/track/45IN3fyPxSBQwdVUYRiaXt
+- https://music.apple.com/song/from-the-void/1749393158
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -410,6 +427,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/fight-for-the-future
 - https://youtu.be/VwZYHC7jank
 - https://open.spotify.com/track/5rlxcta3VPhKqfUJZpYfF5
+- https://music.apple.com/song/fight-for-the-future/1749393159
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -434,6 +452,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/a-life-worth-living
 - https://youtu.be/OP1gj8SwBHE
 - https://open.spotify.com/track/2CZrhKblSy2AOQWG1JwzfG
+- https://music.apple.com/song/a-life-worth-living-feat-chromaphasia/1749393161
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -457,6 +476,7 @@ Duration: 02:09
 URLs:
 - https://youtu.be/CKPd5NKGB90
 - https://open.spotify.com/track/4hMIIaZgSjiXaEejHVhJvA
+- https://music.apple.com/song/let-the-rain-fall-where-it-may/1749393162
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 
@@ -483,6 +503,7 @@ Referenced Tracks:
 URLs:
 - https://youtu.be/V7SSgAbi2g4
 - https://open.spotify.com/track/2lOpDDyDxMzgqMw9CxcViK
+- https://music.apple.com/song/a-life-worth-living-piano-feat-chromaphasia/1749393163
 Commentary: |-
     <i>Rainy:</i> (booklet commentary)
 

--- a/album/tagging-da-riots.yaml
+++ b/album/tagging-da-riots.yaml
@@ -5,6 +5,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/tagging-da-riots
 - https://youtube.com/playlist?list=PLtcgklmZsk9C-1fRVhkprNEF_1pLbCw3U
 - https://open.spotify.com/album/5htBWoPXQg41yG5o4UZxLR
+- https://music.apple.com/album/tagging-da-riots-single/1556563692
 Cover Artists:
 - Caelan Kier
 - Phos
@@ -35,6 +36,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/main-musical-element
 - https://youtu.be/SakWgCdilzc
 - https://open.spotify.com/track/5ssC0T8QYhlsGdyFrRYZ7O
+- https://music.apple.com/song/main-musical-element/1556563694
 ---
 Track: R U Serious?
 Artists:
@@ -44,3 +46,4 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/r-u-serious
 - https://youtu.be/qIt-iNd2oss
 - https://open.spotify.com/track/1tno27dF8IvYoE62QooCVK
+- https://music.apple.com/song/r-u-serious/1556563695

--- a/album/the-homestuck-strife-project-vol-1.yaml
+++ b/album/the-homestuck-strife-project-vol-1.yaml
@@ -15,6 +15,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/the-homestuck-strife-project-vol-1-original-soundtrack
 - https://www.youtube.com/playlist?list=PLqi0iMdsva_zjsmK8qimv6beWvxfnc6Ts
 - https://open.spotify.com/album/5q2iYd1dA3IXyyBYLLJxit
+- https://music.apple.com/album/the-homestuck-strife-project-vol-1-original-soundtrack-ep/1750272957
 Color: '#1cd159'
 Groups:
 - The Paradox Music Team
@@ -69,6 +70,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/strife-main-menu
 - https://www.youtube.com/watch?v=nY5UbySvTZ4
 - https://open.spotify.com/track/4ds2a8oWNsTQFTHrj880iT
+- https://music.apple.com/song/strife-main-menu/1750272961
 ---
 Track: Choose Your Fighter! (Character Select)
 Directory: choose-your-fighter
@@ -77,6 +79,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/choose-your-fighter-character-select
 - https://www.youtube.com/watch?v=roVDTWti1w8
 - https://open.spotify.com/track/2oAVq9o44z9BB0Dj2KG8px
+- https://music.apple.com/song/choose-your-fighter-character-select/1750272962
 ---
 Track: A Gust of Dreams (John's Theme)
 Directory: a-gust-of-dreams
@@ -104,6 +107,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/a-gust-of-dreams-johns-theme
 - https://www.youtube.com/watch?v=UKfEqJTUPd0
 - https://open.spotify.com/track/273G4uaqu7rZYq0XbrGRkN
+- https://music.apple.com/song/a-gust-of-dreams-johns-theme/1750272963
 ---
 Track: Grimdark Borealis (Rose's Theme)
 Directory: grimdark-borealis
@@ -117,6 +121,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/grimdark-borealis-roses-theme
 - https://www.youtube.com/watch?v=m1xsv66pNBQ
 - https://open.spotify.com/track/3zwGqey9ktFMsmVozCqX1C
+- https://music.apple.com/song/grimdark-borealis-roses-theme/1750272964
 ---
 Track: Tricky Wild Strider Style (Dave's Theme)
 Directory: tricky-wild-strider-style
@@ -128,6 +133,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tricky-wild-strider-style-daves-theme
 - https://www.youtube.com/watch?v=-LrWjCjLyw4
 - https://open.spotify.com/track/0MHk0zCyBJLXZYq9skoRt5
+- https://music.apple.com/song/tricky-wild-strider-style-daves-theme/1750272965
 ---
 Track: Falling off the Planet (Jade's Theme)
 Directory: falling-off-the-planet
@@ -155,6 +161,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/falling-off-the-planet-jades-theme
 - https://www.youtube.com/watch?v=ABoyG8iEGWo
 - https://open.spotify.com/track/3Xl0S1MsTSvvd902ooeYXH
+- https://music.apple.com/song/falling-off-the-planet-jades-theme/1750272966
 Lyrics: |-
     Don't panic  <!-- 0:23 -->
     Don't panic

--- a/album/the-nobles.yaml
+++ b/album/the-nobles.yaml
@@ -8,6 +8,7 @@ URLs:
 - https://www.youtube.com/watch?v=BbnDPwfP-ro
 - https://www.youtube.com/playlist?list=PLtcgklmZsk9AiC6iWWlffTGxU7aow814N
 - https://open.spotify.com/album/6zvwkqvF7QBYxyehFrJvm7
+- https://music.apple.com/album/the-nobles/1749386503
 Cover Artists:
 - animmania
 Default Track Cover Artists:
@@ -80,6 +81,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/side-1
 - https://www.youtube.com/watch?v=Ev_8Dobng3E
 - https://open.spotify.com/track/2mOa5ck3Wakemtd3ZrRJLa
+- https://music.apple.com/song/side-1/1749386504
 Art Tags:
 - Jane
 - Roxy
@@ -99,6 +101,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/miasmic-resurrection
 - https://www.youtube.com/watch?v=YMPcbJ_VZ_c
 - https://open.spotify.com/track/2oFWafO9EnxLB5VNvLt2jZ
+- https://music.apple.com/song/miasmic-resurrection/1749386506
 Art Tags:
 - LoTaK
 # - Heart (aspect)
@@ -117,6 +120,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dormant-wishes
 - https://www.youtube.com/watch?v=n_2PXVmW9BY
 - https://open.spotify.com/track/1pvvKy4Aav6QLq7bDik1sy
+- https://music.apple.com/song/dormant-wishes/1749386507
 Art Tags:
 - LoCaH
 # - Life (aspect)
@@ -136,6 +140,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/perxenic-highlands
 - https://www.youtube.com/watch?v=5rX5CRTVXCE
 - https://open.spotify.com/track/3PoestLj4Ro99sJe4nETTQ
+- https://music.apple.com/song/perxenic-highlands/1749386508
 Art Tags:
 - LoMaX
 # - Hope (aspect)
@@ -162,6 +167,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/radiant-dunes
 - https://www.youtube.com/watch?v=3zSlc9FGqnM
 - https://open.spotify.com/track/0uuRkqSP98DIQpR6bgXJ5O
+- https://music.apple.com/song/radiant-dunes/1749386539
 Art Tags:
 - LoPaN
 # - Perfectly Generic Object
@@ -178,6 +184,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-nobles
 - https://www.youtube.com/watch?v=nu1YSuTFFkc
 - https://open.spotify.com/track/6omJickT0FqgHYdT1TSnNW
+- https://music.apple.com/song/the-nobles/1749386540
 Art Tags:
 - Jane
 - Roxy
@@ -211,6 +218,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/side-2
 - https://www.youtube.com/watch?v=b7w_0plrbsc
 - https://open.spotify.com/track/47MGf9Aq69GP3I7pnenwSt
+- https://music.apple.com/song/side-2/1749386541
 Art Tags:
 - Jake
 - Dirk
@@ -233,6 +241,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/voids-edge
 - https://www.youtube.com/watch?v=0SfwniXWhhg
 - https://open.spotify.com/track/4dElVT3zYRoAK6PUX6kcAr
+- https://music.apple.com/song/voids-edge/1749386542
 Art Tags:
 - Roxy
 - Dirk
@@ -263,6 +272,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/broken-dreams
 - https://www.youtube.com/watch?v=n_TA9HnLhrI
 - https://open.spotify.com/track/2LTnFsm2EDRoBJ9BG8wmK2
+- https://music.apple.com/song/broken-dreams/1749386544
 Art Tags:
 - Jane
 - Jake
@@ -290,6 +300,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/those-who-tread-the-furthest-ring
 - https://www.youtube.com/watch?v=8ZNiqmHED8I
 - https://open.spotify.com/track/1ZylzkSva6devgPF4rSSsg
+- https://music.apple.com/song/those-who-tread-the-furthest-ring/1749386546
 Art Tags:
 - Dirk
 - Horrorterrors
@@ -314,6 +325,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/terminus
 - https://www.youtube.com/watch?v=iDp5lVhO12Y
 - https://open.spotify.com/track/1SUSTTWCbJ7QU4SSAyDyTQ
+- https://music.apple.com/song/terminus/1749386547
 Art Tags:
 - Jane
 - Jake
@@ -330,6 +342,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/stardust-glitches
 - https://www.youtube.com/watch?v=srwnfzWuupE
 - https://open.spotify.com/track/3viI2VJCTaSnOxO1XrFhWc
+- https://music.apple.com/song/stardust-glitches/1749386548
 Art Tags:
 - John
 - Jade
@@ -355,6 +368,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/alls-well
 - https://www.youtube.com/watch?v=1fb6-Sm6mOI
 - https://open.spotify.com/track/7DOrrNcyXp2RZguO4w5Fc9
+- https://music.apple.com/song/alls-well/1749386551
 Art Tags:
 - John
 - Jane
@@ -382,6 +396,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-nobles-reprise
 - https://www.youtube.com/watch?v=e8BMbdanV_8
 - https://open.spotify.com/track/4oKScvMRuJa10pGNPjEhvC
+- https://music.apple.com/song/the-nobles-reprise/1749386552
 Art Tags:
 - John
 - Jane
@@ -415,6 +430,7 @@ Duration: 2:01
 URLs:
 - https://www.youtube.com/watch?v=G8kUq6XzA-E
 - https://open.spotify.com/track/3JNUVj2MbK9TRcyRiD1AWg
+- https://music.apple.com/song/a-noble-goodbye/1749386553
 Cover Artists:
 - Phos
 Art Tags:

--- a/album/unbound-day-selection-original-soundtrack.yaml
+++ b/album/unbound-day-selection-original-soundtrack.yaml
@@ -7,6 +7,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/unbound-day-selection-original-soundtrack
 - https://youtube.com/playlist?list=PLtcgklmZsk9DJQcgiN2mWUIm5Aji2g5at
 - https://open.spotify.com/album/3IKY2lpDE3T6Z3pPQIr2Sb
+- https://music.apple.com/album/unbound-day-selection-original-soundtrack/1762054647
 Cover Artists:
 - GITGOT
 Cover Art File Extension: png
@@ -74,6 +75,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/skeli-games-logo-2
 - https://youtu.be/BlAWEjn3hnk
 - https://open.spotify.com/track/0njfL7JrEjb3Wvk2PMFpsC
+- https://music.apple.com/song/skeli-games-logo/1762054650
 ---
 Track: Borrian History
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -84,6 +86,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/borrian-history-2
 - https://youtu.be/xRqxKD17dcI
 - https://open.spotify.com/track/1kGO7VP33aDMyua1B89Ybu
+- https://music.apple.com/song/borrian-history/1762054651
 ---
 Track: Shadow Base
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -94,6 +97,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/shadow-base-3
 - https://youtu.be/fxCZceCZdcY
 - https://open.spotify.com/track/6s6BJRbKTnRB8J8RJeFbpE
+- https://music.apple.com/song/shadow-base/1762054652
 ---
 Track: Frozen Heights (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -106,6 +110,7 @@ URLs:
 - https://youtu.be/q8mdIKLCNuo
 #Youtube upload is wrong, will be fixed when fixed
 - https://open.spotify.com/track/6AbPxl2lHKJUeKPEJAozkr
+- https://music.apple.com/song/frozen-heights-day/1762054653
 ---
 Track: Professor Log
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -116,6 +121,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/professor-log-2
 - https://youtu.be/j-Bawe6dmbQ
 - https://open.spotify.com/track/65tvOJcaplUAeBpJHVH5v9
+- https://music.apple.com/song/professor-log/1762054654
 ---
 Track: Professor Log's Lab
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -126,6 +132,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/professor-logs-lab-2
 - https://youtu.be/eDNvto0bdHQ
 - https://open.spotify.com/track/6aFlQI26REREENZLjsybh4
+- https://music.apple.com/song/professor-logs-lab/1762054655
 ---
 Track: Route 1
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -136,6 +143,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-1-3
 - https://youtu.be/w1Qjhy4WYhs
 - https://open.spotify.com/track/7HxFUD5YxoCRDCYQEtoQM0
+- https://music.apple.com/song/route-1/1762054656
 ---
 Track: Bellin Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -146,6 +154,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/bellin-town-day-2
 - https://youtu.be/lKiFkH4WI54
 - https://open.spotify.com/track/0KgOwcUSI6UajNaQ3EuqxM
+- https://music.apple.com/song/bellin-town-day/1762054657
 ---
 Track: Icicle Cave
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -156,6 +165,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/icicle-cave-3
 - https://youtu.be/u1643il1F6c
 - https://open.spotify.com/track/36OFeTXXdeiFojCeUJTGzh
+- https://music.apple.com/song/icicle-cave/1762054658
 ---
 Track: Route 2
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -167,6 +177,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-2-3
 - https://youtu.be/MZxd37gd7vg
 - https://open.spotify.com/track/3LeEkWuY0MNxUMFlq7Y44y
+- https://music.apple.com/song/route-2/1762054659
 ---
 Track: Dresco Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -177,6 +188,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dresco-town-day-2
 - https://youtu.be/FAv0Il3Kj_M
 - https://open.spotify.com/track/6QH1O6yJPUtgnmzJ6zQTYV
+- https://music.apple.com/song/dresco-town-day/1762054660
 ---
 Track: Route 3
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -187,6 +199,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-3-3
 - https://youtu.be/6AAClhOeX6I
 - https://open.spotify.com/track/4K4ockJKa5leJlv5uDAprc
+- https://music.apple.com/song/route-3/1762054661
 ---
 Track: Flower Paradise
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -198,6 +211,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/flower-paradise-2
 - https://youtu.be/9vMTZeEH670
 - https://open.spotify.com/track/2hG9eeIAA3a0g9yGSPotXU
+- https://music.apple.com/song/flower-paradise/1762054662
 ---
 Track: Grim Woods
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -208,6 +222,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/grim-woods-3
 - https://youtu.be/jya3mrO_HWo
 - https://open.spotify.com/track/0IlRrcZUJag6C6t6ew665y
+- https://music.apple.com/song/grim-woods/1762054663
 ---
 Track: Cinder Volcano
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -218,6 +233,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/cinder-volcano-2
 - https://youtu.be/P0bWMb4WY6o
 - https://open.spotify.com/track/7Dvva2Dr2sNnAnHiNTqqXU
+- https://music.apple.com/song/cinder-volcano/1762054664
 ---
 Track: Route 4 & 5
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -228,6 +244,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-4-5-2
 - https://youtu.be/Gdda22hDh1c
 - https://open.spotify.com/track/5IFaYqG9O6DDkyMnVZ35yR
+- https://music.apple.com/song/route-4-5/1762054665
 ---
 Track: Crater Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -238,6 +255,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/crater-town-day-2
 - https://youtu.be/ELBPeWsIowk
 - https://open.spotify.com/track/1xI2dqbxAMdH8XEz0A6rCJ
+- https://music.apple.com/song/crater-town-day/1762054666
 ---
 Track: KBT Expressway
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -249,6 +267,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/kbt-expressway-2
 - https://youtu.be/SVvOZ-lKKuo
 - https://open.spotify.com/track/3gMLjXkt6klun9EthXWk5W
+- https://music.apple.com/song/kbt-expressway/1762054667
 ---
 Track: Valley Cave
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -259,6 +278,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/valley-cave-2
 - https://youtu.be/ClBc67jgG0A
 - https://open.spotify.com/track/2xNKbLiZMHmENOJ0Q3ODln
+- https://music.apple.com/song/valley-cave/1762054668
 ---
 Track: Route 6 & 7
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -269,6 +289,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-6-7-2
 - https://youtu.be/lvHwFYyVifQ
 - https://open.spotify.com/track/6EHsu9YCbUhNaLDErWqZJz
+- https://music.apple.com/song/route-6-7/1762054789
 ---
 Track: Frost Mt.
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -280,6 +301,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/frost-mt-2
 - https://youtu.be/fIudlybH4rE
 - https://open.spotify.com/track/0MpUv9N429tBwFKRAqzswA
+- https://music.apple.com/song/frost-mt/1762054790
 ---
 Track: Route 8
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -290,6 +312,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-8-3
 - https://youtu.be/tggrN_-Riow
 - https://open.spotify.com/track/0LwvprZY6cqHVyflBnwTyY
+- https://music.apple.com/song/route-8/1762054791
 ---
 Track: Blizzard City (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -300,6 +323,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/blizzard-city-day-2
 - https://youtu.be/PJXK60SbSZg
 - https://open.spotify.com/track/4kwNyrJWR1H9vImlKORo89
+- https://music.apple.com/song/blizzard-city-day/1762054792
 ---
 Track: Fallshore City (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -310,6 +334,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/fallshore-city-day-2
 - https://youtu.be/ItgCVIYHOH8
 - https://open.spotify.com/track/3XchJYuzyGWNRUzmiEPDpf
+- https://music.apple.com/song/fallshore-city-day/1762054793
 ---
 Track: Auburn Waterway
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -321,6 +346,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/auburn-waterway-2
 - https://youtu.be/GdbsC8lvitM
 - https://open.spotify.com/track/44LjueGuw2l8tDGRngxLDQ
+- https://music.apple.com/song/auburn-waterway/1762054794
 ---
 Track: Tehl Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -331,6 +357,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tehl-town-day-2
 - https://youtu.be/jc9S2B9SG_k
 - https://open.spotify.com/track/6JwTW8psA1SNFzhV5N2n0x
+- https://music.apple.com/song/tehl-town-day/1762054795
 ---
 Track: Underground Path
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -341,6 +368,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/underground-path-3
 - https://youtu.be/6cLeKlM_9_A
 - https://open.spotify.com/track/5Bab4TI3xvuRBTYaAE8baP
+- https://music.apple.com/song/underground-path/1762054796
 ---
 Track: Route 11
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -351,6 +379,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-11-2
 - https://youtu.be/DAV2oxR07Ec
 - https://open.spotify.com/track/4aYNQHNqFSPqEqT8S6gzHD
+- https://music.apple.com/song/route-11/1762054797
 ---
 Track: Epidimy Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -362,6 +391,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/epidimy-town-day-2
 - https://youtu.be/9X8I8jwANhk
 - https://open.spotify.com/track/7nuUGZrVAqHE4g7mOamavN
+- https://music.apple.com/song/epidimy-town-day/1762054798
 ---
 Track: Tarmigan Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -372,6 +402,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tarmigan-town-day-3
 - https://youtu.be/sRz-4AhlP7s
 - https://open.spotify.com/track/7bFd8OtoPouanYzTsPC2P7
+- https://music.apple.com/song/tarmigan-town-day/1762054799
 ---
 Track: Tarmigan Mansion
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -383,6 +414,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tarmigan-mansion-2
 - https://youtu.be/_wqP6oauu_M
 - https://open.spotify.com/track/5hvTLJB4Y8xjUzkuy6dcKp
+- https://music.apple.com/song/tarmigan-mansion/1762054800
 ---
 Track: The Shadows at Thundercap Mt.
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -393,6 +425,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-shadows-at-thundercap-mt-2
 - https://youtu.be/WOJg3AgQBxo
 - https://open.spotify.com/track/0ClwwBMnGDWeMH4c7ot6rC
+- https://music.apple.com/song/the-shadows-at-thundercap-mt/1762054801
 ---
 Track: Route 12 & 18
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -404,6 +437,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-12-18-2
 - https://youtu.be/kdozwvCG2AI
 - https://open.spotify.com/track/4wHVOysLcTHvUbtgpOEUt1
+- https://music.apple.com/song/route-12-18/1762054802
 ---
 Track: Dehara City (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -414,6 +448,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dehara-city-day-2
 - https://youtu.be/o0gfAPwjpe8
 - https://open.spotify.com/track/2SfZN89WTePsSE5oP6iu95
+- https://music.apple.com/song/dehara-city-day/1762054803
 ---
 Track: Happening at the Ruins of Void
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -424,6 +459,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/happening-at-the-ruins-of-void-2
 - https://youtu.be/uvyxsgVSoTo
 - https://open.spotify.com/track/4jGZ2iVlSGtzikW6ogIGZB
+- https://music.apple.com/song/happening-at-the-ruins-of-void/1762054804
 ---
 Track: Cube Space
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -434,6 +470,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/cube-space-2
 - https://youtu.be/1YQ6EWDrNUw
 - https://open.spotify.com/track/06GdGRGKq9BcpjfVhhB0kY
+- https://music.apple.com/song/cube-space/1762054805
 ---
 Track: An Emotional Moment
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -444,6 +481,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/an-emotional-moment-2
 - https://youtu.be/tXhqFQby0DQ
 - https://open.spotify.com/track/62L4uAyLYnT9mH3bCedtVh
+- https://music.apple.com/song/an-emotional-moment/1762054806
 ---
 Track: The Great Desert
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -454,6 +492,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-great-desert-2
 - https://youtu.be/bkvXkW6Fvv0
 - https://open.spotify.com/track/5eV7PV9gIWeXTDI1pOT6D3
+- https://music.apple.com/song/the-great-desert/1762054807
 ---
 Track: Gurun Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -465,6 +504,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/gurun-town-day-3
 - https://youtu.be/RcdR6krw8dA
 - https://open.spotify.com/track/3pMZAGVD5d9yrRVKVeb5Di
+- https://music.apple.com/song/gurun-town-day/1762054808
 ---
 Track: Vivill Town in Peril
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -475,6 +515,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/vivill-town-in-peril-2
 - https://youtu.be/KYq1lAtEMaE
 - https://open.spotify.com/track/6hB92114xuItPmJuNGAPtL
+- https://music.apple.com/song/vivill-town-in-peril/1762054809
 ---
 Track: Vivill Town Warehouse Ambushed!
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -485,6 +526,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/vivill-town-warehouse-ambushed-2
 - https://youtu.be/_Ni1TI9uHiw
 - https://open.spotify.com/track/3mXhy9wS94iymfj7xZEcvh
+- https://music.apple.com/song/vivill-town-warehouse-ambushed/1762054810
 ---
 Track: Route 16 & 17
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -495,6 +537,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/route-16-17-3
 - https://youtu.be/91ix68e0CwI
 - https://open.spotify.com/track/6JSZY70y7B43YhvovzDHmb
+- https://music.apple.com/song/route-16-17/1762054811
 ---
 Track: Antisis City (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -505,6 +548,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/antisis-city-day-2
 - https://youtu.be/NtAWCk8PCG4
 - https://open.spotify.com/track/12GvztsvstZwcTBVVc2VzJ
+- https://music.apple.com/song/antisis-city-day/1762054812
 ---
 Track: Seaport City (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -515,6 +559,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/seaport-city-day-2
 - https://youtu.be/9Q_YBoIBCvI
 - https://open.spotify.com/track/5qjbrelzepC9aisGpzl1jz
+- https://music.apple.com/song/seaport-city-day/1762054813
 ---
 Track: Polder Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -525,6 +570,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/polder-town-day-2
 - https://youtu.be/TgzrYynrG8Y
 - https://open.spotify.com/track/26hyQhEhqVEspVr6baUjOU
+- https://music.apple.com/song/polder-town-day/1762054815
 ---
 Track: Cootes Bog
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -535,6 +581,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/cootes-bog-3
 - https://youtu.be/XA3Ait_6sOA
 - https://open.spotify.com/track/5SSC2upliz3XhfPbDlSI4v
+- https://music.apple.com/song/cootes-bog/1762054816
 ---
 Track: Magnolia Town (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -545,6 +592,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/magnolia-town-day-2
 - https://youtu.be/vcRV_g9UQnY
 - https://open.spotify.com/track/1vpPepNPvpHlaIsk4981Ii
+- https://music.apple.com/song/magnolia-town-day/1762054817
 ---
 Track: Rush to the Top of Crystal Peak!
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -555,6 +603,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/rush-to-the-top-of-crystal-peak-2
 - https://youtu.be/Ej-5YZ1cr2w
 - https://open.spotify.com/track/2IdoHBVkoLpuqzwA2O3wHK
+- https://music.apple.com/song/rush-to-the-top-of-crystal-peak/1762054818
 ---
 Track: Magnolia Fields
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -565,6 +614,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/magnolia-fields-2
 - https://youtu.be/o1hUaOpZbDQ
 - https://open.spotify.com/track/0wFQt9W9m37YTIm8s2SBem
+- https://music.apple.com/song/magnolia-fields/1762054849
 ---
 Track: Redwood Village (Day)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -576,3 +626,4 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/redwood-village-day-2
 - https://youtu.be/thi6B1gMp2I
 - https://open.spotify.com/track/0uvXV0dn9xuFLGnSYpqtMw
+- https://music.apple.com/song/redwood-village-day/1762054850

--- a/album/unbound-night-selection-original-soundtrack.yaml
+++ b/album/unbound-night-selection-original-soundtrack.yaml
@@ -7,7 +7,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/unbound-night-selection-original-soundtrack
 - https://www.youtube.com/playlist?list=PLtcgklmZsk9CGqGzjofAnyu7kus1ACZuk
 - https://open.spotify.com/album/2kApxUhIOYX5T18ds6KZZz
--https://music.apple.com/album/unbound-night-selection-original-soundtrack/1781295982
+- https://music.apple.com/album/unbound-night-selection-original-soundtrack/1781295982
 Cover Artists:
 - KiddleScribbles
 Cover Art File Extension: png

--- a/album/unbound-night-selection-original-soundtrack.yaml
+++ b/album/unbound-night-selection-original-soundtrack.yaml
@@ -7,6 +7,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/unbound-night-selection-original-soundtrack
 - https://www.youtube.com/playlist?list=PLtcgklmZsk9CGqGzjofAnyu7kus1ACZuk
 - https://open.spotify.com/album/2kApxUhIOYX5T18ds6KZZz
+-https://music.apple.com/album/unbound-night-selection-original-soundtrack/1781295982
 Cover Artists:
 - KiddleScribbles
 Cover Art File Extension: png
@@ -77,6 +78,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/frozen-heights-night-2
 - https://www.youtube.com/watch?v=BihS9B8a9rM
 - https://open.spotify.com/track/0lrvZmu3wCz5UHmQ1K00nC
+- https://music.apple.com/song/frozen-heights-night/1781295989
 ---
 Track: Zeph
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -88,6 +90,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/zeph-2
 - https://www.youtube.com/watch?v=zvhByn2hTOc
 - https://open.spotify.com/track/2JPs14gGNA1tJRwSdUGKYY
+- https://music.apple.com/song/zeph/1781295990
 ---
 Track: Bellin Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -98,6 +101,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/bellin-town-night-2
 - https://www.youtube.com/watch?v=S-wuxd4JvLw
 - https://open.spotify.com/track/6PoZXcPz4WtPWD8HEnAJU5
+- https://music.apple.com/song/bellin-town-night/1781295991
 ---
 Track: Dresco Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -108,6 +112,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dresco-town-night-2
 - https://www.youtube.com/watch?v=K_I-0W9Qm2E
 - https://open.spotify.com/track/4nX5CKMzy33IzXBYfA4mO1
+- https://music.apple.com/song/dresco-town-night/1781295992
 ---
 Track: Trainer House
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -118,6 +123,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/trainer-house-2
 - https://www.youtube.com/watch?v=ky5VP2HZaNo
 - https://open.spotify.com/track/43Pjf1abcRDG8SkIyy0Kbn
+- https://music.apple.com/song/trainer-house/1781295993
 ---
 Track: Crater Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -128,6 +134,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/crater-town-night-2
 - https://www.youtube.com/watch?v=uKzndeKOQa0
 - https://open.spotify.com/track/7GZf9ezI2PcU59YxQ65FuJ
+- https://music.apple.com/song/crater-town-night/1781295994
 ---
 Track: Motorcycle
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -138,6 +145,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/motorcycle-3
 - https://www.youtube.com/watch?v=HMnGjdVb2tA
 - https://open.spotify.com/track/7m3lGfTMfZlLXBv8Y2RMXb
+- https://music.apple.com/song/motorcycle/1781295995
 ---
 Track: Gate
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -148,6 +156,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/gate-2
 - https://www.youtube.com/watch?v=cnaVUqShQmY
 - https://open.spotify.com/track/12oDWCrBtcAfeJ8MSxyO9f
+- https://music.apple.com/song/gate/1781295996
 ---
 Track: Blizzard City (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -158,6 +167,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/blizzard-city-night-2
 - https://www.youtube.com/watch?v=6_lConTiwFk
 - https://open.spotify.com/track/1ZK6trGMmDYkFZ9c6nYXPH
+- https://music.apple.com/song/blizzard-city-night/1781295997
 ---
 Track: Frozen Forest
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -168,6 +178,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/frozen-forest-3
 - https://www.youtube.com/watch?v=CeFzl8rkY-I
 - https://open.spotify.com/track/5GuHDrWMsIijWtQJz0mQbK
+- https://music.apple.com/song/frozen-forest/1781295998
 ---
 Track: Tehl Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -178,6 +189,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tehl-town-night-2
 - https://www.youtube.com/watch?v=ikmefjQ6pkk
 - https://open.spotify.com/track/6FAR3gGWTfm72ZcLyRnUNP
+- https://music.apple.com/song/tehl-town-night/1781295999
 ---
 Track: Fallshore City (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -188,6 +200,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/fallshore-city-night-2
 - https://www.youtube.com/watch?v=TeFG20KFCmA
 - https://open.spotify.com/track/2rZGrGoO7izgsPXm6RLukW
+- https://music.apple.com/song/fallshore-city-night/1781296000
 ---
 Track: Epidimy Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -198,6 +211,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/epidimy-town-night-2
 - https://www.youtube.com/watch?v=b37Wxhyxdq8
 - https://open.spotify.com/track/7yXh57nokWAG3OXuxaWvBx
+- https://music.apple.com/song/epidimy-town-night/1781296001
 ---
 Track: Thundercap Mt.
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -208,6 +222,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/thundercap-mt-2
 - https://www.youtube.com/watch?v=SJClk4zXN34
 - https://open.spotify.com/track/0ZL2wjh57Uub2q05gC6GBC
+- https://music.apple.com/song/thundercap-mt/1781296002
 ---
 Track: Tarmigan Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -218,6 +233,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tarmigan-town-night-3
 - https://www.youtube.com/watch?v=cpGZCQMcOco
 - https://open.spotify.com/track/6xax05A5gizMKEA5Cd9nj2
+- https://music.apple.com/song/tarmigan-town-night/1781296003
 ---
 Track: Dehara City (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -229,6 +245,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dehara-city-night-3
 - https://www.youtube.com/watch?v=lYtDQE7QwKw
 - https://open.spotify.com/track/74pJeX9nbrhQU8sKoINOOj
+- https://music.apple.com/song/dehara-city-night/1781296004
 ---
 Track: Game Corner
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -240,6 +257,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/game-corner-2
 - https://www.youtube.com/watch?v=IHoRLF6aCU8
 - https://open.spotify.com/track/4HUe60wMvNps8dxdS7qWFT
+- https://music.apple.com/song/game-corner/1781296005
 ---
 Track: Surf
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -250,6 +268,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/surf-2
 - https://www.youtube.com/watch?v=YVC8VGDDRTs
 - https://open.spotify.com/track/0kSMMMFeT45jHOYZb4cCGE
+- https://music.apple.com/song/surf/1781296006
 ---
 Track: Tomb of Borrius
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -260,6 +279,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/tomb-of-borrius-3
 - https://www.youtube.com/watch?v=JUemMXkr_wk
 - https://open.spotify.com/track/5VT7mlFEcu9cHkY0howB4A
+- https://music.apple.com/song/tomb-of-borrius/1781296007
 ---
 Track: Gurun Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -270,6 +290,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/gurun-town-night-2
 - https://www.youtube.com/watch?v=RWVHstPHEQU
 - https://open.spotify.com/track/5FzIKC0dKmfuxUwpWHQOC7
+- https://music.apple.com/song/gurun-town-night/1781296008
 ---
 Track: Vivill Woods
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -280,6 +301,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/vivill-woods-3
 - https://www.youtube.com/watch?v=Ci3vami3-aw
 - https://open.spotify.com/track/0CUJJG4AXtc6AoTwZK8Y6H
+- https://music.apple.com/song/vivill-woods/1781296039
 ---
 Track: Vivill Town
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -290,6 +312,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/vivill-town-2
 - https://www.youtube.com/watch?v=Ecyp22hs2A0
 - https://open.spotify.com/track/3gLR6ERtPzd2xWBwhxRs5u
+- https://music.apple.com/song/vivill-town/1781296040
 ---
 Track: Antisis City (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -300,6 +323,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/antisis-city-night-2
 - https://www.youtube.com/watch?v=Kl_YNYeOYb8
 - https://open.spotify.com/track/5Iplz6kXz7cIIRuX9nB0Z6
+- https://music.apple.com/song/antisis-city-night/1781296041
 ---
 Track: Antisis Sewers
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -310,6 +334,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/antisis-sewers-2
 - https://www.youtube.com/watch?v=klek675rnkI
 - https://open.spotify.com/track/0RHwpGrNZiWntdqXzeL9qf
+- https://music.apple.com/song/antisis-sewers/1781296042
 ---
 Track: Black Ferrothorn Turf
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -320,6 +345,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/black-ferrothorn-turf-2
 - https://www.youtube.com/watch?v=oO44TeRsG04
 - https://open.spotify.com/track/1j90uA9dbFT1u60Z67xZW7
+- https://music.apple.com/song/black-ferrothorn-turf/1781296043
 ---
 Track: Seaport City (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -330,6 +356,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/seaport-city-night-2
 - https://www.youtube.com/watch?v=5XPv5uC_jOE
 - https://open.spotify.com/track/3cu5aicTA7s59oGTnWrY4I
+- https://music.apple.com/song/seaport-city-night/1781296044
 ---
 Track: Battleground
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -341,6 +368,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/battleground-2
 - https://www.youtube.com/watch?v=CcsaTUQlQiY
 - https://open.spotify.com/track/67GkXMJshd0rOZKr0IqYBt
+- https://music.apple.com/song/battleground/1781296045
 ---
 Track: Dive
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -351,6 +379,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dive-3
 - https://www.youtube.com/watch?v=mJsL50rMP88
 - https://open.spotify.com/track/7BCsXdRjXOMHaqYCa9yyeP
+- https://music.apple.com/song/dive/1781296046
 ---
 Track: Aklove's Scheme
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -361,6 +390,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/akloves-scheme-2
 - https://www.youtube.com/watch?v=uvZSlYXkHFc
 - https://open.spotify.com/track/7fWfr86Z46sa9rzDRTKPKY
+- https://music.apple.com/song/akloves-scheme/1781296047
 ---
 Track: Ruins of Void
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -371,6 +401,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/ruins-of-void-2
 - https://www.youtube.com/watch?v=Zy5RsscvHtE
 - https://open.spotify.com/track/3HrFqd7z3XWMen1aEPZUIS
+- https://music.apple.com/song/ruins-of-void/1781296048
 ---
 Track: S.S. Marine
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -382,6 +413,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/s-s-marine-2
 - https://www.youtube.com/watch?v=XJY2kN7m0p8
 - https://open.spotify.com/track/0qRZ30BRP6B5sXRNI8ISpu
+- https://music.apple.com/song/ruins-of-void/1781296048
 ---
 Track: Polder Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -392,6 +424,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/polder-town-night-3
 - https://www.youtube.com/watch?v=LiWfO1DQVPM
 - https://open.spotify.com/track/7LEZDDK072miQzZkJcrE0q
+- https://music.apple.com/song/polder-town-night/1781296050
 ---
 Track: Safari Zone
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -402,6 +435,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/safari-zone-3
 - https://www.youtube.com/watch?v=zD4PAPSkalk
 - https://open.spotify.com/track/6HiOUI83qKmBryxrAvN0nh
+- https://music.apple.com/song/safari-zone/1781296051
 ---
 Track: Magnolia Town (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -412,6 +446,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/magnolia-town-night-3
 - https://www.youtube.com/watch?v=aEcaaI2OJC4
 - https://open.spotify.com/track/0jBdgv9RW5CVdKIFjX8Ctg
+- https://music.apple.com/song/magnolia-town-night/1781296052
 ---
 Track: Redwood Village (Night)
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -422,6 +457,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/redwood-village-night-3
 - https://www.youtube.com/watch?v=t5I_kEBnlpM
 - https://open.spotify.com/track/347pCSXmWdxIWMUUHX1ovO
+- https://music.apple.com/song/redwood-village-night/1781296053
 ---
 Track: Redwood Forest
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -432,6 +468,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/redwood-forest-3
 - https://www.youtube.com/watch?v=0hOozLywMWE
 - https://open.spotify.com/track/6JnfVoh7Bql2VUj2Gy2nI8
+- https://music.apple.com/song/redwood-forest/1781296054
 ---
 Track: Arthur's Theme
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -442,6 +479,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/arthurs-theme-2
 - https://www.youtube.com/watch?v=WVM_z9zDEYk
 - https://open.spotify.com/track/4zxaiBvIL7m87RQU705LzP
+- https://music.apple.com/song/arthurs-theme/1781296055
 ---
 Track: Crystal Peak
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -452,6 +490,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/crystal-peak-3
 - https://www.youtube.com/watch?v=dldkKp0ySbI
 - https://open.spotify.com/track/3MXSDAS73pISvbFkRJn1DV
+- https://music.apple.com/song/crystal-peak/1781296056
 ---
 Track: Cube Corp.
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -462,6 +501,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/cube-corp-3
 - https://www.youtube.com/watch?v=5tij2ynxww0
 - https://open.spotify.com/track/2WYsvrWAZXPrFtUv9YVrd3
+- https://music.apple.com/song/cube-corp/1781296057
 ---
 Track: Battle Mine
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -472,6 +512,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/battle-mine-3
 - https://www.youtube.com/watch?v=ONqDILYefZo
 - https://open.spotify.com/track/1YKFAmDj6vpxUzXDflD1Pw
+- https://music.apple.com/song/battle-mine/1781296058
 ---
 Track: Battle Circus
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -482,6 +523,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/battle-circus-3
 - https://www.youtube.com/watch?v=2eSApVio9ZM
 - https://open.spotify.com/track/7z6XLNlf0spgheAf9QZIDS
+- https://music.apple.com/song/battle-circus/1781296059
 ---
 Track: Victory Road
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -492,6 +534,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/victory-road-2
 - https://www.youtube.com/watch?v=Sz9Zv8zpVYs
 - https://open.spotify.com/track/0S4svtaALYPoeQGar1U71Y
+- https://music.apple.com/song/victory-road/1781296060
 ---
 Track: Champion League
 Main Release: track:pokemon-league-pokemon-unbound
@@ -502,6 +545,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/champion-league
 - https://www.youtube.com/watch?v=bTxDNqbAwck
 - https://open.spotify.com/track/4FrLpq7bNwIyNdHGwIAz4C
+- https://music.apple.com/song/champion-league/1781296061
 ---
 Track: Challenging the Champion League!
 Main Release: Challenging the Pokémon League!
@@ -512,6 +556,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/challenging-the-champion-league
 - https://www.youtube.com/watch?v=aOqE5JHoUB0
 - https://open.spotify.com/track/0f5TRm5FHBc7UwKCApPNi8
+- https://music.apple.com/song/challenging-the-champion-league/1781296062
 ---
 Track: Room of Glory
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -522,6 +567,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/room-of-glory-2
 - https://www.youtube.com/watch?v=Lts6rPbLMQc
 - https://open.spotify.com/track/1Fychptm5rf0ucOe2lp8qx
+- https://music.apple.com/song/room-of-glory/1781296063
 ---
 Track: Staff Credits
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -532,6 +578,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/staff-credits-2
 - https://www.youtube.com/watch?v=jt8mmWa3Se0
 - https://open.spotify.com/track/732Gx6ZGPvRRu6ZzPoWUFY
+- https://music.apple.com/song/staff-credits/1781296064
 ---
 Track: The End
 Main Release: 'GBA Pokémon Unbound: Super Music Collection'
@@ -542,3 +589,4 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-end-2
 - https://www.youtube.com/watch?v=paZOYImKHLU
 - https://open.spotify.com/track/2F6zTWrsyutGtWHvUTQf46
+- https://music.apple.com/song/the-end/1781296065

--- a/album/whats-your-favorite-song-earthbound-2019.yaml
+++ b/album/whats-your-favorite-song-earthbound-2019.yaml
@@ -6,6 +6,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/album/whats-your-favorite-song-earthbound-2019
 - https://youtube.com/playlist?list=PLtcgklmZsk9Dg-tNyrzm7r60iRFmA70lc
 - https://open.spotify.com/album/5LYD0MrHWpuCiBBsSGhLLX
+- https://music.apple.com/album/whats-your-favorite-song-earthbound-2019/1807515608
 Cover Artists:
 - KiddleScribbles
 Wallpaper Artists:
@@ -58,6 +59,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/a-new-beginning
 - https://youtu.be/ctP4W65lb5M
 - https://open.spotify.com/track/7GLFNMG7q15sONAdnV7lC1
+- https://music.apple.com/song/a-new-beginning/1807515611
 ---
 Track: Autumn Hues
 Artists:
@@ -73,6 +75,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/autumn-hues
 - https://youtu.be/0fkIOTf4pPM
 - https://open.spotify.com/track/0A7oNfFIm4xDgRgcnVYbsx
+- https://music.apple.com/song/autumn-hues/1807515612
 ---
 Track: Odd Confrontment
 Artists:
@@ -86,6 +89,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/odd-confrontment
 - https://youtu.be/7Ngj4EOsuXE
 - https://open.spotify.com/track/0aS9VKJmBgi2SNIsKROJrc
+- https://music.apple.com/song/odd-confrontment/1807515613
 ---
 Track: Aracade Bizarre
 Artists:
@@ -98,6 +102,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/aracade-bizarre
 - https://youtu.be/SOG51dcHXuU
 - https://open.spotify.com/track/0ND8h9aX39sxzSNsEcqWOH
+- https://music.apple.com/song/aracade-bizarre/1807515614
 ---
 Track: The Runaway Five Extravaganza
 Artists:
@@ -111,6 +116,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/the-runaway-five-extravaganza
 - https://youtu.be/WO0P4jhXi7E
 - https://open.spotify.com/track/6owjaXqMmNYhGGSKXw4Vin
+- https://music.apple.com/song/the-runaway-five-extravaganza/1807515615
 ---
 Track: Sleeping Town
 Artists:
@@ -128,6 +134,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/sleeping-town
 - https://youtu.be/y31X9L5s5y0
 - https://open.spotify.com/track/0S1YjzwT8uqh4IyvAslGZ2
+- https://music.apple.com/song/sleeping-town/1807515616
 ---
 Track: Battle Against a Nocturne Enemy
 Artists:
@@ -139,6 +146,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/battle-against-a-nocturne-enemy
 - https://youtu.be/3Rq6fYywVE0
 - https://open.spotify.com/track/1PWO3R0O1qHYLJi6HOt1xU
+- https://music.apple.com/song/battle-against-a-nocturne-enemy/1807515617
 ---
 Track: Haunting Grounds
 Artists:
@@ -150,6 +158,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/haunting-grounds
 - https://youtu.be/atws42dA_SI
 - https://open.spotify.com/track/6RQmEp7OcBHbd6dSNxVHQo
+- https://music.apple.com/song/haunting-grounds/1807515618
 ---
 Track: Pastel
 Suffix Directory: true
@@ -168,6 +177,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/pastel
 - https://youtu.be/aACzSXnYkRE
 - https://open.spotify.com/track/6NpY8adAqeBM01hCUdl8rf
+- https://music.apple.com/song/pastel/1807515619
 ---
 Track: Diamond Dust
 Artists:
@@ -181,6 +191,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/diamond-dust
 - https://youtu.be/7bfC_-fWy84
 - https://open.spotify.com/track/1UrbAhgnBwGWpckTEka66T
+- https://music.apple.com/song/diamond-dust/1807515680
 ---
 Track: Children's March
 Artists:
@@ -197,6 +208,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/childrens-march
 - https://youtu.be/pcaz9F-slso
 - https://open.spotify.com/track/6GoqLpX1E7wDF4E8hWmVfF
+- https://music.apple.com/song/childrens-march/1807515681
 ---
 Track: 16-Bit Prodigy
 Artists:
@@ -213,6 +225,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/16-bit-prodigy
 - https://youtu.be/9jC8M-VUG9M
 - https://open.spotify.com/track/4Mgw0BFvbN4qlI1Lplm4hi
+- https://music.apple.com/song/16-bit-prodigy/1807515682
 ---
 Track: Winter, Again (Memories of a Past Season)
 Artists:
@@ -225,6 +238,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/winter-again-memories-of-a-past-season
 - https://youtu.be/UGO8bu8lbX0
 - https://open.spotify.com/track/2vAVhY7POKf3sNmsYQYifi
+- https://music.apple.com/song/winter-again-memories-of-a-past-season/1807515683
 ---
 Track: From the Depths
 Artists:
@@ -237,6 +251,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/from-the-depths
 - https://youtu.be/poLMecgdu_o
 - https://open.spotify.com/track/4Kg5ZeoefP6lccYJb5Q1vm
+- https://music.apple.com/song/from-the-depths/1807515684
 ---
 Track: Fiverrun
 Artists:
@@ -248,6 +263,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/fiverrun
 - https://youtu.be/ku8RBIDZ3l4
 - https://open.spotify.com/track/3FFKWWYDzBOpRN3B2KXc6k
+- https://music.apple.com/song/fiverrun/1807515685
 ---
 Track: Nightlight
 Suffix Directory: true
@@ -266,6 +282,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/nightlight
 - https://youtu.be/MRByIDrcKZY
 - https://open.spotify.com/track/0syG8ZGaiZm4mq4fxFoA0a
+- https://music.apple.com/song/nightlight/1807515686
 ---
 Track: Important Foe
 Artists:
@@ -277,6 +294,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/important-foe
 - https://youtu.be/LPiHbm3iNZs
 - https://open.spotify.com/track/3ZsHNXWXbLjws0jvimbM7L
+- https://music.apple.com/song/important-foe/1807515687
 ---
 Track: Subconscious Melody
 Artists:
@@ -290,6 +308,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/subconscious-melody
 - https://youtu.be/rAyeAHezEZ0
 - https://open.spotify.com/track/17Xq0zXymrpnQqKpJrx7vb
+- https://music.apple.com/song/subconscious-melody/1807515688
 ---
 Track: Giygas Strikes Back!
 Artists:
@@ -305,6 +324,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/giygas-strikes-back
 - https://youtu.be/Xm0otscPXAw
 - https://open.spotify.com/track/6dDSPTOWxLIO6xXqQ4Kpgd
+- https://music.apple.com/song/giygas-strikes-back/1807515689
 ---
 Track: Dust
 Suffix Directory: true
@@ -320,3 +340,4 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/dust
 - https://youtu.be/DJ1aAjd35B8
 - https://open.spotify.com/track/0HIaqdHkCvFcz7S6S1x68W
+- https://music.apple.com/song/dust/1807515690

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -302,6 +302,7 @@ Content: |-
     - added SoundCloud listening link to [[track:dord-waltz]] (thanks, Lilith!)
     - added Bandcamp listening link to [[track:objection]] (thanks, Lilith, Meulanie, Lavender!)
     - added SoundCloud listening link to [[track:heir-seer-knight-witch]] (thanks, Lilith, Lan!)
+    - added Apple Music listening links for [[album:beforusbound]], [[album:whats-your-favorite-song-earthbound-2019]], [[album:the-nobles]], [[album:on-the-rox]], [[album:tagging-da-riots]], [[album:midnight-jungle]], [[album:the-homestuck-strife-project-vol-1]], [[album:midnight-jungle-type-1-5-vertigo-zone]], [[album:unbound-day-selection-original-soundtrack]], and [[album:unbound-night-selection-original-soundtrack]] (thanks, Lilith!)
     - added YouTube and SoundCloud listening links to [[track:two-sweeps-older]], [[track:purple-hot-mess]], [[track:a-narrative-force]], [[track:idle-playthings-mimis-music]], [[track:corruptedcultist]], [[track:perfection-vast-error]], [[track:two-spooks-greater]], [[track:spawn-of-scribes-shadow]], [[track:the-hotel-california-lounge]], [[track:kheparia]], and across [[album:faux-dramatica]] (thanks, Lilith!)
     - added Apple Music listening links to [[album:agents-of-reality]] (thanks, Lan!)
     - added Tumblr listening link to [[track:catscratch]] (thanks, Lilith, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -581,6 +581,7 @@ Content: |-
     - fixed [[flash:fs-vol1]] being named "Of Bloodthurst and Bratwurst" ("Bloodthurst" instead of "Bloodthirst"; thanks, Meulanie, Lilith, Lavender!)
     - fixed [[tag:astronomical-bodies-canwc]] being named "Astronomical Bodies (CaNWC)" (uppercase "Bodies"; thanks, Lan!)
     <!-- general data fixes -->
+    - fixed main release of [[track:safari-zone-night-selection]] being [[track:polder-town-night]] instead of [[track:safari-zone]] (thanks, Lilith!)
     - fixed duration of various tracks to align with Nintendo Music: (thanks, ruby!)
         - fixed duration of [[track:advanced-step]] (was 3:33, now 4:11)
         - fixed duration of [[track:bomb-rush-blush]] (was 2:31, now 2:30)


### PR DESCRIPTION
Corrects Safari Zone (Night Selection) being erroneously linked with Polder Town (Night) as a main release, when it should be Safari Zone.

Adds Apple Music listening links to:
- The Nobles
- On the Rox
- Midnight Jungle
- Midnight Jungle Type 1.5
- What's Your Favorite Song
- Unbound Day Selection
- Unbound Night Selection
- BeforusBound
- homestuck strife project
- tagging da riots