### PR TITLE
I Miss You - EarthBound 2012 png cover art support

### DIFF
--- a/album/i-miss-you-earthbound-2012.yaml
+++ b/album/i-miss-you-earthbound-2012.yaml
@@ -7,6 +7,7 @@ URLs:
 - https://youtube.com/playlist?list=PLI7cAsCDsB3Frjq5OxscvQ8aVp6XFJIG6
 Cover Artists:
 - sleepytimejesse
+Cover Art File Extension: png
 Wallpaper Artists:
 - Jebb (for wiki)
 - Lilithtreasure (for wiki)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -202,6 +202,7 @@ Content: |-
     - added cover artwork to [[album:seven-seas]] (thanks, Lilith, Jebb, Lan!)
     - added alternate artworks to [[track:hiatus-lofam4]], [[track:crystalmethequins-broken-bad]], and [[track:juju-breaker]] (thanks, Lan!)
     - added earlier artwork ([[date:4/20/2022]]) to [[album:cascading-light]] (thanks, Lan!)
+    - added higher-quality artwork to [[album:i-miss-you-earthbound-2012]] (thanks, Lilith!)
     - added revised artwork ([[date:3/13/2013]]) to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
     - added SoundCloud artwork to [[track:dave-striders-cool-mixtape]] (thanks, Lan!)
     <!-- art tag additions -->
@@ -268,6 +269,7 @@ Content: |-
     <!-- album presentational tweaks -->
     - revised [[track:center-of-brilliance]] and [[track:candles-and-clockwork-alpha-version]] to present artwork assets from Bandcamp first, with alternatively sourced higher-res cuts as secondary artworks instead (thanks, Lan, Tangle!)
     - revised color of [[album:seven-seas]] to match newly added cover artwork (thanks, Jebb!)
+    - improved background for [[album:i-miss-you-earthbound-2012]] (thanks, Lilith!)
     - revised colors of [[album:deltarune-ch1-ost]] and [[album:deltarune-ch2-ost]] (thanks, ruby, Cello, Jebb!)
     <!-- crediting presentational changes -->
     - reworked cases of crediting both a solo musician's "main" artist and the actual album artist, together, as album and track co-artists (thanks, Lavender, Lan, Whisper!)


### PR DESCRIPTION
Adds Cover Art File Extension field to I Miss You - EarthBound 2012.

Merge with: [hsmusic-media#178](https://github.com/hsmusic/hsmusic-media/pull/178)