### PR TITLE
Full-size Black Rose / Green Sun & Warhammer of Zillyhoo + Made of Time artwork support

### DIFF
--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -1155,14 +1155,27 @@ Duration: 2:17
 URLs:
 - https://homestuck.bandcamp.com/track/made-of-time
 - https://youtu.be/MMwFJp_e3BQ
-Cover Artists:
-- Alexia Khodanian
-Cover Art File Extension: png
-Art Tags:
-- Aradia
-- Jack Noir
-- Green Sun
-- 'cw: blood'
+Track Artwork:
+- Artists:
+  - Alexia Khodanian
+  File Extension: png
+  Tags:
+  - Aradia
+  - Jack Noir
+  - Green Sun
+  - 'cw: blood'
+- Label: Full-size artwork
+  Directory: full
+  Attach Above: true
+  Dimensions: 1400x1100
+  File Extension: png
+  Source: [Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am)
+Commentary: |-
+    <i>Alexia Khodanian:</i> ([Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am))
+
+    this morning I woke up and said “I am going to draw something I can be proud of today”. I think I did it.
+
+    [[flash:3297|[S\] Wake]] is one of my favorite pages
 ---
 Track: Nine Lives One Love
 Artists:

--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -1169,10 +1169,11 @@ Track Artwork:
   Attach Above: true
   Dimensions: 1400x1100
   File Extension: png
+  Date: February 11, 2012
   Source: >-
     [Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am)
 Commentary: |-
-    <i>Alexia Khodanian:</i> ([Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am))
+    <i>Alexia Khodanian:</i> ([Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am), 2/11/2012)
 
     this morning I woke up and said “I am going to draw something I can be proud of today”. I think I did it.
 

--- a/album/coloUrs-and-mayhem-universe-a.yaml
+++ b/album/coloUrs-and-mayhem-universe-a.yaml
@@ -1169,7 +1169,8 @@ Track Artwork:
   Attach Above: true
   Dimensions: 1400x1100
   File Extension: png
