### PR TITLE
Album addition: Sound Test I from Deconreconstruction! + referencing fixes for Serpaz's Happy Accordion Funtimes

### DIFF
--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -146,7 +146,7 @@ Artists:
 - dbnet18
 Cover Artists:
 - Spruik
-Previous Productions:
+Referenced Tracks:
 - Cultista De Le Sala (Radio Mix)
 URLs:
 - https://vasterror.bandcamp.com/track/pursuit-of-happiness

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -21,7 +21,7 @@ Artists:
 - SplitSuns
 Cover Artists:
 - Ephemerald
-Previous Productions:
+Referenced Tracks:
 - Minute To Win It (No Intro)
 # Sampled Tracks:
 # - SFX from Street Fighter II
@@ -36,7 +36,7 @@ Artists:
 - SplitSuns
 Cover Artists:
 - Ojajy
-Previous Productions:
+Referenced Tracks:
 - Arcjec's Theme (Scrapped Guitars)
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme
@@ -115,9 +115,8 @@ Cover Artists:
 Art Tags:
 - 'cw: blood'
 Cover Art File Extension: jpg
-Previous Productions:
-- Murrit's Theme [Demo]
 Referenced Tracks:
+- Murrit's Theme [Demo]
 - track:the-show-must-go-on-vast-error
 - Best Foot Forward
 - Think (About It)
@@ -158,7 +157,7 @@ Artists:
 - Alex Votl
 Cover Artists:
 - Daytura
-Previous Productions:
+Referenced Tracks:
 - Anywhere Can Be Paradise [Demo]
 URLs:
 - https://vasterror.bandcamp.com/track/anywhere-can-be-paradise

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -248,7 +248,7 @@ Artists:
 - pragmaticNihilist
 Cover Artists:
 - Crystalrina
-Previous Productions:
+Referenced Tracks:
 - Ellsee's Theme (Take 2) [UF]
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -248,8 +248,6 @@ Artists:
 - pragmaticNihilist
 Cover Artists:
 - Crystalrina
-Referenced Tracks:
-- Ellsee's Theme (Take 2) [UF]
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme
 - https://www.youtube.com/watch?v=GajG_jQc048

--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -21,6 +21,8 @@ Artists:
 - SplitSuns
 Cover Artists:
 - Ephemerald
+Previous Productions:
+- Minute To Win It (No Intro)
 # Sampled Tracks:
 # - SFX from Street Fighter II
 # - SFX from Rhythm Heaven
@@ -34,6 +36,8 @@ Artists:
 - SplitSuns
 Cover Artists:
 - Ojajy
+Previous Productions:
+- Arcjec's Theme (Scrapped Guitars)
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme
 - https://www.youtube.com/watch?v=6q89YAbPgsk
@@ -111,7 +115,10 @@ Cover Artists:
 Art Tags:
 - 'cw: blood'
 Cover Art File Extension: jpg
+Previous Productions:
+- Murrit's Theme [Demo]
 Referenced Tracks:
+- track:the-show-must-go-on-vast-error
 - Best Foot Forward
 - Think (About It)
 - track:summer-vanilla
@@ -139,6 +146,8 @@ Artists:
 - dbnet18
 Cover Artists:
 - Spruik
+Previous Productions:
+- Cultista De Le Sala (Radio Mix)
 URLs:
 - https://vasterror.bandcamp.com/track/pursuit-of-happiness
 - https://www.youtube.com/watch?v=bOQqrzz5c14
@@ -149,6 +158,8 @@ Artists:
 - Alex Votl
 Cover Artists:
 - Daytura
+Previous Productions:
+- Anywhere Can Be Paradise [Demo]
 URLs:
 - https://vasterror.bandcamp.com/track/anywhere-can-be-paradise
 - https://www.youtube.com/watch?v=AfVEX0_lL_A
@@ -237,6 +248,8 @@ Artists:
 - pragmaticNihilist
 Cover Artists:
 - Crystalrina
+Previous Productions:
+- Ellsee's Theme (Take 2) [UF]
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme
 - https://www.youtube.com/watch?v=GajG_jQc048

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -209,6 +209,8 @@ Duration: 01:32
 URLs:
 - https://vasterror.bandcamp.com/track/lovecraft
 - https://www.youtube.com/watch?v=0a_l51iUt-w
+Previous Productions:
+- Lovecraft [Beta]
 ---
 Track: Money For Nothing
 Artists:

--- a/album/dead-shufflers-anything-goes.yaml
+++ b/album/dead-shufflers-anything-goes.yaml
@@ -209,7 +209,7 @@ Duration: 01:32
 URLs:
 - https://vasterror.bandcamp.com/track/lovecraft
 - https://www.youtube.com/watch?v=0a_l51iUt-w
-Previous Productions:
+Referenced Tracks:
 - Lovecraft [Beta]
 ---
 Track: Money For Nothing

--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1950,16 +1950,6 @@ Artists:
 Referenced Tracks:
 - track:affliction-janestuck
 ---
-Track: Alpocalypse [Loud]
-Directory: alpocalypse
-Artists:
-- SplitSuns
-URLs:
-- https://vasterror.bandcamp.com/track/alpocalypse-loud
-Sampled Tracks:
-- Bohemian Polka
-- Ready Let's Go
----
 Track: Ascend (Famitracker 8-Bit Cover)
 Artists:
 - cookiefonster
@@ -2365,17 +2355,6 @@ Referenced Tracks:
 - TiK ToK
 Sampled Tracks:
 - TiK ToK
----
-Track: Glimpses Of Perfection [Loud]
-Directory: glimpses-of-perfection
-Artists:
-- SplitSuns
-URLs:
-- https://vasterror.bandcamp.com/track/glimpses-of-perfection-loud
-Referenced Tracks:
-- 'The End of Evangelion - TV Spot #1'
-- Uneven Compromise
-- Beyond the Wall (Intermission)
 ---
 Track: Heir of Grief Sax Cover
 Directory: heir-of-grief-sax-cover-youtube
@@ -2951,19 +2930,6 @@ Lyrics: |-
     Cool shit that I set up earlier it's no
     Big deal, wait I lied it's actually the coolest thing ever!
     (Sup.)
----
-Track: Serpaz's Happy Accordion Funtimes
-Artists:
-- Veritas Unae
-URLs:
-- https://vasterror.bandcamp.com/track/serpazs-happy-accordion-funtimes
-Referenced Tracks:
-- The Simpsons Theme
-- Seinfeld Theme
-- Space Jam
-- track:megalovania-undertale
-- Meet the Flintstones
-- Fly
 ---
 Track: Shut Me Down
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -51114,6 +51114,7 @@ Lyrics: |-
     I've made a severe and continuous lapse in my judgment, and I don't expect to be forgiven. I'm simply here to apologize. So what we came across that day in the woods was obviously unplanned, and the reactions you saw on tape were raw, they were unfiltered. None of us knew how to react, or how to feel. I should have never posted the video. I should have put the cameras down, and stopped recording what we were going through. There's a lot of things I should have done differently but I didn't. And for that, from the bottom of my heart, I am sorry. I want to apologize to the internet. I want to apologize to anyone who has seen the video. I want to apologize to anyone who has been affected or touched by mental illness, or depression, or suicide. But, most importantly, I want to apologize to the victim and his family. For my fans who are defending my actions, please don't. They do not deserve to be defended. Um, the goal of my content is always to entertain, to push the boundaries, to be all-inclusive - in the world I live in I share almost everything I do, the intent is never to be heartless, cruel, or malicious. Ah, like I said, I've made a huge mistake. I don't expect to be forgiven. I'm just here to apologize. I'm ashamed of myself. I'm disappointed in myself. And I promise to be better. I will be better. Thank you.
 ---
 Track: Sonic Adventure 2 (Dark Story + Final Story)
+Directory: sonic-adventure-2-dark-story-final-story
 Duration: 32:17
 Artists:
 - SnapCube

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -13521,7 +13521,61 @@ Contributors:
 Duration: 2:26
 URLs:
 - https://www.youtube.com/watch?v=pF4OH-6NgFY
-Needs Lyrics: true
+Lyrics: |-
+    Well, Ali Baba had them forty thieves
+    Scheherazade had a thousand tales
+    Master, you're in luck, 'cause up your sleeve
+    You got a brand magic never fails
+    You got some power in your corner now
+    Some ammunition in your camp
+    You got some punch, pizzazz, yahoo, and how
+    So all you gotta do is rub that lamp, and I'll say
+    Mister Aladdin, sir, what will your pleasure be
+    Let me take your order, jot it down
+    Yeah, you never had a friend like me
+    Ha-ha-ho!
+    Life is your restaurant and I'm your maître d'
+    Come on, whisper what it is you want
+    Yeah, you never had a friend like me
+
+    Yes sir, we pride ourselves on service
+    You're the boss, the king, the shah
+    Say what you wish, it's yours, true dish
+    About a little more baklava
+    Have some of column A, try all of column B
+    I'm in the mood to help you, dude
+    Yeah, you never had a friend like me
+
+    [???]
+
+    Can your friends do this
+    Can your friends do that
+    Can your friends pull this
+    Out their little hat
+    Can your friends go
+    Hey, lookie here, haha
+    Can your friends go
+    Abracadabra, let 'er rip
+    And make a sucker disappear
+
+    So don't you sit here, slack-jawed, buggy-eyed
+    I'm here to answer all your midday prayers
+    You got the bona fide, certified
+    You got the genie for your charge, d'affaires
+    I got a powerful urge to help you out
+    What you wish, I really wanna know
+    You got a list that's three miles long, no doubt
+    Well, all you gotta do is rub like so
+
+    Mister Aladdin, sir, have a wish or two or three
+    I'm on the job, you big nabob
+    You ain't never had a friend, never had a friend
+    You ain't never had a friend, never had a friend
+    You ain't never have a friend like me
+    Ah-ha-ha!
+    Wah-ha-ha!
+    You ain't never had a friend like me
+    Ha!
 ---
 Track: Futurama Main Theme
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -51113,6 +51113,13 @@ URLs:
 Lyrics: |-
     I've made a severe and continuous lapse in my judgment, and I don't expect to be forgiven. I'm simply here to apologize. So what we came across that day in the woods was obviously unplanned, and the reactions you saw on tape were raw, they were unfiltered. None of us knew how to react, or how to feel. I should have never posted the video. I should have put the cameras down, and stopped recording what we were going through. There's a lot of things I should have done differently but I didn't. And for that, from the bottom of my heart, I am sorry. I want to apologize to the internet. I want to apologize to anyone who has seen the video. I want to apologize to anyone who has been affected or touched by mental illness, or depression, or suicide. But, most importantly, I want to apologize to the victim and his family. For my fans who are defending my actions, please don't. They do not deserve to be defended. Um, the goal of my content is always to entertain, to push the boundaries, to be all-inclusive - in the world I live in I share almost everything I do, the intent is never to be heartless, cruel, or malicious. Ah, like I said, I've made a huge mistake. I don't expect to be forgiven. I'm just here to apologize. I'm ashamed of myself. I'm disappointed in myself. And I promise to be better. I will be better. Thank you.
 ---
+Track: Sonic Adventure 2 (Dark Story + Final Story)
+Duration: 32:17
+Artists:
+- SnapCube
+URLs:
+- https://www.youtube.com/watch?v=IMC0uZY2iH0
+---
 Track: Step Brothers
 Duration: 1:45:32
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -13511,6 +13511,18 @@ URLs:
 - https://disasterpeace.bandcamp.com/track/father
 - https://www.youtube.com/watch?v=tIkFD9-qGYY
 ---
+Track: Friend Like Me
+Artists:
+- Aladdin
+- Alan Menken (composition)
+- Howard Ashman (lyrics)
+Contributors:
+- Robin Williams (vocals)
+Duration: 2:26
+URLs:
+- https://www.youtube.com/watch?v=pF4OH-6NgFY
+Needs Lyrics: true
+---
 Track: Futurama Main Theme
 Artists:
 - Futurama
@@ -29692,6 +29704,105 @@ Lyrics: |-
 
     Mother father gentleman
     Mother father gentleman
