### PR TITLE
Track sections for BETA (autumnalEquinox)

### DIFF
--- a/album/beta.yaml
+++ b/album/beta.yaml
@@ -64,7 +64,7 @@ Section: Sampleless tracks
 Track: Wind and Shade (Sampleless)
 Duration: 4:17
 URLs:
-- hhttps://autumnaleqvinox.bandcamp.com/track/wind-and-shade-sampleless
+- https://autumnaleqvinox.bandcamp.com/track/wind-and-shade-sampleless
 Referenced Tracks:
 - Wind and Shade
 ---

--- a/album/beta.yaml
+++ b/album/beta.yaml
@@ -19,6 +19,8 @@ Groups:
 - Fandom
 Cover Art File Extension: png
 ---
+Section: Main album
+---
 Track: Wind and Shade
 Main Release: same name single
 Suffix Directory: true
@@ -56,6 +58,8 @@ URLs:
 - https://www.youtube.com/watch?v=vVD02AGZoC8
 Referenced Tracks:
 - track:frost-vol6
+---
+Section: Sampleless tracks
 ---
 Track: Wind and Shade (Sampleless)
 Duration: 4:17

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -2795,7 +2795,7 @@ Date: June 13, 2021
 Featured Tracks:
 - Waiting Room
 URLs:
-- hhttps://mspfa.com/?s=31376&p=133
+- https://mspfa.com/?s=31376&p=133
 - https://www.youtube.com/watch?v=mDri9wioeOM
 ---
 Act: The Crow Strider AU

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -175,7 +175,7 @@ Content: |-
         - added [[album:the-tapestry-vol-1-5]]!
         - added [[album:the-tapestry-vol-2]]!
     - added releases by [[group:autumnal-equinox]]! (thanks, Lilith, Lan, Tangle!)
-        - added [[album:terezi-still-owns]].  [[album:wind-and-shade]], and [[album:beta]]!
+        - added [[album:terezi-still-owns]], [[album:wind-and-shade]], and [[album:beta]]!
         - added [[album:4-pass-olds]], [[album:vigor-and-tundra]], [[album:phantasmal]], [[album:just-leave]], [[album:1-in-322103112018-incognizable]], [[album:stop-smoking-we-care-about-you]], [[album:tangential-acid]], [[album:where-dreams-go-to-die]], and [[album:in-medias-res-autumn-cut]]!
     - added releases by [[group:circlejourney]]! (thanks, Jebb, Lan!)
         - added [[album:shallow-shores]]!
@@ -432,7 +432,6 @@ Content: |-
     - moved [[track:scientific-method]] from [[album:references-beyond-homestuck]] to [[album:omegalodon]] (thanks, Jebb, Lan!)
     - moved [[track:noun-astro-kids-pronoun-remix]] from [[album:references-beyond-homestuck]] to [[album:will-remix-for-food-remixes-vol-i]] (thanks, Lilith!)
     - moved [[track:lets-read-a-webcomic]] from [[album:references-beyond-homestuck]] to [[album:more-homestuck-fandom]] (thanks, Lan!)
-    - divided "Main album" section of [[album:beta]] into "Main album" and "Sampleless tracks" (thanks, Lilith!)
     <!-- general removals -->
     - removed [[album:references-beyond-homestuck]] track "Settings (Wii Fit)" since it's part of [[track:main-menu-wii-fit]] (thanks, ruby!)
     - removed "(…) - Single" additional names automatically enforced on Apple Music and iTunes platforms, affecting [[track:black-richaadeb]], [[track:heir-of-grief-richaadeb]], [[track:dance-of-thorns-richaadeb]], [[track:oppa-toby-style]] (all [[artist:richaadeb]]), and [[album:dreamers-diarchy]] (thanks, Whisper, ruby!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -432,6 +432,7 @@ Content: |-
     - moved [[track:scientific-method]] from [[album:references-beyond-homestuck]] to [[album:omegalodon]] (thanks, Jebb, Lan!)
     - moved [[track:noun-astro-kids-pronoun-remix]] from [[album:references-beyond-homestuck]] to [[album:will-remix-for-food-remixes-vol-i]] (thanks, Lilith!)
     - moved [[track:lets-read-a-webcomic]] from [[album:references-beyond-homestuck]] to [[album:more-homestuck-fandom]] (thanks, Lan!)
+    - divided "Main album" section of [[album:beta]] into "Main album" and "Sampleless tracks" (thanks, Lilith!)
     <!-- general removals -->
     - removed [[album:references-beyond-homestuck]] track "Settings (Wii Fit)" since it's part of [[track:main-menu-wii-fit]] (thanks, ruby!)
     - removed "(…) - Single" additional names automatically enforced on Apple Music and iTunes platforms, affecting [[track:black-richaadeb]], [[track:heir-of-grief-richaadeb]], [[track:dance-of-thorns-richaadeb]], [[track:oppa-toby-style]] (all [[artist:richaadeb]]), and [[album:dreamers-diarchy]] (thanks, Whisper, ruby!)


### PR DESCRIPTION
~~Removes Wind and Shade single and moves the contents (such as cover art and commentary, and first released date) to the track entry on BETA instead; unmarking it as a rerelease, and changes its directory to also just be ``wind-and-shade`` rather than ``wind-and-shade-beta``.~~

~~Also~~ Adds track sections to BETA.

~~Merge with: [hsmusic-media#180](https://github.com/hsmusic/hsmusic-media/pull/180)~~

