### PR TITLE
reference fix: Penumbra Phantasm not referencing Doctor

### DIFF
--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1389,20 +1389,24 @@ Referencing Sources:
     - track:doctor
     ```
 
-    onto Penumba by the way? Currently it's displayed as if it's a completely original track.<br>
+    onto Penumba by the way? Currently it's displayed as if it's a completely original track.
+
     <i>Rainy:</i><br>
-    Yeah actually why wasn't that the case before<br>
+    Yeah actually why wasn't that the case before
+
     <i>ruby:</i><br>
     [...]<br>
     because we established it's referencing penumbra<br>
     something from penumbra that is derived from doctor<br>
     [...]<br>
-    onto penumbra? Yeah<br>
+    onto penumbra? Yeah
+
     <i>wertercatt:</i><br>
-    This track is presented as if it doesn't reference anything.<br>
+    This track is presented as if it doesn't reference anything.
+
     <i>ruby:</i><br>
     surprising we don't<br>
-    the main riff, while technically unique, is 100% based on doctor's<br>
+    the main riff, while technically unique, is 100% based on doctor's
 
     [...]
 
@@ -1417,11 +1421,14 @@ Referencing Sources:
     [...]
 
     <i>Lilithtreasure:</i><br>
-    it's surprising that penumbra isn't listed as referencing doctor, but [[track:patient|patient]] is<br>
+    it's surprising that penumbra isn't listed as referencing doctor, but [[track:patient|patient]] is
+
     <i>Rainy:</i><br>
-    yeah that's odd<br>
+    yeah that's odd
+
     <i>Jebb:</i><br>
-    Wait why does it not have doctor listed<br>
+    Wait why does it not have doctor listed
+
     <i>Lan:</i><br>
     It's an oversight!!
 

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1325,6 +1325,110 @@ URLs:
 - https://www.youtube.com/watch?v=OdntMzdkFnk
 Referenced Tracks:
 - Doctor
+Referencing Sources:
+- Date: February 24, 2023
+  Artists: [Makin, Niklink]
+  Annotation: >-
+    [HSMusic Discord](https://discord.com/channels/749042497610842152/779895315750715422/1078897493133246495), excerpt
+  Body: |-
+    <i>Makin:</i><br>
+    > ok question.
+    > does [[track:doctor|doctor]] reference penumbral phantasm, or is it the other way around?<br>
+    > the wiki doesnt say and i couldnt find the info anywhwere else online (albeit i only looked briefly). is that like. unknown? - Dyst<br>
+
+    neither<br>
+    the original pp was a melody that was quoted in [[Savior of the Waking World|savior of the waking world]], which combines doctor and penumbra phantasm successfully and inspired a lot of pp remixes with doctor in them<br>
+    and every version of PP that has leaked is post sotww I think<br>
+    I guess you can make a case that all existing versions of PP reference doctor<br>
+    definitely not the other way around
+
+    [...]
+
+    <i>Niklink:</i><br>
+    there's this one part of PP that sounds almost identical to the first few notes of doctor and they often get blurred together
+- Date: October 4, 2024
+  Artists: [Jebb]
+  Annotation: >-
+    [HSMusic Discord](https://discord.com/channels/749042497610842152/749067042250031214/1291751049094365314), excerpt
+  Body: |-
+    <i>Jebb:</i><br>
+    Well, very little is known about penumbra phantasm<br>
+    It's referenced in like 1 toby track<br>
+    Its melody is heavily based on [[Doctor|Doctor's]]<br>
+    There's a piano sketch and [[track:null-vol8|a tiny teaser]] i think<br>
+    That's more or less it<br>
+- Date: May 20, 2025
+  Artists: [ruby]
+  Annotation: >-
+    [HSMusic Discord](https://discord.com/channels/749042497610842152/779895315750715422/1374380935771984012), excerpt
+  Body: |-
+    <i>ruby:</i><br>
+    [...]<br>
+    but the part of pp itself is undeniably based on [[Doctor|doctor]]
+- Date: November 22, 2025
+  Artist Text: >-
+    [[artist:ruby]],
+    [[artist:wertercatt]],
+    [[artist:rainy]],
+    [[artist:makin]],
+    [[artist:lilithtreasure]],
+    [[artist:jebb]], and
+    [[artist:quasar-nebula|Lan]]
+  Annotation: >-
+    [HSMusic Discord](https://discord.com/channels/749042497610842152/779895315750715422/1419705641932423219), excerpt
+  Body: |-
+    <i>ruby:</i><br>
+    the riff in [[track:hopes-and-dreams|HaD]] is identical to pp, but it in pp is based on [[Doctor]]
+
+    [...]
+
+    <i>wertercatt:</i><br>
+    Should we stick a<br>
+    ```
+    Referenced Tracks:
+    - track:doctor
+    ```
+
+    onto Penumba by the way? Currently it's displayed as if it's a completely original track.<br>
+    <i>Rainy:</i><br>
+    Yeah actually why wasn't that the case before<br>
+    <i>ruby:</i><br>
+    [...]<br>
+    because we established it's referencing penumbra<br>
+    something from penumbra that is derived from doctor<br>
+    [...]<br>
+    onto penumbra? Yeah<br>
+    <i>wertercatt:</i><br>
+    This track is presented as if it doesn't reference anything.<br>
+    <i>ruby:</i><br>
+    surprising we don't<br>
+    the main riff, while technically unique, is 100% based on doctor's<br>
+
+    [...]
+
+    <i>Makin:</i><br>
+    I think it's just time to retire the "it's penumbra when doctor is one note off" and just admit it's a doctor variation that PP used
+
+    [...]
+    
+    <i>wertercatt:</i><br>
+    Penumbra still needs Doctor added to its references tho.
+
+    [...]
+
+    <i>Lilithtreasure:</i><br>
+    it's surprising that penumbra isn't listed as referencing doctor, but [[track:patient|patient]] is<br>
+    <i>Rainy:</i><br>
+    yeah that's odd<br>
+    <i>Jebb:</i><br>
+    Wait why does it not have doctor listed<br>
+    <i>Lan:</i><br>
+    It's an oversight!!
+
+    [...]
+
+    <i>Lan:</i><br>
+    Guys, I swear, it's an oversight. This one - I do believe - is not intentional.
 ---
 Track: Plasmatic Blaquaciousness
 Artists:

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1323,6 +1323,8 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=RIq4GrMv96I
 - https://www.youtube.com/watch?v=OdntMzdkFnk
+Referenced Tracks:
+- Doctor
 ---
 Track: Plasmatic Blaquaciousness
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -509,6 +509,7 @@ Content: |-
     - fixed [[track:cascading-light]] main artwork not referencing [[album:homestuck-vol-8]] album cover (thanks, Lan!)
     - fixed [[track:fuchsia-ruler-single]] (single) artwork not referencing [[track:fuchsia-ruler]] ([[album:coloUrs-and-mayhem-universe-a]]; thanks, Jackie!)
     - added various referencing sources to [[track:dissension-remix]], [[track:white]], [[track:octoroon-rangoon]], [[track:clockwork-sorrow]], [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] (thanks, Lan!)
+    - added referencing sources to [[track:penumbra-phantasm]] (thanks, Lilith!)
     <!-- crediting fixes -->
     - fixed a bunch of missing contributor credits across [[album:super-smash-bros-ultimate]] (thanks, ruby!)
         - fixed [[track:delfino-plaza-ssbu]], [[track:the-map-page-bonus-level]], [[track:kasss-theme-ssbu]], [[track:f-zero-medley]], [[track:vega-stage-ssbu]], [[track:aeriths-theme-ssbu]], [[track:pasta-ff2-ssbu]], [[track:banquet-of-nature-ss-ssbu]] not crediting any performing contributors

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -498,6 +498,7 @@ Content: |-
     - fixed [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] not referencing [[track:penumbra-phantasm]] (thanks, ruby, Makin, Jebb, Interrobang, Witch's Cadence, Monckat, Red Rax, Rainy, Meulanie, Jackie, Lan!)
     - fixed [[track:christmas-time-is-here-lo-fi]] not referencing [[track:christmas-time-is-here-vocal]] (thanks, Lilith, Tangle, Lan!)
     - fixed [[track:dead-maams-chest]] not referencing [[track:im-your-treasure-box-you-have-found-captain-marine-in-a-treasure-chest]] (thanks, ruby!)
+    - fixed [[track:penumbra-phantasm]] not referencing [[track:doctor]] (thanks, Makin, Niklink, Jebb, ruby, wertercatt, Rainy, Lan, Lilith!)
     - fixed [[track:do-the-homestuck-demo]] not referencing [[track:sunsetter]], [[track:sburban-jungle]], and [[track:MeGaLoVania]], nor sampling [[track:amen-brother]] (thanks to an emailer, FF, ruby, and Lan!)
     - fixed [[track:findher]] not referencing [[track:lost-girl]] (thanks, vriska, ruby!)
     - fixed [[track:radiation-is-now-on-youtube]] referencing [[track:bro-hop]] instead of sampling it (thanks, Lilith, Jackie!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -509,7 +509,7 @@ Content: |-
     - fixed [[track:cascading-light]] main artwork not referencing [[album:homestuck-vol-8]] album cover (thanks, Lan!)
     - fixed [[track:fuchsia-ruler-single]] (single) artwork not referencing [[track:fuchsia-ruler]] ([[album:coloUrs-and-mayhem-universe-a]]; thanks, Jackie!)
     - added various referencing sources to [[track:dissension-remix]], [[track:white]], [[track:octoroon-rangoon]], [[track:clockwork-sorrow]], [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] (thanks, Lan!)
-    - added referencing sources to [[track:penumbra-phantasm]] (thanks, Lilith!)
+    - added referencing sources to [[track:penumbra-phantasm]] (thanks, Lilith, Lan!)
     <!-- crediting fixes -->
     - fixed a bunch of missing contributor credits across [[album:super-smash-bros-ultimate]] (thanks, ruby!)
         - fixed [[track:delfino-plaza-ssbu]], [[track:the-map-page-bonus-level]], [[track:kasss-theme-ssbu]], [[track:f-zero-medley]], [[track:vega-stage-ssbu]], [[track:aeriths-theme-ssbu]], [[track:pasta-ff2-ssbu]], [[track:banquet-of-nature-ss-ssbu]] not crediting any performing contributors


### PR DESCRIPTION
Penumbra Phantasm, for a long time, was not listed as referencing Doctor, but this fixes it, alongside providing Referencing Sources.

thanks, Makin, Niklink, Jebb, ruby, wertercatt, Rainy, and Lan!