+---
+Track: Germs
+Directory: germs-weird-al-yankovic
+Always Reference By Directory: true
+Artists:
+- Weird Al Yankovic
+Duration: 4:38
+URLs:
+- https://www.youtube.com/watch?v=U7G6GbTMOtg
+Lyrics: |-
+    Sometimes I really wanna be alone
+    But that's one state I'm never in
+    Because I know that I've got millions upon millions
+    Of tiny one-celled organisms living on my skin
+
+    (Germs) I rub and scrub until my flesh is raw and bleeding
+    (Germs) But they just come right back again
+    (Germs) Can't even see them but I know they're up to somethin'
+    Hey, don't touch that, you don't know where it's been
+
+    They're all over me
+    They're inside of me
+    Can't get them offa me
+    I'm covered with
+    Microscopic bacteria
+    What do they want from me
+    What'll they do to me
+    There's no escape for me
+    I'm crawlin' with
+    Microscopic bacteria
+
+    Now if I ever dare to go to sleep
+    That's when they start their sneak attack
+    In the morning I wake up in utter horror
+    To find my teeth are covered with bacterial plague
+
+    (Germs) Can't get those parasitic creatures off my face
+    (Germs) And there's more comin' every day
+    (Germs) I never said that they could camp out on my body
+    Wish they'd pack their tiny little bags and move away
+
+    They're all over me
+    They're inside of me
+    Can't get them offa me
+    I'm covered with
+    Microscopic bacteria
+    What do they want from me
+    What'll they do to me
+    There's no escape for me
+    I'm crawlin' with
+    Microscopic bacteria
+
+    Germs
+    Germs
+    Germs
+    Germs
+    (Germs) They're creepin' around my shorts
+    They're under the bathroom sink
+    (Germs) They're ridin' inside my car
+    They're swimmin' in every drink
+    (Germs) They're hidin' between my toes
+    They're lurkin' in every kiss
+    (Germs) I've got them way up my nose
+    In every orafice
+    (Germs) I'm gonna show them who's boss
+    I'm gonna get even yet
+    (Germs) Just give me some Lysol spray
+    Just hand me a moist towelette
+    (Germs) Don't tell me I'm paranoid
+    I know that they're after me
+    (Germs) Look under the microscope
+    See?
+
+    They're all over me
+    They're inside of me
+    Can't get them offa me
+    I'm covered with
+    Microscopic bacteria
+    What do they want from me
+    What'll they do to me
+    There's no escape for me
+    I'm crawlin' with
+    Microscopic bacteria
+
+    They're all over me
+    I can feel them all over me
+    Over every part of me
+    Microscopic bacteria
+    I know they're watching me
+    They're always watching me
+    They're comin' after me
+    Won't somebody help me
+    Please, somebody help me
+    You've gotta believe me
+    They're out to get me
+    They wanna control me
+    They wanna destroy me
+    They're tryin' to kill me
+    It kind of upsets me
 ---
 Track: Get It On
 Artists:
@@ -46174,6 +46285,46 @@ Lyrics: |-
     For the lives all so wasted and gone
     We feel the pain of a lifetime lost in a thousand days
     Through the fire and the flames we carry on
+---
+Track: Tic-Tock Polka
+Artists:
+- Frankie Yankovic
+Duration: 2:31
+URLs:
+- https://www.youtube.com/watch?v=cwcD8jgaNhs
+Lyrics: |-
+    Tick, tick, tick, tock
+    Goes the clock on the wall
+    As we're dancing the evening away
+    Tick, tick, tick, tock
+    Goes my heart with the clock
+    Beating time while the music is gay
+    Tick, tick, tick, tock
+    Is the rhythm that plays
+    And I know it will make you feel blue
+    Tick, tick, tick, tock
+    Goes my heart with the clock
+    Cause they know I am dancing with you
+
+    Tick, tick, tick, tock
+    Goes the clock on the wall
+    As we're dancing the evening away
+    Tick, tick, tick, tock
+    Goes my heart with the clock
+    Beating time while the music is gay
+    Tick, tick, tick, tock
+    Is the rhythm that plays
+    And I know it will make you feel blue
+    Tick, tick, tick, tock
+    Goes my heart with the clock
+    Cause they know I am dancing with you
+
+    La-la-la-la-la-la-la-la
+    La-la-la-la-la-la-la-la
+    La-la-la-la-la-la-la-la
+    La-la-la-la-la-la-la-la
+
+    Hey!
 ---
 Track: TiK ToK
 Artists:

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -34,6 +34,8 @@ Duration: 4:20
 URLs:
 - https://vasterror.bandcamp.com/track/day-after-day
 - https://www.youtube.com/watch?v=Tm4vT4PkWyI
+Previous Productions:
+- Day After Day [Demo]
 ---
 Track: Moment's Notice
 Cover Artists:

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -34,7 +34,7 @@ Duration: 4:20
 URLs:
 - https://vasterror.bandcamp.com/track/day-after-day
 - https://www.youtube.com/watch?v=Tm4vT4PkWyI
-Previous Productions:
+Referenced Tracks:
 - Day After Day [Demo]
 ---
 Track: Moment's Notice

--- a/album/sbahj-the-album.yaml
+++ b/album/sbahj-the-album.yaml
@@ -601,7 +601,7 @@ Additional Names:
 Artists:
 - Facetious & Friends
 - justinisabitch (featuring)
-- suburrito (featuring)
+- Sburito (featuring)
 - Lydia (featuring)
 Duration: 7:23
 URLs:

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -242,6 +242,11 @@ Commentary: |-
     <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf))
 
     Created to be a Murrit track, but was eventually abandoned due to a lack of interest.
+Referencing Sources: |-
+    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf), excerpt)
+
+    [[artist:gorillaz]]- [[track:feel-good-inc|Feel Good Inc]]<br>
+    Dialogue from Sonic Adventure 2- Real-Time Fandub by Snapcube
 ---
 Track: Here We Go [Beta]
 Artists:
@@ -308,6 +313,13 @@ Commentary: |-
     <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/alpocalypse-loud))
 
     Audio used in the hidden "WEIRDAL" screen of [[flash:serpaz-play-your-soul-out-on-the-accursed-accordion|'[S\] Serpaz: Play your soul out on the accursed accordion.']]
+Referencing Sources: |-
+    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/alpocalypse-loud), excerpt)
+
+    Contains samples from:
+
+    [[artist:weird-al-yankovic|"Weird Al" Yankovic]] - [[track:bohemian-polka]]<br>
+    [[artist:boards-of-canada]] - [[track:ready-lets-go]]
 ---
 Track: Kazoo Call
 Artists:

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -107,7 +107,7 @@ URLs:
 Referenced Tracks:
 - Chamber Cultist
 Commentary: |-
-    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix))
+    <i>Veritas Unae:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix))
 
     A lo-fi Spanish version of [[track:chamber-cultist]] that eventually (with the help of [[artist:dbnet18|dbnet]]) became [[track:pursuit-of-happiness]]. Used in the ['War From Another World' radio play](https://www.youtube.com/watch?v=yl3XTGhKcM4) submitted for the Vast Error Yulepassing Fic Jam on AO3.
 ---
@@ -146,7 +146,7 @@ Duration: 0:54
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it-demo
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo))
 
     [[track:minute-to-win-it|Minute to Win It]] was originally created as a one-off doodle I made to test some instruments out. I came across this interesting 90s-electro synth backing while working on the [[group:unofficial-mspa-fans|UMSPAF]] track [[track:home|"Home"]] with [[artist:grace-medley]], and decided to throw together a quick song based around it. This is the first version of that file, with the synth lead, a rudimentary bassline, and some drum loops.
 ---
@@ -159,7 +159,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It [Demo]
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2))
 
     An updated version of [[track:minute-to-win-it-demo|the demo file]] with more sections; still relatively unpolished, but I began to add more instruments inspired by 90s big beat as well as a rough outline of the guitar outro.
 ---
@@ -172,7 +172,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It [Demo 2]
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3))
 
     The final version of [[track:minute-to-win-it-demo|the demo file]]. I added the SFX intro (made by throwing a quick snippet of a snare drum through tape delay) and polished up the composition and instrumentation throughout. At this point I realized I had made something deserving of more work than a demo: I talked to Austin about it and work on [[track:minute-to-win-it|Minute to Win It]] began.
 ---
@@ -185,7 +185,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It [Demo 3]
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro))
 
     An alternate version of [[track:minute-to-win-it|Minute to Win It]] without the "video game startup" opening. This was supposed to be the version of the song that made it onto [[album:catch-322]], but I felt the SFX intro was too sudden to work well as an album opener.
 ---
@@ -200,7 +200,7 @@ Referenced Tracks:
 Sampled Tracks:
 - Minute To Win It (No Intro)
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-slowed))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-slowed))
 
     A "vaporwave" version of [[track:minute-to-win-it|Minute to Win It]] I made for fun while working on the song.
 ---
@@ -224,7 +224,7 @@ Duration: 1:41
 URLs:
 - https://vasterror.bandcamp.com/track/jcore-uf
 Commentary: |-
-    <i>Kal-la-kal-la:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/jcore-uf))
+    <i>Kal-la-kal-la:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/jcore-uf))
 
     One of the scraps I offered to develop for [[album:vast-error-vol-3|Vol. 3]] for [[artist:austinado|Austin]], he preferred the other one which became [[track:sunrise-vast-error]], I didn't expect anything to ever come of this file but I like the sound it had.
 ---
@@ -416,7 +416,7 @@ URLs:
 Referenced Tracks:
 - Solana
 Commentary: |-
-    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/belladonna-radio-mix))
+    <i>Veritas Unae:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/belladonna-radio-mix))
     
     A jazz take on [[track:solana]] for the [War From Another World radio play.](https://www.youtube.com/watch?v=yl3XTGhKcM4) This is the full amount of the song I made (so far? wink).
 ---
@@ -461,7 +461,7 @@ Duration: 2:01
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars))
 
     A version of [[track:arcjecs-theme]] with different guitars. I made this part of the track over the course of a few days in April. I only revisited the song in late June, when I swapped out the guitars for the updated samples in the final version.
 ---
@@ -474,7 +474,7 @@ URLs:
 Referenced Tracks:
 - Arcjec's Theme
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-detuned))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-detuned))
 
     An alternate take of [[track:arcjecs-theme]] a quarter step lower in pitch. I considered using this for [[album:catch-322]] to match [[track:minute-to-win-it|Minute to Win It's]] similar detuned effect, but decided on the original take instead.
 ---
@@ -489,7 +489,7 @@ Referenced Tracks:
 Sampled Tracks:
 - Arcjec's Theme
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-slowed))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-slowed))
 
     A "vaporwave" version of [[track:arcjecs-theme]] I made some time after finishing the song. I had given [[track:minute-to-win-it|Minute to Win it]] [[track:minute-to-win-it-slowed|a similar treatment]] and wanted to see what it would make other songs sound like. Results were predictable: very cool.
 ---
@@ -633,7 +633,7 @@ URLs:
 Referenced Tracks:
 - Showtime (Original Mix)
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-show-must-go-on))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-show-must-go-on))
 
     A song I finished in 2015, at the end of 8th grade. This was one of the first songs I wrote entirely by myself without using Apple Loops, made on a Mac at my old middle school. It was a silly techno track that I decided to reference [[track:showtime-original-mix|Showtime]] in just because I thought it sounded cool. Although I've improved since, the melody never left my mind: I ended up reusing most of it in [[track:murrits-theme]] years later, albeit altered and placed under a different chord progression.
 ---
@@ -646,7 +646,7 @@ URLs:
 Referenced Tracks:
 - track:the-show-must-go-on-vast-error
 Commentary: |-
