### PR TITLE
Muddledash! bonus tracks (rebase/jebb)

### DIFF
--- a/album/muddledash.yaml
+++ b/album/muddledash.yaml
@@ -342,6 +342,9 @@ Commentary: |-
     the melancholy and happy sublime, that feeling when those two vibes meet, riiiiiiight in the center between them? that is a tone i will probably spend my entire life chasing.
 ---
 Section: Bonus tracks
+# bonus track lyrics via Bandcamp album download
+# id3v2 unsyncedlyrics (ref #hsmusic-chat 10/26/2025)
+# https://discord.com/channels/749042497610842152/779895315750715422/1432115333862396065
 ---
 Track: ~flip tape over~
 Directory: flip-tape-over

--- a/album/muddledash.yaml
+++ b/album/muddledash.yaml
@@ -29,6 +29,13 @@ Commentary: |-
     i hope you love it as much as the love that went into it.
 
     art by [[artist:rachel-lake|rachel lundin]]
+
+    <i>rj lake:</i> ([Reddit reply](https://www.reddit.com/r/homestuck/comments/8xw7ki/comment/e273sx1/), 7/11/2018)
+    firstly thank you for posting this dang thing before i could
+
+    secondly since seemingly nobody has noticed yet there is [[Squidmaster P and Argyle the Warmhearted Rage Against the Construct of Linear Time (Tentacles Forever)|a sequel]] to the track [[Tentacles|"tentacles"]] from [[album:squiddles|squiddles: sing along]] in the bonus tracks, and this time it is...good on accident, instead of bad on purpose
+
+    please give me your thoughts
 ---
 Section: Main album
 ---

--- a/album/muddledash.yaml
+++ b/album/muddledash.yaml
@@ -30,6 +30,8 @@ Commentary: |-
 
     art by [[artist:rachel-lake|rachel lundin]]
 ---
+Section: Main album
+---
 Track: DASH!!!!!!!!
 Duration: 2:34
 URLs:
@@ -379,7 +381,7 @@ Lyrics: |-
     they say i'm rapping good enough that i should be employed
     over at the gift shop where they selling squeaky toys
     i got haters just because i ain't a humanoid
-    but i don't belabor getting sad over the shaudenfreude 
+    but i don't belabor getting sad over the shaudenfreude
     after all, it's hard for me to even try to be annoyed
     when their girlfriends are on my many arms to be enjoyed!
     in my jacuzzi, takin' selfie polaroids
@@ -397,10 +399,10 @@ Lyrics: |-
 
     yeah y-y-yeah
 
-    (hey my man, my man, my man 
+    (hey my man, my man, my man
     man
 
-    man 
+    man
 
 
     squidmaster p, formerly known as squiddle g?

--- a/album/muddledash.yaml
+++ b/album/muddledash.yaml
@@ -15,6 +15,7 @@ Banner File Extension: png
 #Wallpaper File Extension: png
 URLs:
 - https://spellmynamewithabang.bandcamp.com/album/muddledash
+- https://store.steampowered.com/app/852030/Muddledash_Soundtrack/
 Color: '#ce9fd5'
 Groups:
 - rj lake
@@ -33,6 +34,8 @@ Track: DASH!!!!!!!!
 Duration: 2:34
 URLs:
 - https://spellmynamewithabang.bandcamp.com/track/dash
+Referenced Tracks:
+- DASH!!!!!!!! (original demo)
 Commentary: |-
     <i>rj lake:</i> ([Bandcamp about blurb](https://spellmynamewithabang.bandcamp.com/track/dash))
 
@@ -58,6 +61,7 @@ Commentary: |-
 Track: Octopus's Garden Party
 Duration: 3:05
 Referenced Tracks:
+- Octopus's Garden Party (original demo)
 - DASH!!!!!!!!
 URLs:
 - https://spellmynamewithabang.bandcamp.com/track/octopuss-garden-party
@@ -168,6 +172,8 @@ Track: Slidesurf
 Duration: 2:49
 URLs:
 - https://spellmynamewithabang.bandcamp.com/track/slidesurf
+Referenced Tracks:
+- Slidesurf (original demo)
 Commentary: |-
     <i>rj lake:</i> ([Bandcamp about blurb](https://spellmynamewithabang.bandcamp.com/track/slidesurf))
 
@@ -325,3 +331,141 @@ Commentary: |-
     it rules
 
     the melancholy and happy sublime, that feeling when those two vibes meet, riiiiiiight in the center between them? that is a tone i will probably spend my entire life chasing.
+---
+Section: Bonus tracks
+---
+Track: ~flip tape over~
+Directory: flip-tape-over
+Duration: 1:35
+Lyrics: |-
+    <i>rj lake:</i> (artist's lyrics)
+    that was the last song on this album that you are listening to
+    but there is still some more stuff on this cd
+
+    i know that you're not probably listening to this on a disk
+    i am speaking metaphorically
+
+    there are some bonus tracks to hear that are coming up very soon
+    warning that they might be kind of a mixed bag
+
+    that being said i hope you enjoy listening to all of them
+    if you are okay with all of that
+---
+Track: Squidmaster P and Argyle the Warmhearted Rage Against the Construct of Linear Time (Tentacles Forever)
+Duration: 2:19
+Lyrics: |-
+    <i>rj lake:</i> (artist's lyrics)
+    (check)
+
+    guess what!
+
+    GUESS What
+
+    we're back and we learned how to cuss a real grown-up cuss [BEEP] [BEEP] [BEEP] doo doo doo poo poo poo poo people
+
+    did you THINK we were [BEEP] [BEEP] DEAD?
+
+    (no, STOP!)
+
+    (uh hey dude, you can't swear. this is gonna be associated with a family friendly property)
+
+    (oh)
+
+    anyway, READY?
+
+    hey what up friends it's your number one squeaky boy
+    when they hear my squeaky voice
+    ladies get a squeaky voice
+    they say i'm rapping good enough that i should be employed
+    over at the gift shop where they selling squeaky toys
+    i got haters just because i ain't a humanoid
+    but i don't belabor getting sad over the shaudenfreude 
+    after all, it's hard for me to even try to be annoyed
+    when their girlfriends are on my many arms to be enjoyed!
+    in my jacuzzi, takin' selfie polaroids
+    eatin' gooey cheesy slices from the local pizza joint
+    see a movie
+    we hope it doesn't disappoint
+    but we ain't choosy, there's not a lot that we avoid
+    i ain't bougie, my stuff is for the hoi polloi!
+    i ain't smooth, see, my skin is made of courderoy
+    i ain't sushi even if my meat is sushi grade
+    don't call me a tiny toon, man
+    i'm a FREAKAZOID!
+
+    yeah y-y-yeah
+
+    yeah y-y-yeah
+
+    (hey my man, my man, my man 
+    man
+
+    man 
+
+
+    squidmaster p, formerly known as squiddle g?
+
+    you realize that the last time [[track:tentacles|we did a song together]] was eight years before this one?
+
+    makes me feel old.)
+
+    dropped out of school but i didn't stop learnin'
+    that's why this stupid dum dum started earnin'
+    get a big ol' cash stack
+    spend it all on candy
+    throw it in my knapsack
+    roadtrip to miami
+    peach drink in hand i'm sippin' on a sandy
+    beach thinkin' back to my days in the classroom
+    late with my homework
+    grades slippin' back
+    teacher call me a hillbilly
+    nah
+    i'm a hill mandy
+
+    yeah y-y-yeah
+---
+Track: Couch Multi
+Duration: 1:58
+---
+Track: Public Radio
+Duration: 1:33
+---
+Track: Puddle Formation
+Duration: 2:41
+---
+Track: Boom Box Beatdown
+Duration: 1:12
+---
+Track: Elevator Music for a Racing Game
+Duration: 1:16
+---
+Track: Garageaquarium
+Duration: 2:06
+---
+Track: Seafood Madness
+Duration: 2:34
+---
+Track: Mmm Hmm
+Duration: 1:58
+---
+Track: Snackjam
+Duration: 1:26
+---
+Track: Squidward's Curse
+Duration: 2:11
+---
+Track: Slumberpals
+Duration: 1:45
+---
+Track: Flophop
+Duration: 1:22
+---
+Track: Slidesurf (original demo)
+Duration: 0:52
+---
+Track: Octopus's Garden Party (original demo)
+Duration: 1:08
+---
+Track: DASH!!!!!!!! (original demo)
+Duration: 1:25

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -122,7 +122,7 @@ Content: |-
         - added [[album:deltarune-status-update-sept-2022]]!
         - added [[album:deltarune-ch3-status-update]]!
         - added [[album:deltarune-ch2-rejected-tracks]]!
-    - added albums by [[group:rj-lake]]! (thanks, <<Jebb:album data, presentation, research>>, <<Lan:data review, additional data>>!)
+    - added albums by [[group:rj-lake]]! (thanks, <<Jebb:album data, presentation, research>>, <<Lan:data review, additional data>>, <<Lilith:additional data>>!)
         - added [[album:omegalodon]]!
         - added [[album:songs-for-rune]]!
         - added [[album:muddledash]]!


### PR DESCRIPTION
Adds bonus tracks to Muddledash!

Also adds missing "Main album" section for the main 23 tracks, and a miscellaneous Reddit reply from rj lake regarding a sequel to Tentacles from the Squiddles album, as commentary, which conveniently is on this album.