-  Source: [Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am)
+  Source: >-
+    [Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am)
 Commentary: |-
     <i>Alexia Khodanian:</i> ([Tumblr](https://web.archive.org/web/20120510173130/http://alexiadraws.tumblr.com/post/17469516234/full-size-this-morning-i-woke-up-and-said-i-am))
 

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -101,11 +101,12 @@ Track Artwork:
   Tags:
   - Rose
   - Horrorterrors
-  - Green Sun
-  - Thorns of Oglogoth
   - Casey
   - Crocodiles (consort)
   - Turtles (consort)
+  - Green Sun
+  - Thorns of Oglogoth
+  - Rag of Souls
 Referenced Tracks:
 - Macabre
 Sheet Music Files:
@@ -731,10 +732,10 @@ Track Artwork:
     [DeviantArt](https://web.archive.org/web/20120201070109/http://schellibie.deviantart.com/art/Heir-of-Breath-210157535)
   Tags:
   - John
-  - Warhammer of Zillyhoo
   - CD
   - Rabbit
   - WV
+  - Warhammer of Zillyhoo
 Lyrics: |-
     Warhammer
     Of Zillyhoo

--- a/album/homestuck-vol-7.yaml
+++ b/album/homestuck-vol-7.yaml
@@ -82,14 +82,30 @@ Duration: 3:18
 URLs:
 - https://homestuck.bandcamp.com/track/black-rose-green-sun
 - https://youtu.be/XoFbJllomCo
-Cover Artists:
-- Vinks (lines)
-- Shelby Cragg (colors)
-Art Tags:
-- Rose
-- Horrorterrors
-- Green Sun
-- Thorns of Oglogoth
+Track Artwork:
+- Artists:
+  - Vinks (lines)
+  - Shelby Cragg (colors)
+  Tags:
+  - Rose
+  - Horrorterrors
+  - Green Sun
+  - Thorns of Oglogoth
+- Label: Full-size artwork
+  Directory: full
+  Attach Above: true
+  Dimensions: 900x1146
+  Date: May 26, 2011
+  Source: >-
+    [DeviantArt](https://web.archive.org/web/20120201074127/http://schellibie.deviantart.com/art/Seer-of-Light-210386488)
+  Tags:
+  - Rose
+  - Horrorterrors
+  - Green Sun
+  - Thorns of Oglogoth
+  - Casey
+  - Crocodiles (consort)
+  - Turtles (consort)
 Referenced Tracks:
 - Macabre
 Sheet Music Files:
@@ -699,12 +715,26 @@ Duration: 0:49
 URLs:
 - https://homestuck.bandcamp.com/track/warhammer-of-zillyhoo
 - https://youtu.be/0EVrOapzDvg
-Cover Artists:
-- Vinks (lines)
-- Shelby Cragg (colors)
-Art Tags:
-- John
-- Warhammer of Zillyhoo
+Track Artwork:
+- Artists:
+  - Vinks (lines)
+  - Shelby Cragg (colors)
+  Tags:
+  - John
+  - Warhammer of Zillyhoo
+- Label: Full-size artwork
+  Directory: full
+  Attach Above: true
+  Dimensions: 900x1261
+  Date: May 24, 2011
+  Source: >-
+    [DeviantArt](https://web.archive.org/web/20120201070109/http://schellibie.deviantart.com/art/Heir-of-Breath-210157535)
+  Tags:
+  - John
+  - Warhammer of Zillyhoo
+  - CD
+  - Rabbit
+  - WV
 Lyrics: |-
     Warhammer
     Of Zillyhoo

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -278,7 +278,7 @@ Content: |-
     - added Bandcamp crediting sources to [[track:empress]], [[track:army-of-the-wicked-god]], [[album:grim-chain-of-feast]], [[album:war-marks]], [[album:rites-of-bloodgrinded]], [[track:his-honorable-tyranny]], [[album:genesis-genocide]], [[album:faces-of-oglogoth]], [[track:im-a-member-of-the-midnight-crew-soapstone]], and [[album:jugglanoids-from-outer-space]] (thanks, Tangle!)
     - added Tumblr commentary to [[track:catscratch]] (thanks, Lilith, Lan!)
     <!-- artwork additions -->
-    - added full-size artworks to [[track:at-the-price-of-oblivion]], [[track:even-in-death]], [[track:trial-and-execution]], [[track:spider8reath]], [[track:lifdoff]], [[track:havoc-to-be-wrought]], and [[track:earthsea-borealis]] (thanks, Meulanie, Lan!)
+    - added full-size artworks to [[track:black-rose-green-sun]], [[track:at-the-price-of-oblivion]], [[track:even-in-death]], [[track:trial-and-execution]], [[track:spider8reath]], [[track:lifdoff]], [[track:havoc-to-be-wrought]], [[track:earthsea-borealis]], and [[track:warhammer-of-zillyhoo]] (thanks, Meulanie, Lan, Lilith!)
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added full-size artwork to [[track:riches-to-ruins-movements-i-and-ii]] (thanks, Lilith!)
     - added full-size alternate artwork to [[track:noirscape]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -260,6 +260,7 @@ Content: |-
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
     - added Tumblr commentary ([[artist:myotishi]]) to [[track:teal-hunter]] (thanks, Lan!)
     - added Tumblr commentary ([[artist:grue]]) to [[track:cobalt-corsair]] and [[track:spider8ite]] (thanks, Lan, Lilith!)
+    - added Tumblr commentary ([[artist:alexia-khodanian]]) to [[track:made-of-time]] (thanks, Lilith!)
     - added YouTube commentary to [[track:orange-hat]] (thanks, Lilith, Lan!)
     - added Tumblr WIP commentary for [[track:dord-waltz]] (thanks, Lilith!)
     - added missing paragraphs and structure to Tumblr commentary for [[track:dord-waltz]] (thanks, Lilith!)
@@ -278,7 +279,7 @@ Content: |-
     - added Bandcamp crediting sources to [[track:empress]], [[track:army-of-the-wicked-god]], [[album:grim-chain-of-feast]], [[album:war-marks]], [[album:rites-of-bloodgrinded]], [[track:his-honorable-tyranny]], [[album:genesis-genocide]], [[album:faces-of-oglogoth]], [[track:im-a-member-of-the-midnight-crew-soapstone]], and [[album:jugglanoids-from-outer-space]] (thanks, Tangle!)
     - added Tumblr commentary to [[track:catscratch]] (thanks, Lilith, Lan!)
     <!-- artwork additions -->
-    - added full-size artworks to [[track:black-rose-green-sun]], [[track:at-the-price-of-oblivion]], [[track:even-in-death]], [[track:trial-and-execution]], [[track:spider8reath]], [[track:lifdoff]], [[track:havoc-to-be-wrought]], [[track:earthsea-borealis]], and [[track:warhammer-of-zillyhoo]] (thanks, Meulanie, Lan, Lilith!)
+    - added full-size artworks to [[track:black-rose-green-sun]], [[track:at-the-price-of-oblivion]], [[track:even-in-death]], [[track:trial-and-execution]], [[track:spider8reath]], [[track:lifdoff]], [[track:havoc-to-be-wrought]], [[track:earthsea-borealis]], [[track:warhammer-of-zillyhoo]], and [[track:made-of-time]] (thanks, Meulanie, Lan, Lilith!)
     - added higher-res artworks to [[track:maplehoofs-adventure]] and [[track:emerald-terror]] (thanks, Meulanie, Makin, Lan!)
     - added full-size artwork to [[track:riches-to-ruins-movements-i-and-ii]] (thanks, Lilith!)
     - added full-size alternate artwork to [[track:noirscape]] (thanks, Lilith!)


### PR DESCRIPTION
Adds support for Black Rose / Green Sun & Warhammer of Zillyhoo + Made of Time full-size artwork.
Plus Made of Time art commentary from Tumblr.

Makes more sense with... [hsmusic-media#182](https://github.com/hsmusic/hsmusic-media/pull/182)