-    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/murrits-theme-demo))
+    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/murrits-theme-demo))
     
     An early version of [[track:murrits-theme]] with a different chord progression on the verse. This take was very similar to [[track:the-show-must-go-on-vast-error]], but after feedback from the team I decided to alter it for the final version.
 ---

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -1,0 +1,796 @@
+Album: Sound Test I
+Date: October 31, 2019
+Color: '#68f150'
+URLs:
+- https://vasterror.bandcamp.com/album/sound-test-i
+Cover Artists:
+- Brebby (editing)
+Cover Art File Extension: png
+Groups:
+- Deconreconstruction
+- Fandom
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/album/sound-test-i), excerpt)
+
+    The first collection of various unreleased and unfinished songs from the VEMT that would have never seen the light of day otherwise.
+
+    GUIDE:
+
+    [UF]- Unfinished<br>
+    [Demo]- Earliest version of a track<br>
+    [Beta]- A track in the process of being finished or revised<br>
+    [Loud]- The song is loud.
+Crediting Sources: |-
+    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/album/sound-test-i), excerpt)
+
+    Cover edited by [[artist:brebby|[Brebby\]]]
+---
+Section: Main album
+---
+Track: Our Tapestry [UF]
+Directory: our-tapestry-unfinished
+Artists:
+- Alex Votl
+Duration: 1:18
+URLs:
+- https://vasterror.bandcamp.com/track/our-tapestry-uf
+Cover Artists:
+- Xamag
+Cover Art File Extension: png
+Art Tags:
+- 'cw: corpse'
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/our-tapestry-uf))
+
+    Planned to be the intro for [[album:catch-322]], but the file was corrupted before it could be finished.
+Crediting Sources: |-
+    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/album/sound-test-i), excerpt)
+
+    'Our Tapestry' art by [[artist:xamag]]
+---
+Track: Calm Before The Storm
+Directory: calm-before-the-storm-vast-error
+Artists:
+- sympolite
+Duration: 4:29
+URLs:
+- https://vasterror.bandcamp.com/track/calm-before-the-storm
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/calm-before-the-storm))
+
+    Originally the title theme for 'You're Happy Now', a game being made by [[artist:austinado|austinado]] from 2015-2016. Was going to be reutilized as an Arcjec song.
+---
+Track: Dismas's Theme [Beta]
+Artists:
+- pragmaticNihilist
+Duration: 1:21
+URLs:
+- https://vasterror.bandcamp.com/track/dismass-theme-beta
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/dismass-theme-beta))
+
+    Originally made for [[album:catch-322]], scrapped because it was discovered that there were no plans for a Dismas-centric walkaround in the future at the time the song was made. May eventually be repurposed into a standalone track.
+---
+Track: Godroot [Demo]
+Artists:
+- Rnd
+Duration: 8:08
+URLs:
+- https://vasterror.bandcamp.com/track/godroot-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/godroot-demo))
+
+    Demo meant to be attributed to Wormwood, Denizen of Blood. Was planned to be attached to a now scrapped denizen album, most tracks of which ended up on [[album:vast-error-vol-4|Vol. 4]].
+---
+Track: BLOODRIGHTCORE
+Artists:
+- Kohi
+Duration: 2:45
+URLs:
+- https://vasterror.bandcamp.com/track/bloodrightcore
+Referenced Tracks:
+- Blood Right
+Sampled Tracks:
+- Blood Right
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/bloodrightcore))
+
+    Literally just [[track:blood-right]] from [[album:vast-error-vol-3|Vol. 3]], but it's nightcore now. We are so very sorry, [[artist:psithurist]].
+---
+Track: Cultista De Le Sala (Radio Mix)
+Artists:
+- Veritas Unae
+Duration: 1:48
+URLs:
+- https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix
+Referenced Tracks:
+- Chamber Cultist
+Commentary: |-
+    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix))
+
+    A lo-fi Spanish version of [[track:chamber-cultist]] that eventually (with the help of [[artist:dbnet18|dbnet]]) became [[track:pursuit-of-happiness]]. Used in the 'War From Another World' radio play submitted for the Vast Error Yulepassing Fic Jam on AO3.
+---
+Track: Reverent
+Directory: reverent-vast-error
+Artists:
+- dbnet18
+Duration: 2:01
+URLs:
+- https://vasterror.bandcamp.com/track/reverent
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/reverent))
+
+    Song originally meant for [[album:vast-error-vol-3|Vol. 3]], but was scrapped due to a lack of satisfaction with the sound. Probably would have been related to Calder or Occeus.
+---
+Track: Tomatoes
+Directory: tomatoes-vast-error
+Additional Names:
+- Belladonna (original name)
+Artists:
+- Circlejourney
+Duration: 4:14
+URLs:
+- https://vasterror.bandcamp.com/track/tomatoes
+Referenced Tracks:
+- Solana
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/tomatoes))
+
+    Yet another [[track:solana]] arrangement meant for [[album:vast-error-vol-4|Vol. 4]] but scrapped for time and a lack of polish. It was originally titled 'Belladonna' but since we already have [[Belladonna (Radio Mix)|another song on here titled that]], we gave it a sillier name to distinguish itself.
+---
+Track: Minute To Win It [Demo]
+Artists:
+- SplitSuns
+Duration: 0:54
+URLs:
+- https://vasterror.bandcamp.com/track/minute-to-win-it-demo
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo))
+
+    [[track:minute-to-win-it|Minute to Win It]] was originally created as a one-off doodle I made to test some instruments out. I came across this interesting 90s-electro synth backing while working on the [[group:unofficial-mspa-fans|UMSPAF]] track [[track:home|"Home"]] with [[artist:grace-medley]], and decided to throw together a quick song based around it. This is the first version of that file, with the synth lead, a rudimentary bassline, and some drum loops.
+---
+Track: Minute To Win It [Demo 2]
+Artists:
+- SplitSuns
+Duration: 1:51
+URLs:
+- https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2
+Previous Productions:
+- Minute To Win It [Demo]
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2))
+
+    An updated version of [[track:minute-to-win-it-demo|the demo file]] with more sections; still relatively unpolished, but I began to add more instruments inspired by 90s big beat as well as a rough outline of the guitar outro.
+---
+Track: Minute To Win It [Demo 3]
+Artists:
+- SplitSuns
+Duration: 2:00
+URLs:
+- https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3
+Previous Productions:
+- Minute To Win It [Demo 2]
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3))
+
+    The final version of [[track:minute-to-win-it-demo|the demo file]]. I added the SFX intro (made by throwing a quick snippet of a snare drum through tape delay) and polished up the composition and instrumentation throughout. At this point I realized I had made something deserving of more work than a demo: I talked to Austin about it and work on [[track:minute-to-win-it|Minute to Win It]] began.
+---
+Track: Minute To Win It (No Intro)
+Artists:
+- SplitSuns
+Duration: 3:05
+URLs:
+- https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro
+Previous Productions:
+- Minute To Win It [Demo 3]
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro))
+
+    An alternate version of [[track:minute-to-win-it|Minute to Win It]] without the "video game startup" opening. This was supposed to be the version of the song that made it onto [[album:catch-322]], but I felt the SFX intro was too sudden to work well as an album opener.
+---
+Track: Minute To Win It (Slowed)
+Artists:
+- SplitSuns
+Duration: 4:19
+URLs:
+- https://vasterror.bandcamp.com/track/minute-to-win-it-slowed
+Referenced Tracks:
+- Minute To Win It (No Intro)
+Sampled Tracks:
+- Minute To Win It (No Intro)
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-slowed))
+
+    A "vaporwave" version of [[track:minute-to-win-it|Minute to Win It]] I made for fun while working on the song.
+---
+Track: yo dogg whos bumpin that hotline miami noise at 5am [UF]
+Directory: yo-dogg-whos-bumpin-that-hotline-miami-noise-at-5am-unfinished
+Artists:
+- Cerulean
+Duration: 1:10
+URLs:
+- https://vasterror.bandcamp.com/track/yo-dogg-whos-bumpin-that-hotline-miami-noise-at-5am-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/yo-dogg-whos-bumpin-that-hotline-miami-noise-at-5am-uf))
+
+    Scrapped track intended for [[album:vast-error-vol-4|Vol. 4]], tossed aside in favor of [[track:secure-vast-error]].
+---
+Track: JCore [UF]
+Directory: jcore-unfinished
+Artists:
+- Kal-la-kal-la
+Duration: 1:41
+URLs:
+- https://vasterror.bandcamp.com/track/jcore-uf
+Commentary: |-
+    <i>Kal-la-kal-la:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/jcore-uf))
+
+    One of the scraps I offered to develop for [[album:vast-error-vol-3|Vol. 3]] for [[artist:austinado|Austin]], he preferred the other one which became [[track:sunrise-vast-error]], I didn't expect anything to ever come of this file but I like the sound it had.
+---
+Track: I'VE COME TO MAKE AN ANNOUNCEMENT [UF]
+Directory: ive-come-to-make-an-announcement-unfinished
+Artists:
+- whimsi
+Duration: 1:09
+URLs:
+- https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf
+Sampled Tracks:
+- Feel Good Inc.
+# - Dialogue from Sonic Adventure 2- Real-Time Fandub by SnapCube
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf))
+
+    Created to be a Murrit track, but was eventually abandoned due to a lack of interest.
+---
+Track: Here We Go [Beta]
+Artists:
+- Alex Votl
+Duration: 1:48
+URLs:
+- https://vasterror.bandcamp.com/track/here-we-go-beta
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/here-we-go-beta))
+
+    Work in progress for a track that is meant to go on [[album:reminders-of-you-beta|an eventual votl solo album]], potentially focused on the relationships of the main cast.
+---
+Track: Albion's Theme (Ucklin Cut)
+Artists:
+- Grace Medley
+- Ucklin
+Duration: 4:15
+URLs:
+- https://vasterror.bandcamp.com/track/albions-theme-ucklin-cut
+Referenced Tracks:
+- Albion's Theme
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/albions-theme-ucklin-cut))
+
+    Edited version of [[Albion's Theme]] with extra flourishes added by [[artist:ucklin]]. This was going to be the final version of the song, but it wasn't finished in time for the release, so the original cut was chosen.
+---
+Track: Serpaz's Happy Accordion Funtimes
+Artists:
+- Veritas Unae
+Duration: 1:19
+URLs:
+- https://vasterror.bandcamp.com/track/serpazs-happy-accordion-funtimes
+Referenced Tracks:
+- The Simpsons Theme
+- Seinfeld Theme
+- Space Jam
+- track:megalovania-undertale
+- Meet the Flintstones
+- Fly
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/serpazs-happy-accordion-funtimes))
+
+    All of the little accordion ditties from [[flash:serpaz-play-your-soul-out-on-the-accursed-accordion|'[S\] Serpaz: Play your soul out on the accursed accordion']]. Plus a few that didn't make it in. Ordered by original conception, not including the section specifically taken from [[artist:weird-al-yankovic|Weird Al's]] Polka song or John Mulaney's 'No'.
+---
+Track: Alpocalypse [Loud]
+Directory: alpocalypse
+Artists:
+- SplitSuns
+Duration: 0:34
+URLs:
+- https://vasterror.bandcamp.com/track/alpocalypse-loud
+Sampled Tracks:
+- Bohemian Polka
+- Ready Let's Go
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/alpocalypse-loud))
+
+    Audio used in the hidden "WEIRDAL" screen of [[flash:serpaz-play-your-soul-out-on-the-accursed-accordion|'[S\] Serpaz: Play your soul out on the accursed accordion.']]
+---
+Track: Kazoo Call
+Artists:
+- Rnd
+Duration: 0:43
+URLs:
+- https://vasterror.bandcamp.com/track/kazoo-call
+Referenced Tracks:
+- Curtain Call
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/kazoo-call))
+
+    Joke track recorded as a prank for the VEMT.
+---
+Track: Immortal (Country Rock Mix)
+Directory: immortal-vast-error-country-rock-mix
+Artists:
+- Circlejourney
+Duration: 2:55
+URLs:
+- https://vasterror.bandcamp.com/track/immortal-country-rock-mix
+Referenced Tracks:
+- track:immortal-vast-error
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/immortal-country-rock-mix))
+
+    Edited version of [[track:immortal-vast-error]], stripping down and adding some intruments to make it sound like a completely different song. [[artist:circlejourney|CJ]] does not remember why this was done at all.
+---
+Track: At Death's Door [Demo]
+Artists:
+- dbnet18
+Duration: 0:45
+URLs:
+- https://vasterror.bandcamp.com/track/at-deaths-door-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/at-deaths-door-demo))
+
+    Riff concepted for Sorush, Denizen of Doom on the scrapped denizens album. It would later be revamped and utilized for [[track:be-all-end-all|'Be All End All']] on [[album:vast-error-vol-4|Vol. 4]].
+---
+Track: Lovecraft [Beta]
+Directory: lovecraft-vast-error-beta
+Artists:
+- sympolite
+Duration: 1:32
+URLs:
+- https://vasterror.bandcamp.com/track/lovecraft-beta
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/lovecraft-beta))
+
+    Originally used as a barkeeper shop theme in 'You're Happy Now'. The song is being revised as [[track:lovecraft-vast-error|a Dead Shufflers track]].
+---
+Track: Ellsee's Theme (Take 1) [UF]
+Directory: ellsees-theme-take-1-unfinished
+Artists:
+- pragmaticNihilist
+Duration: 0:48
+URLs:
+- https://vasterror.bandcamp.com/track/ellsees-theme-take-1-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-take-1-uf))
+
+    First of five concepts for [[track:ellsees-theme]]. One of which would eventually become Sirage's Theme in Snowbound Blood and another being the final version. This version was lost and then later found much too late.
+---
+Track: Ellsee's Theme (Take 2) [UF]
+Directory: ellsees-theme-take-2-unfinished
+Artists:
+- pragmaticNihilist
+Duration: 1:26
+URLs:
+- https://vasterror.bandcamp.com/track/ellsees-theme-take-2-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-take-2-uf))
+
+    Second version of [[track:ellsees-theme]]. Scrapped because of dissatisfaction with the sound, but would influence what the final version became.
+---
+Track: Ellsee's Theme (Ft. Calder Kerian) [UF]
+Directory: ellsees-theme-ft-calder-kerian-unfinished
+Artists:
+- pragmaticNihilist
+Duration: 1:37
+URLs:
+- https://vasterror.bandcamp.com/track/ellsees-theme-ft-calder-kerian-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-ft-calder-kerian-uf))
+
+    Fourth version of [[track:ellsees-theme]], with the idea being that Calder sort of hijacks the track much as he tries to hijack Ellsee's role in the comic. Rejected as it didn't really seem to fit Ellsee specifically as a character.
+---
+Track: Belladonna (Radio Mix)
+Artists:
+- Veritas Unae
+Duration: 1:42
+URLs:
+- https://vasterror.bandcamp.com/track/belladonna-radio-mix
+Referenced Tracks:
+- Solana
+Commentary: |-
+    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/belladonna-radio-mix))
+    
+    A jazz take on [[track:solana]] for the War From Another World radio play. This is the full amount of the song I made (so far? wink).
+---
+Track: Hope Onwards
+Artists:
+- Cristata
+- FRUITYTEE
+Duration: 3:00
+URLs:
+- https://vasterror.bandcamp.com/track/hope-onwards
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/hope-onwards))
+
+    Albion song originally made for [[album:vast-error-vol-5-side-1|Vol.]] [[album:vast-error-vol-5-side-2|5]] but the song file was corrupted. Basically finished outside of some mixing issues.
+---
+Track: The Static [Demo]
+Artists:
+- Kal-la-kal-la
+Duration: 3:37
+URLs:
+- https://vasterror.bandcamp.com/track/the-static-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-static-demo))
+
+    The original full live recording of [[track:the-static]], sans the record player effects by [[artist:sympolite]].
+---
+Track: Day After Day [Demo]
+Artists:
+- pragmaticNihilist
+Duration: 2:04
+URLs:
+- https://vasterror.bandcamp.com/track/day-after-day-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/day-after-day-demo))
+
+    Original concept for [[track:day-after-day]] from [[album:repiton]], revised for the final album.
+---
+Track: Arcjec's Theme (Scrapped Guitars)
+Artists:
+- SplitSuns
+Duration: 2:01
+URLs:
+- https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars))
+
+    A version of [[track:arcjecs-theme]] with different guitars. I made this part of the track over the course of a few days in April. I only revisited the song in late June, when I swapped out the guitars for the updated samples in the final version.
+---
+Track: Arcjec's Theme (Detuned)
+Artists:
+- SplitSuns
+Duration: 3:03
+URLs:
+- https://vasterror.bandcamp.com/track/arcjecs-theme-detuned
+Previous Productions:
+- Arcjec's Theme
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-detuned))
+
+    An alternate take of [[track:arcjecs-theme]] a quarter step lower in pitch. I considered using this for [[album:catch-322]] to match [[track:minute-to-win-it|Minute to Win It's]] similar detuned effect, but decided on the original take instead.
+---
+Track: Arcjec's Theme (Slowed)
+Artists:
+- SplitSuns
+Duration: 3:57
+URLs:
+- https://vasterror.bandcamp.com/track/arcjecs-theme-slowed
+Referenced Tracks:
+- Arcjec's Theme
+Sampled Tracks:
+- Arcjec's Theme
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-slowed))
+
+    A "vaporwave" version of [[track:arcjecs-theme]] I made some time after finishing the song. I had given [[track:minute-to-win-it|Minute to Win it]] [[track:minute-to-win-it-slowed|a similar treatment]] and wanted to see what it would make other songs sound like. Results were predictable: very cool.
+---
+Track: Hesitating [UF]
+Directory: hesitating-vast-error-unfinished
+Artists:
+- Circlejourney
+Duration: 1:05
+URLs:
+- https://vasterror.bandcamp.com/track/hesitating-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/hesitating-uf))
+
+    A theme made for Jentha, meant to go on [[album:catch-322]]. Scrapped because it didn't fit the tone of the album.
+---
+Track: Talking Hands
+Artists:
+- sympolite
+Duration: 1:43
+URLs:
+- https://vasterror.bandcamp.com/track/talking-hands
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/talking-hands))
+
+    Battle theme originally made for 'You're Happy Now', was going to be reutilized as a White Noise song.
+---
+Track: Disk Of Violet
+Artists:
+- Rnd
+Duration: 2:52
+URLs:
+- https://vasterror.bandcamp.com/track/disk-of-violet
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/disk-of-violet))
+
+    A song based on the Star Childrens purple emotional response (compassion). Originally made for a scrapped Star Children album that never came to be due to a lack of interest and information.
+---
+Track: Rootin' Tootin' [UF]
+Directory: rootin-tootin-unfinished
+Artists:
+- dbnet18
+Duration: 2:29
+URLs:
+- https://vasterror.bandcamp.com/track/rootin-tootin-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/rootin-tootin-uf))
+
+    Scrapped Dismas track for [[album:vast-error-vol-4|Vol. 4]], abandoned due to a lack of time and the sound not necessarily fitting the character.
+---
+Track: Anywhere Can Be Paradise [Demo]
+Artists:
+- Alex Votl
+Duration: 3:18
+URLs:
+- https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-demo))
+
+    First version of [[track:anywhere-can-be-paradise]], originally lacking orchestration and made with a piano and chiptune lead in mind.
+---
+Track: Anywhere Can Be Paradise (Alt. Take) [UF]
+Directory: anywhere-can-be-paradise-alt-take-unfinished
+Artists:
+- Alex Votl
+Duration: 1:02
+URLs:
+- https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-alt-take-uf
+Referenced Tracks:
+- Anywhere Can Be Paradise [Demo]
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-alt-take-uf))
+
+    A sort of reprise version of the original [[track:anywhere-can-be-paradise-demo|Anywhere Can Be Paradise]], scrapped in favor of [[track:anywhere-can-be-paradise|the final track]].
+---    
+Track: Sympath [UF]
+Directory: sympath-vast-error-unfinished
+Artists:
+- Cerulean
+Duration: 0:41
+URLs:
+- https://vasterror.bandcamp.com/track/sympath-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/sympath-uf))
+
+    The first track ever submitted by [[artist:cerulean]] to the VEMT, sent more as a test than anything made to be finished. A test of their sound, if you will.
+---
+Track: Land Of Wave And Record [Demo]
+Artists:
+- Rnd
+Duration: 2:04
+URLs:
+- https://vasterror.bandcamp.com/track/land-of-wave-and-record-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/land-of-wave-and-record-demo))
+
+    Concept made for a scrapped land centric album.
+---
+Track: Negative Feedback [Beta]
+Artists:
+- slime
+Duration: 5:38
+URLs:
+- https://vasterror.bandcamp.com/track/negative-feedback-beta
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/negative-feedback-beta))
+    
+    Originally made for [[album:catch-322]] but is currently being wholly revised for [[track:negative-feedback|an eventual release]], potentially on [[album:vast-error-vol-5-side-1|Vol. 5]].
+---
+Track: Procel [UF]
+Directory: procel-unfinished
+Artists:
+- Alex Votl
+Duration: 1:01
+URLs:
+- https://vasterror.bandcamp.com/track/procel-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/procel-uf))
+
+    Unfinished track for Procel, Denizen of Void. Originally made for the scrapped denizen album.
+---
+Track: Alter Schmerz
+Artists:
+- sympolite
+Duration: 0:37
+URLs:
+- https://vasterror.bandcamp.com/track/alter-schmerz
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/alter-schmerz))
+
+    Song that plays after you die in 'You're Happy Now', was going to be utilized in a later walkaround but the initial concept that would have used it was scrapped.
+---
+Track: The Show Must Go On
+Directory: the-show-must-go-on-vast-error
+Artists:
+- SplitSuns
+Duration: 3:56
+URLs:
+- https://vasterror.bandcamp.com/track/the-show-must-go-on
+Referenced Tracks:
+- Showtime (Original Mix)
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-show-must-go-on))
+
+    A song I finished in 2015, at the end of 8th grade. This was one of the first songs I wrote entirely by myself without using Apple Loops, made on a Mac at my old middle school. It was a silly techno track that I decided to reference [[track:showtime-original-mix|Showtime]] in just because I thought it sounded cool. Although I've improved since, the melody never left my mind: I ended up reusing most of it in [[track:murrits-theme]] years later, albeit altered and placed under a different chord progression.
+---
+Track: Murrit's Theme [Demo]
+Artists:
+- SplitSuns
+Duration: 0:39
+URLs:
+- https://vasterror.bandcamp.com/track/murrits-theme-demo
+Referenced Tracks:
+- track:the-show-must-go-on-vast-error
+Commentary: |-
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/murrits-theme-demo))
+    
+    An early version of [[track:murrits-theme]] with a different chord progression on the verse. This take was very similar to [[track:the-show-must-go-on-vast-error]], but after feedback from the team I decided to alter it for the final version.
+---
+Track: Bittersweet [Demo]
+Directory: bittersweet-vast-error-demo
+Artists:
+- Alex Votl
+Contributors:
+- suburrito (extra guitar work)
+Duration: 3:00
+URLs:
+- https://vasterror.bandcamp.com/track/bittersweet-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/bittersweet-demo))
+
+    First recording of [[track:bittersweet-vast-error]] from [[album:vast-error-vol-4|Vol. 4]].
+---
+Track: Sweeps Past [UF]
+Directory: sweeps-past-unfinished
+Artists:
+- sympolite
+Duration: 2:43
+URLs:
+- https://vasterror.bandcamp.com/track/sweeps-past-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/sweeps-past-uf))
+
+    Originally a concept for the credits of 'You're Happy Now', then meant to be a track relating to the past of the main cast.
+---
+Track: Solstice [UF]
+Directory: solstice-vast-error-unfinished
+Artists:
+- Rnd
+Duration: 1:59
+URLs:
+- https://vasterror.bandcamp.com/track/solstice-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/solstice-uf))
+
+    Scrapped track from [[album:vast-error-vol-4|Vol. 4]], unfinished due to time constraints.
+---
+Track: The Midnight Meat Train
+Artists:
+- sympolite
+Duration: 1:14
+URLs:
+- https://vasterror.bandcamp.com/track/the-midnight-meat-train
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-midnight-meat-train))
+
+    Butcher shopkeeper theme from 'You're Happy Now', was going to be reused in a walkaround but was scrapped.
+---
+Track: Undone [UF]
+Directory: undone-vast-error-unfinished
+Artists:
+- Rnd
+- Alex Votl
+Duration: 2:02
+URLs:
+- https://vasterror.bandcamp.com/track/undone-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/undone-uf))
+
+    Scrapped collab between [[artist:rnd]] and [[artist:alex-votl|votl]] meant for [[album:vast-error-vol-4|Vol. 4]], abandoned due to time constraints.
+---
+Track: Star Crossed [UF]
+Directory: star-crossed-unfinished
+Artists:
+- sympolite
+Duration: 1:46
+URLs:
+- https://vasterror.bandcamp.com/track/star-crossed-uf
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/star-crossed-uf))
+
+    VHS rental store shopkeeper track from 'You're Happy Now', was originally going to be repurposed as an Albion track but was scrapped.
+---
+Track: Sickly Green Glow [Demo]
+Artists:
+- Rnd
+Duration: 2:50
+URLs:
+- https://vasterror.bandcamp.com/track/sickly-green-glow-demo
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/sickly-green-glow-demo))
+
+    Original concept for [[track:sickly-green-glow]] from [[album:vast-error-vol-3|Vol. 3]].
+---
+Track: Bohemian Rhapsody (VE Mix) [UF]
+Directory: bohemian-rhapsody-ve-mix-unfinished
+Artists:
+- Michael Guy Bowman
+- Ucklin
+- pragmaticNihilist
+- SplitSuns
+Contributors:
+- Michael Guy Bowman (vocals)
+- Ucklin (vocals)
+- pragmaticNihilist (main piano)
+- SplitSuns (drums, bass, additional piano, additional instruments/SFX, mixing)
+Duration: 5:35
+URLs:
+- https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf
+Referenced Tracks:
+- Bohemian Rhapsody
+Lyrics: |-
+    Mama, just killed a man
+
+    Put a gun against his head, pulled my trigger, now he's dead
+    Mama, life had just begun
+    But now I've gone and thrown it all away
+    Mama, oh, didn't mean to make you cry
+    If I'm not back again this time tomorrow
+    Carry on, carry on as if nothing really matters
+
+    Too late, my time has come
+    Sends shivers down my spine, body's aching all the time
+    Goodbye, everybody, I've got to go
+    Gotta leave you all behind and face the truth
+    Mama, ooh
+    I don't wanna die
+    I sometimes wish I'd never been born at all
+
+    Scaramouche, Scaramouche, will you do the Fandango?
+    Thunderbolt and lightning, very, very frightening me
+    (Galileo) Galileo, (Galileo) Galileo, Galileo Figaro
+    He's just a poor boy from a poor family
+    Spare him his life from this monstrosity
+
+    بِسْمِ ٱللَّٰهِ
+    No, we will not let you go (let him go)
+    بِسْمِ ٱللَّٰهِ
+    We will not let you go (let him go)
+    بِسْمِ ٱللَّٰهِ
+    Will not let you go
+    Will not let you go
+    Will not let you go
+    No, no, no, no, no, no, no
+
+    Mamma mia, let me go
+    Beelzebub has a devil put aside for me, for me, for me
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf))
+
+    An unfinished cover of [[artist:queen|Queen's]] [[track:bohemian-rhapsody|"Bohemian Rhapsody,"]] featuring [[artist:michael-guy-bowman]].
+Crediting Sources: |-
+    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf))
+
+    Credits:
+
+    [[artist:michael-guy-bowman]] - vocals<br>
+    [[artist:ucklin]] - vocals<br>
+    [[artist:pragmaticnihilist]] - main piano<br>
+    [[artist:splitsuns]] - drums, bass, additional piano, additional instruments/SFX, mixing
+---
+Track: Glimpses Of Perfection [Loud]
+Directory: glimpses-of-perfection
+Artists:
+- SplitSuns
+Duration: 0:44
+URLs:
+- https://vasterror.bandcamp.com/track/glimpses-of-perfection-loud
+Referenced Tracks:
+- 'The End of Evangelion - TV Spot #1'
+- Uneven Compromise
+- Beyond the Wall (Intermission)
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/glimpses-of-perfection-loud))
+
+    Audio used in [[flash:what-did-you-do-to-them|[S\] WHAT DID YOU DO TO THEM.]] Loops infinitely in the animation; this version consists of two loops and a fade-out.

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -713,7 +713,7 @@ Commentary: |-
     Original concept for [[track:sickly-green-glow]] from [[album:vast-error-vol-3|Vol. 3]].
 ---
 Track: Bohemian Rhapsody (VE Mix) [UF]
-Directory: bohemian-rhapsody-ve-mix-unfinished
+Directory: bohemian-rhapsody-vast-error-mix-unfinished
 Artists:
 - Michael Guy Bowman
 - Ucklin

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -595,6 +595,7 @@ URLs:
 - https://vasterror.bandcamp.com/track/negative-feedback-beta
 Referenced Tracks:
 - Curtain Call
+- track:nostalgia-vast-error
 Commentary: |-
     @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/negative-feedback-beta)
     

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -277,13 +277,13 @@ URLs:
 Referenced Tracks:
 - Nailed It
 - Beat It
-#- Germs (Weird Al Yankovic)
+- track:germs-weird-al-yankovic
 - Bohemian Polka
-#- Tic Toc Polka (Frankie Yankovic)
+- Tic-Tock Polka
 - The Simpsons Theme
 - Seinfeld Theme
 #- Accordion (MF DOOM)
-#- Friend Like Me (from Aladdin)
+- Friend Like Me
 - Layton's Theme
 - Space Jam
 - track:megalovania-undertale

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -237,7 +237,7 @@ URLs:
 - https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf
 Sampled Tracks:
 - Feel Good Inc.
-# - Dialogue from Sonic Adventure 2- Real-Time Fandub by SnapCube
+- Sonic Adventure 2 (Dark Story + Final Story)
 Commentary: |-
     <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf))
 
@@ -246,7 +246,7 @@ Referencing Sources: |-
     <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf), excerpt)
 
     [[artist:gorillaz]]- [[track:feel-good-inc|Feel Good Inc]]<br>
-    Dialogue from Sonic Adventure 2- Real-Time Fandub by Snapcube
+    [[track:sonic-adventure-2-dark-story-final-story|Dialogue from Sonic Adventure 2- Real-Time Fandub]] by [[artist:snapcube|Snapcube]]
 ---
 Track: Here We Go [Beta]
 Artists:

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -23,7 +23,7 @@ Commentary: |-
 Crediting Sources: |-
     @@ [Bandcamp credits blurb, excerpt](https://vasterror.bandcamp.com/album/sound-test-i)
 
-    Cover edited by [[artist:brebby|[Brebby\]]]
+    Cover edited by [[artist:brebby]]
 ---
 Section: Main album
 ---

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -275,8 +275,16 @@ Duration: 1:19
 URLs:
 - https://vasterror.bandcamp.com/track/serpazs-happy-accordion-funtimes
 Referenced Tracks:
+- Nailed It
+- Beat It
+#- Germs (Weird Al Yankovic)
+- Bohemian Polka
+#- Tic Toc Polka (Frankie Yankovic)
 - The Simpsons Theme
 - Seinfeld Theme
+#- Accordion (MF DOOM)
+#- Friend Like Me (from Aladdin)
+- Layton's Theme
 - Space Jam
 - track:megalovania-undertale
 - Meet the Flintstones

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -107,7 +107,7 @@ URLs:
 Referenced Tracks:
 - Chamber Cultist
 Commentary: |-
-    <i>Veritas Unae:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix))
+    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix))
 
     A lo-fi Spanish version of [[track:chamber-cultist]] that eventually (with the help of [[artist:dbnet18|dbnet]]) became [[track:pursuit-of-happiness]]. Used in the ['War From Another World' radio play](https://www.youtube.com/watch?v=yl3XTGhKcM4) submitted for the Vast Error Yulepassing Fic Jam on AO3.
 ---
@@ -146,7 +146,7 @@ Duration: 0:54
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it-demo
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo))
 
     [[track:minute-to-win-it|Minute to Win It]] was originally created as a one-off doodle I made to test some instruments out. I came across this interesting 90s-electro synth backing while working on the [[group:unofficial-mspa-fans|UMSPAF]] track [[track:home|"Home"]] with [[artist:grace-medley]], and decided to throw together a quick song based around it. This is the first version of that file, with the synth lead, a rudimentary bassline, and some drum loops.
 ---
@@ -159,7 +159,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It [Demo]
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2))
 
     An updated version of [[track:minute-to-win-it-demo|the demo file]] with more sections; still relatively unpolished, but I began to add more instruments inspired by 90s big beat as well as a rough outline of the guitar outro.
 ---
@@ -172,7 +172,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It [Demo 2]
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3))
 
     The final version of [[track:minute-to-win-it-demo|the demo file]]. I added the SFX intro (made by throwing a quick snippet of a snare drum through tape delay) and polished up the composition and instrumentation throughout. At this point I realized I had made something deserving of more work than a demo: I talked to Austin about it and work on [[track:minute-to-win-it|Minute to Win It]] began.
 ---
@@ -185,7 +185,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It [Demo 3]
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro))
 
     An alternate version of [[track:minute-to-win-it|Minute to Win It]] without the "video game startup" opening. This was supposed to be the version of the song that made it onto [[album:catch-322]], but I felt the SFX intro was too sudden to work well as an album opener.
 ---
@@ -200,7 +200,7 @@ Referenced Tracks:
 Sampled Tracks:
 - Minute To Win It (No Intro)
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-slowed))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-slowed))
 
     A "vaporwave" version of [[track:minute-to-win-it|Minute to Win It]] I made for fun while working on the song.
 ---
@@ -224,7 +224,7 @@ Duration: 1:41
 URLs:
 - https://vasterror.bandcamp.com/track/jcore-uf
 Commentary: |-
-    <i>Kal-la-kal-la:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/jcore-uf))
+    <i>Kal-la-kal-la:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/jcore-uf))
 
     One of the scraps I offered to develop for [[album:vast-error-vol-3|Vol. 3]] for [[artist:austinado|Austin]], he preferred the other one which became [[track:sunrise-vast-error]], I didn't expect anything to ever come of this file but I like the sound it had.
 ---
@@ -416,7 +416,7 @@ URLs:
 Referenced Tracks:
 - Solana
 Commentary: |-
-    <i>Veritas Unae:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/belladonna-radio-mix))
+    <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/belladonna-radio-mix))
     
     A jazz take on [[track:solana]] for the [War From Another World radio play.](https://www.youtube.com/watch?v=yl3XTGhKcM4) This is the full amount of the song I made (so far? wink).
 ---
@@ -461,7 +461,7 @@ Duration: 2:01
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-scrapped-guitars))
 
     A version of [[track:arcjecs-theme]] with different guitars. I made this part of the track over the course of a few days in April. I only revisited the song in late June, when I swapped out the guitars for the updated samples in the final version.
 ---
@@ -474,7 +474,7 @@ URLs:
 Referenced Tracks:
 - Arcjec's Theme
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-detuned))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-detuned))
 
     An alternate take of [[track:arcjecs-theme]] a quarter step lower in pitch. I considered using this for [[album:catch-322]] to match [[track:minute-to-win-it|Minute to Win It's]] similar detuned effect, but decided on the original take instead.
 ---
@@ -489,7 +489,7 @@ Referenced Tracks:
 Sampled Tracks:
 - Arcjec's Theme
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-slowed))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-slowed))
 
     A "vaporwave" version of [[track:arcjecs-theme]] I made some time after finishing the song. I had given [[track:minute-to-win-it|Minute to Win it]] [[track:minute-to-win-it-slowed|a similar treatment]] and wanted to see what it would make other songs sound like. Results were predictable: very cool.
 ---
@@ -634,7 +634,7 @@ URLs:
 Referenced Tracks:
 - Showtime (Original Mix)
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-show-must-go-on))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-show-must-go-on))
 
     A song I finished in 2015, at the end of 8th grade. This was one of the first songs I wrote entirely by myself without using Apple Loops, made on a Mac at my old middle school. It was a silly techno track that I decided to reference [[track:showtime-original-mix|Showtime]] in just because I thought it sounded cool. Although I've improved since, the melody never left my mind: I ended up reusing most of it in [[track:murrits-theme]] years later, albeit altered and placed under a different chord progression.
 ---
@@ -647,7 +647,7 @@ URLs:
 Referenced Tracks:
 - track:the-show-must-go-on-vast-error
 Commentary: |-
-    <i>SplitSuns:</i> (composer, [Bandcamp about blurb](https://vasterror.bandcamp.com/track/murrits-theme-demo))
+    <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/murrits-theme-demo))
     
     An early version of [[track:murrits-theme]] with a different chord progression on the verse. This take was very similar to [[track:the-show-must-go-on-vast-error]], but after feedback from the team I decided to alter it for the final version.
 ---

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -572,6 +572,8 @@ Artists:
 Duration: 5:38
 URLs:
 - https://vasterror.bandcamp.com/track/negative-feedback-beta
+Referenced Tracks:
+- Curtain Call
 Commentary: |-
     <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/negative-feedback-beta))
     

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -108,7 +108,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/cultista-de-le-sala-radio-mix))
 
-    A lo-fi Spanish version of [[track:chamber-cultist]] that eventually (with the help of [[artist:dbnet18|dbnet]]) became [[track:pursuit-of-happiness]]. Used in the 'War From Another World' radio play submitted for the Vast Error Yulepassing Fic Jam on AO3.
+    A lo-fi Spanish version of [[track:chamber-cultist]] that eventually (with the help of [[artist:dbnet18|dbnet]]) became [[track:pursuit-of-happiness]]. Used in the ['War From Another World' radio play](https://www.youtube.com/watch?v=yl3XTGhKcM4) submitted for the Vast Error Yulepassing Fic Jam on AO3.
 ---
 Track: Reverent
 Directory: reverent-vast-error
@@ -397,7 +397,7 @@ Referenced Tracks:
 Commentary: |-
     <i>Veritas Unae:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/belladonna-radio-mix))
     
-    A jazz take on [[track:solana]] for the War From Another World radio play. This is the full amount of the song I made (so far? wink).
+    A jazz take on [[track:solana]] for the [War From Another World radio play.](https://www.youtube.com/watch?v=yl3XTGhKcM4) This is the full amount of the song I made (so far? wink).
 ---
 Track: Hope Onwards
 Artists:

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -156,7 +156,7 @@ Artists:
 Duration: 1:51
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2
-Previous Productions:
+Referenced Tracks:
 - Minute To Win It [Demo]
 Commentary: |-
     <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-2))
@@ -169,7 +169,7 @@ Artists:
 Duration: 2:00
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3
-Previous Productions:
+Referenced Tracks:
 - Minute To Win It [Demo 2]
 Commentary: |-
     <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-demo-3))
@@ -182,7 +182,7 @@ Artists:
 Duration: 3:05
 URLs:
 - https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro
-Previous Productions:
+Referenced Tracks:
 - Minute To Win It [Demo 3]
 Commentary: |-
     <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/minute-to-win-it-no-intro))
@@ -471,7 +471,7 @@ Artists:
 Duration: 3:03
 URLs:
 - https://vasterror.bandcamp.com/track/arcjecs-theme-detuned
-Previous Productions:
+Referenced Tracks:
 - Arcjec's Theme
 Commentary: |-
     <i>SplitSuns:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/arcjecs-theme-detuned))

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -38,6 +38,7 @@ Cover Artists:
 - Xamag
 Cover Art File Extension: png
 Art Tags:
+- 'cw: body horror'
 - 'cw: corpse'
 Commentary: |-
     <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/our-tapestry-uf))

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -635,7 +635,7 @@ Directory: bittersweet-vast-error-demo
 Artists:
 - Alex Votl
 Contributors:
-- suburrito (extra guitar work)
+- Sburito (extra guitar work)
 Duration: 3:00
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet-demo

--- a/album/sound-test-i.yaml
+++ b/album/sound-test-i.yaml
@@ -10,7 +10,7 @@ Groups:
 - Deconreconstruction
 - Fandom
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/album/sound-test-i), excerpt)
+    @@ [Bandcamp about blurb, excerpt](https://vasterror.bandcamp.com/album/sound-test-i)
 
     The first collection of various unreleased and unfinished songs from the VEMT that would have never seen the light of day otherwise.
 
@@ -21,7 +21,7 @@ Commentary: |-
     [Beta]- A track in the process of being finished or revised<br>
     [Loud]- The song is loud.
 Crediting Sources: |-
-    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/album/sound-test-i), excerpt)
+    @@ [Bandcamp credits blurb, excerpt](https://vasterror.bandcamp.com/album/sound-test-i)
 
     Cover edited by [[artist:brebby|[Brebby\]]]
 ---
@@ -41,11 +41,11 @@ Art Tags:
 - 'cw: body horror'
 - 'cw: corpse'
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/our-tapestry-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/our-tapestry-uf)
 
     Planned to be the intro for [[album:catch-322]], but the file was corrupted before it could be finished.
 Crediting Sources: |-
-    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/album/sound-test-i), excerpt)
+    @@ [Bandcamp credits blurb, excerpt](https://vasterror.bandcamp.com/album/sound-test-i)
 
     'Our Tapestry' art by [[artist:xamag]]
 ---
@@ -57,7 +57,7 @@ Duration: 4:29
 URLs:
 - https://vasterror.bandcamp.com/track/calm-before-the-storm
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/calm-before-the-storm))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/calm-before-the-storm)
 
     Originally the title theme for 'You're Happy Now', a game being made by [[artist:austinado|austinado]] from 2015-2016. Was going to be reutilized as an Arcjec song.
 ---
@@ -68,7 +68,7 @@ Duration: 1:21
 URLs:
 - https://vasterror.bandcamp.com/track/dismass-theme-beta
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/dismass-theme-beta))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/dismass-theme-beta)
 
     Originally made for [[album:catch-322]], scrapped because it was discovered that there were no plans for a Dismas-centric walkaround in the future at the time the song was made. May eventually be repurposed into a standalone track.
 ---
@@ -79,7 +79,7 @@ Duration: 8:08
 URLs:
 - https://vasterror.bandcamp.com/track/godroot-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/godroot-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/godroot-demo)
 
     Demo meant to be attributed to Wormwood, Denizen of Blood. Was planned to be attached to a now scrapped denizen album, most tracks of which ended up on [[album:vast-error-vol-4|Vol. 4]].
 ---
@@ -94,7 +94,7 @@ Referenced Tracks:
 Sampled Tracks:
 - Blood Right
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/bloodrightcore))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/bloodrightcore)
 
     Literally just [[track:blood-right]] from [[album:vast-error-vol-3|Vol. 3]], but it's nightcore now. We are so very sorry, [[artist:psithurist]].
 ---
@@ -119,7 +119,7 @@ Duration: 2:01
 URLs:
 - https://vasterror.bandcamp.com/track/reverent
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/reverent))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/reverent)
 
     Song originally meant for [[album:vast-error-vol-3|Vol. 3]], but was scrapped due to a lack of satisfaction with the sound. Probably would have been related to Calder or Occeus.
 ---
@@ -135,7 +135,7 @@ URLs:
 Referenced Tracks:
 - Solana
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/tomatoes))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/tomatoes)
 
     Yet another [[track:solana]] arrangement meant for [[album:vast-error-vol-4|Vol. 4]] but scrapped for time and a lack of polish. It was originally titled 'Belladonna' but since we already have [[Belladonna (Radio Mix)|another song on here titled that]], we gave it a sillier name to distinguish itself.
 ---
@@ -212,7 +212,7 @@ Duration: 1:10
 URLs:
 - https://vasterror.bandcamp.com/track/yo-dogg-whos-bumpin-that-hotline-miami-noise-at-5am-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/yo-dogg-whos-bumpin-that-hotline-miami-noise-at-5am-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/yo-dogg-whos-bumpin-that-hotline-miami-noise-at-5am-uf)
 
     Scrapped track intended for [[album:vast-error-vol-4|Vol. 4]], tossed aside in favor of [[track:secure-vast-error]].
 ---
@@ -239,11 +239,11 @@ Sampled Tracks:
 - Feel Good Inc.
 - Sonic Adventure 2 (Dark Story + Final Story)
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf)
 
     Created to be a Murrit track, but was eventually abandoned due to a lack of interest.
 Referencing Sources: |-
-    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf), excerpt)
+    @@ [Bandcamp credits blurb, excerpt](https://vasterror.bandcamp.com/track/ive-come-to-make-an-announcement-uf)
 
     [[artist:gorillaz]]- [[track:feel-good-inc|Feel Good Inc]]<br>
     [[track:sonic-adventure-2-dark-story-final-story|Dialogue from Sonic Adventure 2- Real-Time Fandub]] by [[artist:snapcube|Snapcube]]
@@ -255,7 +255,7 @@ Duration: 1:48
 URLs:
 - https://vasterror.bandcamp.com/track/here-we-go-beta
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/here-we-go-beta))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/here-we-go-beta)
 
     Work in progress for a track that is meant to go on [[album:reminders-of-you-beta|an eventual votl solo album]], potentially focused on the relationships of the main cast.
 ---
@@ -269,7 +269,7 @@ URLs:
 Referenced Tracks:
 - Albion's Theme
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/albions-theme-ucklin-cut))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/albions-theme-ucklin-cut)
 
     Edited version of [[Albion's Theme]] with extra flourishes added by [[artist:ucklin]]. This was going to be the final version of the song, but it wasn't finished in time for the release, so the original cut was chosen.
 ---
@@ -295,7 +295,7 @@ Referenced Tracks:
 - Meet the Flintstones
 - Fly
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/serpazs-happy-accordion-funtimes))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/serpazs-happy-accordion-funtimes)
 
     All of the little accordion ditties from [[flash:serpaz-play-your-soul-out-on-the-accursed-accordion|'[S\] Serpaz: Play your soul out on the accursed accordion']]. Plus a few that didn't make it in. Ordered by original conception, not including the section specifically taken from [[artist:weird-al-yankovic|Weird Al's]] Polka song or John Mulaney's 'No'.
 ---
@@ -310,11 +310,11 @@ Sampled Tracks:
 - Bohemian Polka
 - Ready Let's Go
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/alpocalypse-loud))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/alpocalypse-loud)
 
     Audio used in the hidden "WEIRDAL" screen of [[flash:serpaz-play-your-soul-out-on-the-accursed-accordion|'[S\] Serpaz: Play your soul out on the accursed accordion.']]
 Referencing Sources: |-
-    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/alpocalypse-loud), excerpt)
+    @@ [Bandcamp credits blurb, excerpt](https://vasterror.bandcamp.com/track/alpocalypse-loud)
 
     Contains samples from:
 
@@ -330,7 +330,7 @@ URLs:
 Referenced Tracks:
 - Curtain Call
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/kazoo-call))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/kazoo-call)
 
     Joke track recorded as a prank for the VEMT.
 ---
@@ -344,7 +344,7 @@ URLs:
 Referenced Tracks:
 - track:immortal-vast-error
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/immortal-country-rock-mix))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/immortal-country-rock-mix)
 
     Edited version of [[track:immortal-vast-error]], stripping down and adding some intruments to make it sound like a completely different song. [[artist:circlejourney|CJ]] does not remember why this was done at all.
 ---
@@ -355,7 +355,7 @@ Duration: 0:45
 URLs:
 - https://vasterror.bandcamp.com/track/at-deaths-door-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/at-deaths-door-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/at-deaths-door-demo)
 
     Riff concepted for Sorush, Denizen of Doom on the scrapped denizens album. It would later be revamped and utilized for [[track:be-all-end-all|'Be All End All']] on [[album:vast-error-vol-4|Vol. 4]].
 ---
@@ -367,7 +367,7 @@ Duration: 1:32
 URLs:
 - https://vasterror.bandcamp.com/track/lovecraft-beta
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/lovecraft-beta))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/lovecraft-beta)
 
     Originally used as a barkeeper shop theme in 'You're Happy Now'. The song is being revised as [[track:lovecraft-vast-error|a Dead Shufflers track]].
 ---
@@ -379,7 +379,7 @@ Duration: 0:48
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme-take-1-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-take-1-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-take-1-uf)
 
     First of five concepts for [[track:ellsees-theme]]. One of which would eventually become Sirage's Theme in Snowbound Blood and another being the final version. This version was lost and then later found much too late.
 ---
@@ -391,7 +391,7 @@ Duration: 1:26
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme-take-2-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-take-2-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-take-2-uf)
 
     Second version of [[track:ellsees-theme]]. Scrapped because of dissatisfaction with the sound, but would influence what the final version became.
 ---
@@ -403,7 +403,7 @@ Duration: 1:37
 URLs:
 - https://vasterror.bandcamp.com/track/ellsees-theme-ft-calder-kerian-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-ft-calder-kerian-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/ellsees-theme-ft-calder-kerian-uf)
 
     Fourth version of [[track:ellsees-theme]], with the idea being that Calder sort of hijacks the track much as he tries to hijack Ellsee's role in the comic. Rejected as it didn't really seem to fit Ellsee specifically as a character.
 ---
@@ -428,7 +428,7 @@ Duration: 3:00
 URLs:
 - https://vasterror.bandcamp.com/track/hope-onwards
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/hope-onwards))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/hope-onwards)
 
     Albion song originally made for [[album:vast-error-vol-5-side-1|Vol.]] [[album:vast-error-vol-5-side-2|5]] but the song file was corrupted. Basically finished outside of some mixing issues.
 ---
@@ -439,7 +439,7 @@ Duration: 3:37
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-static-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-static-demo)
 
     The original full live recording of [[track:the-static]], sans the record player effects by [[artist:sympolite]].
 ---
@@ -450,7 +450,7 @@ Duration: 2:04
 URLs:
 - https://vasterror.bandcamp.com/track/day-after-day-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/day-after-day-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/day-after-day-demo)
 
     Original concept for [[track:day-after-day]] from [[album:repiton]], revised for the final album.
 ---
@@ -501,7 +501,7 @@ Duration: 1:05
 URLs:
 - https://vasterror.bandcamp.com/track/hesitating-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/hesitating-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/hesitating-uf)
 
     A theme made for Jentha, meant to go on [[album:catch-322]]. Scrapped because it didn't fit the tone of the album.
 ---
@@ -512,7 +512,7 @@ Duration: 1:43
 URLs:
 - https://vasterror.bandcamp.com/track/talking-hands
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/talking-hands))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/talking-hands)
 
     Battle theme originally made for 'You're Happy Now', was going to be reutilized as a White Noise song.
 ---
@@ -523,7 +523,7 @@ Duration: 2:52
 URLs:
 - https://vasterror.bandcamp.com/track/disk-of-violet
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/disk-of-violet))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/disk-of-violet)
 
     A song based on the Star Childrens purple emotional response (compassion). Originally made for a scrapped Star Children album that never came to be due to a lack of interest and information.
 ---
@@ -535,7 +535,7 @@ Duration: 2:29
 URLs:
 - https://vasterror.bandcamp.com/track/rootin-tootin-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/rootin-tootin-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/rootin-tootin-uf)
 
     Scrapped Dismas track for [[album:vast-error-vol-4|Vol. 4]], abandoned due to a lack of time and the sound not necessarily fitting the character.
 ---
@@ -546,7 +546,7 @@ Duration: 3:18
 URLs:
 - https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-demo)
 
     First version of [[track:anywhere-can-be-paradise]], originally lacking orchestration and made with a piano and chiptune lead in mind.
 ---
@@ -560,7 +560,7 @@ URLs:
 Referenced Tracks:
 - Anywhere Can Be Paradise [Demo]
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-alt-take-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/anywhere-can-be-paradise-alt-take-uf)
 
     A sort of reprise version of the original [[track:anywhere-can-be-paradise-demo|Anywhere Can Be Paradise]], scrapped in favor of [[track:anywhere-can-be-paradise|the final track]].
 ---    
@@ -572,7 +572,7 @@ Duration: 0:41
 URLs:
 - https://vasterror.bandcamp.com/track/sympath-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/sympath-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/sympath-uf)
 
     The first track ever submitted by [[artist:cerulean]] to the VEMT, sent more as a test than anything made to be finished. A test of their sound, if you will.
 ---
@@ -583,7 +583,7 @@ Duration: 2:04
 URLs:
 - https://vasterror.bandcamp.com/track/land-of-wave-and-record-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/land-of-wave-and-record-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/land-of-wave-and-record-demo)
 
     Concept made for a scrapped land centric album.
 ---
@@ -596,7 +596,7 @@ URLs:
 Referenced Tracks:
 - Curtain Call
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/negative-feedback-beta))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/negative-feedback-beta)
     
     Originally made for [[album:catch-322]] but is currently being wholly revised for [[track:negative-feedback|an eventual release]], potentially on [[album:vast-error-vol-5-side-1|Vol. 5]].
 ---
@@ -608,7 +608,7 @@ Duration: 1:01
 URLs:
 - https://vasterror.bandcamp.com/track/procel-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/procel-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/procel-uf)
 
     Unfinished track for Procel, Denizen of Void. Originally made for the scrapped denizen album.
 ---
@@ -619,7 +619,7 @@ Duration: 0:37
 URLs:
 - https://vasterror.bandcamp.com/track/alter-schmerz
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/alter-schmerz))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/alter-schmerz)
 
     Song that plays after you die in 'You're Happy Now', was going to be utilized in a later walkaround but the initial concept that would have used it was scrapped.
 ---
@@ -660,7 +660,7 @@ Duration: 3:00
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/bittersweet-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/bittersweet-demo)
 
     First recording of [[track:bittersweet-vast-error]] from [[album:vast-error-vol-4|Vol. 4]].
 ---
@@ -672,7 +672,7 @@ Duration: 2:43
 URLs:
 - https://vasterror.bandcamp.com/track/sweeps-past-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/sweeps-past-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/sweeps-past-uf)
 
     Originally a concept for the credits of 'You're Happy Now', then meant to be a track relating to the past of the main cast.
 ---
@@ -684,7 +684,7 @@ Duration: 1:59
 URLs:
 - https://vasterror.bandcamp.com/track/solstice-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/solstice-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/solstice-uf)
 
     Scrapped track from [[album:vast-error-vol-4|Vol. 4]], unfinished due to time constraints.
 ---
@@ -695,7 +695,7 @@ Duration: 1:14
 URLs:
 - https://vasterror.bandcamp.com/track/the-midnight-meat-train
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-midnight-meat-train))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/the-midnight-meat-train)
 
     Butcher shopkeeper theme from 'You're Happy Now', was going to be reused in a walkaround but was scrapped.
 ---
@@ -708,7 +708,7 @@ Duration: 2:02
 URLs:
 - https://vasterror.bandcamp.com/track/undone-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/undone-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/undone-uf)
 
     Scrapped collab between [[artist:rnd]] and [[artist:alex-votl|votl]] meant for [[album:vast-error-vol-4|Vol. 4]], abandoned due to time constraints.
 ---
@@ -720,7 +720,7 @@ Duration: 1:46
 URLs:
 - https://vasterror.bandcamp.com/track/star-crossed-uf
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/star-crossed-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/star-crossed-uf)
 
     VHS rental store shopkeeper track from 'You're Happy Now', was originally going to be repurposed as an Albion track but was scrapped.
 ---
@@ -731,7 +731,7 @@ Duration: 2:50
 URLs:
 - https://vasterror.bandcamp.com/track/sickly-green-glow-demo
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/sickly-green-glow-demo))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/sickly-green-glow-demo)
 
     Original concept for [[track:sickly-green-glow]] from [[album:vast-error-vol-3|Vol. 3]].
 ---
@@ -789,11 +789,11 @@ Lyrics: |-
     Mamma mia, let me go
     Beelzebub has a devil put aside for me, for me, for me
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf)
 
     An unfinished cover of [[artist:queen|Queen's]] [[track:bohemian-rhapsody|"Bohemian Rhapsody,"]] featuring [[artist:michael-guy-bowman]].
 Crediting Sources: |-
-    <i>Vast Error:</i> ([Bandcamp credits blurb](https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf))
+    @@ [Bandcamp credits blurb](https://vasterror.bandcamp.com/track/bohemian-rhapsody-ve-mix-uf)
 
     Credits:
 
@@ -814,6 +814,6 @@ Referenced Tracks:
 - Uneven Compromise
 - Beyond the Wall (Intermission)
 Commentary: |-
-    <i>Vast Error:</i> ([Bandcamp about blurb](https://vasterror.bandcamp.com/track/glimpses-of-perfection-loud))
+    @@ [Bandcamp about blurb](https://vasterror.bandcamp.com/track/glimpses-of-perfection-loud)
 
     Audio used in [[flash:what-did-you-do-to-them|[S\] WHAT DID YOU DO TO THEM.]] Loops infinitely in the animation; this version consists of two loops and a fade-out.

--- a/album/vast-error-vol-1.yaml
+++ b/album/vast-error-vol-1.yaml
@@ -50,7 +50,7 @@ Cover Artists:
 Duration: 01:12
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-2
-Previous Productions:
+Referenced Tracks:
 - The Static [Demo]
 Commentary: |-
     @@ [Bandcamp about blurb](https://web.archive.org/web/20210318180555/https://vasterror.bandcamp.com/track/the-static)

--- a/album/vast-error-vol-1.yaml
+++ b/album/vast-error-vol-1.yaml
@@ -50,6 +50,8 @@ Cover Artists:
 Duration: 01:12
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-2
+Previous Productions:
+- The Static [Demo]
 Commentary: |-
     @@ [Bandcamp about blurb](https://web.archive.org/web/20210318180555/https://vasterror.bandcamp.com/track/the-static)
 

--- a/album/vast-error-vol-3.yaml
+++ b/album/vast-error-vol-3.yaml
@@ -230,7 +230,7 @@ Artists:
 - Rnd
 Cover Artists:
 - Ephemerald
-Previous Productions:
+Referenced Tracks:
 - Sickly Green Glow [Demo]
 Duration: 02:42
 URLs:

--- a/album/vast-error-vol-3.yaml
+++ b/album/vast-error-vol-3.yaml
@@ -230,6 +230,8 @@ Artists:
 - Rnd
 Cover Artists:
 - Ephemerald
+Previous Productions:
+- Sickly Green Glow [Demo]
 Duration: 02:42
 URLs:
 - https://vasterror.bandcamp.com/track/sickly-green-glow-2

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -308,6 +308,8 @@ Track Artwork:
 URLs:
 - https://vasterror.bandcamp.com/track/be-all-end-all
 - https://www.youtube.com/watch?v=E0yg37MiCvs
+Referenced Tracks:
+- At Death's Door [Demo]
 ---
 Track: Solidarity
 Directory: solidarity-vast-error
@@ -474,6 +476,8 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet
 - https://www.youtube.com/watch?v=wPW65crQce0
+Previous Productions:
+- Bittersweet [Demo]
 ---
 Section: Bonus tracks
 ---

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -476,7 +476,7 @@ Cover Artists:
 URLs:
 - https://vasterror.bandcamp.com/track/bittersweet
 - https://www.youtube.com/watch?v=wPW65crQce0
-Previous Productions:
+Referenced Tracks:
 - Bittersweet [Demo]
 ---
 Section: Bonus tracks

--- a/album/vast-error-vol-5-side-1.yaml
+++ b/album/vast-error-vol-5-side-1.yaml
@@ -549,9 +549,8 @@ Artists:
 Cover Artists:
 - riversrequiem
 Cover Art Dimensions: 4464x4314
-Previous Productions:
-- Negative Feedback [Beta]
 Referenced Tracks:
+- Negative Feedback [Beta]
 - THE BEAST II
 - Lost Cause
 - Clint Eastwood

--- a/album/vast-error-vol-5-side-1.yaml
+++ b/album/vast-error-vol-5-side-1.yaml
@@ -549,6 +549,8 @@ Artists:
 Cover Artists:
 - riversrequiem
 Cover Art Dimensions: 4464x4314
+Previous Productions:
+- Negative Feedback [Beta]
 Referenced Tracks:
 - THE BEAST II
 - Lost Cause

--- a/artists.yaml
+++ b/artists.yaml
@@ -14385,6 +14385,9 @@ Artist: Studio June
 Artist: STYLE FIVE
 ---
 Artist: suburrito
+Aliases:
+- Suburito #only appears as such on Bandcamp credits page for Sound Test I
+- Sburito #appears as such on credits for Bittersweet [Demo], as well as on the Sound Test I page of the DCRC wiki
 ---
 Artist: subversiveasset
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -13102,6 +13102,11 @@ URLs:
 - https://sburbmon.tumblr.com
 - https://omegaupdate.freeforums.net/thread/152/sburbmon-v3-current-patch-3
 ---
+Artist: Sburito
+Aliases:
+- Suburito #only appears as such on Bandcamp credits page for Sound Test I
+- suburrito #on Sweet Bro & Hella Jeff The Album
+---
 Artist: scarasleepy
 Aliases:
 - Hiklight
@@ -14383,11 +14388,6 @@ Aliases:
 Artist: Studio June
 ---
 Artist: STYLE FIVE
----
-Artist: suburrito
-Aliases:
-- Suburito #only appears as such on Bandcamp credits page for Sound Test I
-- Sburito #appears as such on credits for Bittersweet [Demo], as well as on the Sound Test I page of the DCRC wiki
 ---
 Artist: subversiveasset
 URLs:

--- a/artists.yaml
+++ b/artists.yaml
@@ -320,6 +320,8 @@ Artist: Al Neun
 URLs:
 - https://mous-bones.tumblr.com/
 ---
+Artist: Aladdin
+---
 Artist: Alan Bergman
 ---
 Artist: Alan Hawkshaw
@@ -5278,6 +5280,8 @@ Artist: Francis Scott Key
 Artist: Frank Loesser
 ---
 Artist: Frank Sinatra
+---
+Artist: Frankie Yankovic
 ---
 Artist: frantastically
 URLs:
@@ -12625,6 +12629,8 @@ Artist: Rob Tunstall
 Artist: Robbie Nevil
 ---
 Artist: Robin S
+---
+Artist: Robin Williams
 ---
 Artist: Roblox
 ---

--- a/groups.yaml
+++ b/groups.yaml
@@ -1062,6 +1062,9 @@ Series:
   - Faux Dramatica
   - Fighting Further
   - Duodenary
+- Name: Sound tests
+  Albums:
+  - Sound Test I
 Description: |-
     Studio consisting of many creators from the Homestuck fan community and beyond, responsible for [Vast Error](https://www.deconreconstruction.com/vasterror/1), [its spinoffs](https://deconreconstruction.itch.io/snowbound-blood), and other projects.
     <hr class="split">

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -533,6 +533,7 @@ Content: |-
     - fixed [[track:murrits-theme]] not referencing [[track:murrits-theme-demo]] and [[track:the-show-must-go-on-vast-error]] (thanks, Lilith!)
     - fixed [[track:pursuit-of-happiness]] not referencing [[track:cultista-de-le-sala-radio-mix]] (thanks, Lilith!)
     - fixed [[track:anywhere-can-be-paradise]] not referencing [[track:anywhere-can-be-paradise-demo]] (thanks, Lilith!)
+    - fixed [[track:serpazs-happy-accordion-funtimes]] not referencing [[track:nailed-it]], [[track:beat-it]], [[track:germs-weird-al-yankovic]], [[track:bohemian-polka]], [[track:tic-tock-polka]], [[track:friend-like-me]], or [[track:laytons-theme]] (thanks, Lilith!)
     - fixed [[track:vrissys-theme]] not referencing [[track:vriskas-theme]] (thanks, Lan!)
     - fixed [[track:lucky-sevens]] not referencing [[track:overlook-vast-error]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:dismantled-vast-error]] not referencing [[track:mantle-piece]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -172,6 +172,8 @@ Content: |-
         - added [[album:inspired-by-the-void]]!
         - added [[album:back-burner]]!
         - added [[album:land-of-logic-and-skyscrapers]]!
+    - added releases from [[group:deconrecon]]! (thanks, Lilith!)
+        - added [[album:sound-test-i]] from [[group:deconrecon]]!
     - added releases from [[group:sbargv2]]! (thanks, <<wertercatt:album data, presentation, research>>, <<lavenderSiren:additional research>>, <<Lan:data review>>, <<Whisper:additional review>>!)
         - added [[album:sbargv2-volume-1]]!
     - added releases from [[group:the-tapestry]]! (thanks, Jebb, Lan, Monckat!)
@@ -468,6 +470,7 @@ Content: |-
         - moved [[track:mysterious-shrine]], [[track:absolutely-overfamiliar-shrine]], [[track:bonetrousle-trailer-version]], and [[track:before-the-story]] to [[album:undertale-collectors-edition-soundtrack]]
         - moved [[track:dating-start-fm-version]], [[track:bereavement]], and [[track:dog-dating]] to [[album:undertale-soundtrack-cd]]
         - moved [[track:mad-mew-mew]] to single release
+    - moved [[track:serpazs-happy-accordion-funtimes]], [[track:alpocalypse]], and [[track:glimpses-of-perfection]] from [[album:more-homestuck-fandom]] to [[album:sound-test-i]] (thanks, Lilith!)
     - moved [[track:the-respect-you-rightfully-deserve-single]] from [[album:more-homestuck-fandom]] to [[album:the-respect-you-rightfully-deserve|single release]] (thanks, Lilith!)
     - moved [[track:cascade-directors-cut]] from [[album:more-homestuck-fandom]] to [[album:cascade|single release]] (thanks, ruby, Lan!)
     - moved [[track:scientific-method]] from [[album:references-beyond-homestuck]] to [[album:omegalodon]] (thanks, Jebb, Lan!)
@@ -513,23 +516,36 @@ Content: |-
     - fixed [[track:harmonize-canmt]] referencing [[track:ruins-with-strings]] instead of [[track:ruins-undertale]] (thanks, Makin, Lilith!)
     - fixed [[track:bowstutzlogic]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)
+    - fixed [[track:the-static]] not referencing [[track:the-static-demo]] (thanks, Lilith!)
     - fixed [[track:secretz-barz]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:the-disciples-new-beginning]] not referencing [[track:serenade-vol8]] and [[track:requited]] (thanks, Lan!)
     - fixed [[track:black-heart-green-dress]] referencing [[track:amen-brother]] and [[track:temporal-shenanigans]], instead of sampling them (thanks, Lan!)
+    - fixed [[track:sickly-green-glow]] not referencing [[track:sickly-green-glow-demo]] (thanks, Lilith!)
+    - fixed [[track:day-after-day]] not referencing [[track:day-after-day-demo]] (thanks, Lilith!)
     - fixed [[track:your-quest-bed]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:good-old-hornless-jerryatric]] not referencing [[track:seinfeld-theme]] (thanks, Lilith!)
     - fixed [[track:farewell-but-not-goodbye]] not referencing [[track:curtain-call]] (thanks, Lilith, Sprink!)
+    - fixed [[track:be-all-end-all]] not referencing [[track:at-deaths-door-demo]] (thanks, Lilith!)
+    - fixed [[track:bittersweet-vast-error]] not referencing [[track:bittersweet-vast-error-demo]] (thanks, Lilith!)
+    - fixed [[track:minute-to-win-it]] not referencing [[track:minute-to-win-it-no-intro]] (thanks, Lilith!)
+    - fixed [[track:arcjecs-theme]] not referencing [[track:arcjecs-theme-scrapped-guitars]] (thanks, Lilith!)
     - fixed [[track:shows-over]] not referencing [[track:curtain-call]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
+    - fixed [[track:murrits-theme]] not referencing [[track:murrits-theme-demo]] and [[track:the-show-must-go-on-vast-error]] (thanks, Lilith!)
+    - fixed [[track:pursuit-of-happiness]] not referencing [[track:cultista-de-le-sala-radio-mix]] (thanks, Lilith!)
+    - fixed [[track:anywhere-can-be-paradise]] not referencing [[track:anywhere-can-be-paradise-demo]] (thanks, Lilith!)
+    - fixed [[track:ellsees-theme]] not referencing [[track:ellsees-theme-take-2-unfinished]] (thanks, Lilith!)
     - fixed [[track:vrissys-theme]] not referencing [[track:vriskas-theme]] (thanks, Lan!)
     - fixed [[track:lucky-sevens]] not referencing [[track:overlook-vast-error]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:dismantled-vast-error]] not referencing [[track:mantle-piece]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
+    - fixed [[track:lovecraft-vast-error]] not referencing [[track:lovecraft-vast-error-beta]] (thanks, Lilith!)
     - fixed [[track:teleports-behind-you]] not referencing [[track:the-fourth-wall-falls]] (thanks, Gryotharian, Lan!)
     - fixed [[track:still-here-beta]] not referencing [[track:im-right-here]] and [[track:arcjecs-theme]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:phantazein]] not referencing [[track:a-new-world]] and [[track:zehanpuryu]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:inertia-empyreal-rhapsody]] not referencing [[track:ferocity-weaving]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:gold-mage-playtime-is-over-mix]] not referencing [[track:gold-mage-playtime-is-over-mix-demo]] (thanks, Lilith, Lan!)
-    - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
     - fixed [[track:bowman-combat-archive]] not sampling [[track:your-bed]] (thanks, Lilith!)
+    - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
+    - fixed [[track:negative-feedback]] not referencing [[track:negative-feedback-beta]] (thanks, Lilith!)
     - fixed [[track:the-worlds-heel]] not referencing [[track:production-line-of-the-holy-clown]] (thanks, Gryotharian, Lilith!)
     - fixed [[track:duodenary]] not referencing [[track:six-by-six]] (thanks, Lilith, Rainy!)
     - fixed [[track:coulrocide]] not referencing [[track:jupiter-jebb]] (thanks, Jebb, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -533,7 +533,7 @@ Content: |-
     - fixed [[track:murrits-theme]] not referencing [[track:murrits-theme-demo]] and [[track:the-show-must-go-on-vast-error]] (thanks, Lilith!)
     - fixed [[track:pursuit-of-happiness]] not referencing [[track:cultista-de-le-sala-radio-mix]] (thanks, Lilith!)
     - fixed [[track:anywhere-can-be-paradise]] not referencing [[track:anywhere-can-be-paradise-demo]] (thanks, Lilith!)
-    - fixed [[track:serpazs-happy-accordion-funtimes]] not referencing [[track:nailed-it]], [[track:beat-it]], [[track:germs-weird-al-yankovic]], [[track:bohemian-polka]], [[track:tic-tock-polka]], [[track:friend-like-me]], and [[track:laytons-theme]] (thanks, Lilith!)
+    - fixed [[track:serpazs-happy-accordion-funtimes]] not referencing [[track:nailed-it]], [[track:beat-it]], [[track:germs-weird-al-yankovic]], [[track:bohemian-polka]], [[track:tic-tock-polka]], [[track:friend-like-me]], and [[track:laytons-theme]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:vrissys-theme]] not referencing [[track:vriskas-theme]] (thanks, Lan!)
     - fixed [[track:lucky-sevens]] not referencing [[track:overlook-vast-error]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:dismantled-vast-error]] not referencing [[track:mantle-piece]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -533,7 +533,7 @@ Content: |-
     - fixed [[track:murrits-theme]] not referencing [[track:murrits-theme-demo]] and [[track:the-show-must-go-on-vast-error]] (thanks, Lilith!)
     - fixed [[track:pursuit-of-happiness]] not referencing [[track:cultista-de-le-sala-radio-mix]] (thanks, Lilith!)
     - fixed [[track:anywhere-can-be-paradise]] not referencing [[track:anywhere-can-be-paradise-demo]] (thanks, Lilith!)
-    - fixed [[track:serpazs-happy-accordion-funtimes]] not referencing [[track:nailed-it]], [[track:beat-it]], [[track:germs-weird-al-yankovic]], [[track:bohemian-polka]], [[track:tic-tock-polka]], [[track:friend-like-me]], or [[track:laytons-theme]] (thanks, Lilith!)
+    - fixed [[track:serpazs-happy-accordion-funtimes]] not referencing [[track:nailed-it]], [[track:beat-it]], [[track:germs-weird-al-yankovic]], [[track:bohemian-polka]], [[track:tic-tock-polka]], [[track:friend-like-me]], and [[track:laytons-theme]] (thanks, Lilith!)
     - fixed [[track:vrissys-theme]] not referencing [[track:vriskas-theme]] (thanks, Lan!)
     - fixed [[track:lucky-sevens]] not referencing [[track:overlook-vast-error]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:dismantled-vast-error]] not referencing [[track:mantle-piece]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -533,7 +533,6 @@ Content: |-
     - fixed [[track:murrits-theme]] not referencing [[track:murrits-theme-demo]] and [[track:the-show-must-go-on-vast-error]] (thanks, Lilith!)
     - fixed [[track:pursuit-of-happiness]] not referencing [[track:cultista-de-le-sala-radio-mix]] (thanks, Lilith!)
     - fixed [[track:anywhere-can-be-paradise]] not referencing [[track:anywhere-can-be-paradise-demo]] (thanks, Lilith!)
-    - fixed [[track:ellsees-theme]] not referencing [[track:ellsees-theme-take-2-unfinished]] (thanks, Lilith!)
     - fixed [[track:vrissys-theme]] not referencing [[track:vriskas-theme]] (thanks, Lan!)
     - fixed [[track:lucky-sevens]] not referencing [[track:overlook-vast-error]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)
     - fixed [[track:dismantled-vast-error]] not referencing [[track:mantle-piece]] (thanks, <<koba:organized Vast Error Reference Sheet, although this change was anonymous>>, Lilith!)


### PR DESCRIPTION
Adds the last remaining Deconreconstruction album that was not yet on the wiki at this time (meaning that, alongside [#840 Album addition: Snowbound Blood (Original Game Soundtrack) + flashes addition: Snowbound Blood](https://github.com/hsmusic/hsmusic-data/pull/840) and, [#839 Album addition: Ghost Writer by Cerulean, from Deconreconstruction!](https://github.com/hsmusic/hsmusic-data/pull/839), Deconreconstruction albums on the wiki would now be fully caught up with the Bandcamp, at least 'til further albums pop up), Sound Test I!
Also moves [Glimpses Of Perfection [Loud]](https://preview.hsmusic.wiki/track/glimpses-of-perfection/), [Alpocalypse [Loud]](https://preview.hsmusic.wiki/track/alpocalypse/), and [Serpaz's Happy Accordion Funtimes](https://preview.hsmusic.wiki/track/serpazs-happy-accordion-funtimes/) from [More Homestuck Fandom](https://preview.hsmusic.wiki/album/more-homestuck-fandom/) to Sound Test I.

Merge with: [Sound Test I media](https://github.com/hsmusic/hsmusic-media/pull/184)

but also... (way too many of these, I know, but bear with me)
## Catch 322:
- fixed Minute To Win It not referencing Minute To Win It (No Intro)
- fixed Arcjec's Theme not referencing Arcjec's Theme (Scrapped Guitars)
- fixed Murrit's Theme not referencing The Show Must Go On (Vast Error)
- fixed Murrit's Theme not referencing Murrit's Theme [Demo]
- fixed Pursuit of Happiness not referencing Cultista De Le Sala (Radio Mix)
- fixed Anywhere Can Be Paradise not referencing Anywhere Can Be Paradise [Demo]
- ~~fixed Ellsee's Theme not referencing Ellsee's Theme (Take 2) [UF]~~
## Dead Shufflers: Anything Goes:
- fixed Lovecraft (Dead Shufflers) not referencing Lovecraft [Beta]
## Repiton:
- fixed Day After Day not referencing Day After Day [Demo]
## Vast Error Vol. 4:
- fixed Be All End All not referencing At Death's Door [Demo]
- fixed Bittersweet (Vast Error) not referencing Bittersweet [Demo]
## Vast Error Vol. 1:
- fixed The Static not referencing The Static [Demo]
## Vast Error Vol. 3:
- fixed Sickly Green Glow not referencing Sickly Green Glow [Demo]
## Vast Error Vol. 5: Side 1:
- fixed Negative Feedback not referencing Negative Feedback [Beta]
## Sound Test I (migrated from More Homestuck Fandom):
- fixed Serpaz's Happy Accordion Funtimes not referencing Nailed It, Beat It, Germs ("Weird Al" Yankovic), Bohemian Polka, Tic-Tock Polka, Friend Like Me, and Layton's Theme