### PR TITLE
Album addition: The Scratch Before the Calm by Laurent Désautels-Séguin!

### DIFF
--- a/album/the-scratch-before-the-calm.yaml
+++ b/album/the-scratch-before-the-calm.yaml
@@ -1,0 +1,52 @@
+Album: The Scratch Before the Calm
+Suffix Track Directories: true
+Always Reference Tracks By Directory: true
+Date: April 16, 2016
+Color: '#d45ea7'
+URLs:
+- https://laurentds.bandcamp.com/album/the-scratch-before-the-calm
+Artists:
+- Laurent Désautels-Séguin
+Cover Artists:
+- Data Erase
+Cover Art File Extension: png
+Groups:
+- Fandom
+Commentary: |-
+    <i>Laurent Désautels-Séguin:</i> ([Bandcamp about blurb](https://laurentds.bandcamp.com/album/the-scratch-before-the-calm))
+
+    A collection of tracks that I did for the 2016 Homestuck fandom album [[album:beforus]]. These 4 tracks were really important in forging my musical style that is somewhere between Digital Fusion, Synthwave and Ambient. To this day, I still come back to some sounds that I did in these 4 tracks because they were too good.
+Crediting Sources: |-
+    <i>Laurent Désautels-Séguin:</i> ([Bandcamp credits blurb](https://laurentds.bandcamp.com/album/the-scratch-before-the-calm), excerpt)
+
+    Album art by [[artist:data-erase|@dataerase]]
+---
+Section: Main album
+---
+Track: Anacronus
+Main Release: Anacronus
+Duration: 3:01
+URLs:
+- https://laurentds.bandcamp.com/track/anacronus
+---
+Track: The Scratch Before the Calm
+Main Release: track:the-scratch-before-the-calm
+Duration: 5:33
+URLs:
+- https://laurentds.bandcamp.com/track/the-scratch-before-the-calm
+---
+Track: Dream Around
+Duration: 4:18
+URLs:
+- https://laurentds.bandcamp.com/track/dream-around
+Referenced Tracks:
+- track:dream-around
+- track:speak-no-evil-hear-no-evil
+---
+Track: Land of Rad Tricks and Gnarly Odorless Things (LORTAGOT)
+Suffix Directory: false
+Always Reference By Directory: false
+Main Release: Land of Rad Tricks and Gnarly Odorless Things
+Duration: 3:24
+URLs:
+- https://laurentds.bandcamp.com/track/land-of-rad-tricks-and-gnarly-odorless-things-lortagot

--- a/album/the-scratch-before-the-calm.yaml
+++ b/album/the-scratch-before-the-calm.yaml
@@ -36,6 +36,7 @@ URLs:
 - https://laurentds.bandcamp.com/track/the-scratch-before-the-calm
 ---
 Track: Dream Around
+Count In Artist Totals: false
 Duration: 4:18
 URLs:
 - https://laurentds.bandcamp.com/track/dream-around

--- a/album/the-scratch-before-the-calm.yaml
+++ b/album/the-scratch-before-the-calm.yaml
@@ -17,7 +17,7 @@ Commentary: |-
 
     A collection of tracks that I did for the 2016 Homestuck fandom album [[album:beforus]]. These 4 tracks were really important in forging my musical style that is somewhere between Digital Fusion, Synthwave and Ambient. To this day, I still come back to some sounds that I did in these 4 tracks because they were too good.
 Crediting Sources: |-
-    <i>Laurent Désautels-Séguin:</i> ([Bandcamp credits blurb](https://laurentds.bandcamp.com/album/the-scratch-before-the-calm), excerpt)
+    <i>Laurent Désautels-Séguin:</i> ([Bandcamp credits blurb](https://laurentds.bandcamp.com/album/the-scratch-before-the-calm))
 
     Album art by [[artist:data-erase|@dataerase]]
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -3699,8 +3699,8 @@ Dead URLs:
 Artist: Data Erase
 URLs:
 - https://bsky.app/profile/dataerase.bsky.social
-- https://dataerase.tumblr.com
-- https://dataerase.neocities.org
+- https://dataerase.tumblr.com/
+- https://dataerase.neocities.org/
 ---
 Artist: DAV
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -3696,6 +3696,12 @@ URLs:
 Dead URLs:
 - https://www.youtube.com/channel/UCsG6CV1AZdtSyLxoAl-60Yg
 ---
+Artist: Data Erase
+URLs:
+- https://bsky.app/profile/dataerase.bsky.social
+- https://dataerase.tumblr.com
+- https://dataerase.neocities.org
+---
 Artist: DAV
 Aliases:
 - Dave Steen
@@ -8625,6 +8631,11 @@ URLs:
 Artist: Laurent Désautels-Séguin
 URLs:
 - https://laurentds.bandcamp.com/
+- https://musicfor18magicians.bandcamp.com/
+- https://www.youtube.com/@laurent_ds
+- https://twitter.com/LaurentD_S
+Dead URLs:
+- https://cohost.org/LaurentDS
 ---
 Artist: lavenderSiren
 Aliases:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -119,6 +119,7 @@ Content: |-
     - added [[album:some-artifacts-may-occur]] by [[artist:shinokabe]] (thanks, Lilith, Lan!)
     - added [[album:vaporstuck]] by [[artist:the-hypergiants-asmr]] (thanks, Lilith!)
     - added [[album:hivebreak-vol-1]] by [[artist:eighteen-elbows]] (thanks, <<Jebb:album data, presentation, research>>, <<Lan:data review>>, <<ruby:References Beyond Homestuck review>>, plus <<Not Eno:crediting help>>!)
+    - added [[album:the-scratch-before-the-calm]] by [[artist:laurent-desautels-seguin]]! (thanks, Lilith!)
     - added [[album:vol-10-progress-report]]! (thanks, <<Whisper:album research>>, <<Lan:album data, presentation, research>>, plus <<koba:research help>>, <<Niklink:research help>>, <<Red Rax:research help>>, <<Lilith:research help>>!)
     - added [[album:janestuck-volume-100]] and [[album:janestuck-volume-2]]! (thanks, Lilith, Jackie!)
     - added [[album:tale-of-arpege-clavier-chapter-1-of-92000000]] by [[artist:decon-theed]] and [[artist:repeatedscales]] (thanks, Lilith, Lan!)


### PR DESCRIPTION
Adds the 4-track EP consisting of Beforus rereleases (well, one of them (Dream Around) is two of the artist's Beforus tracks (Dream Around + Speak No Evil. Hear No Evil.) put together) from Laurent Désautels-Séguin!

Merge with: https://github.com/hsmusic/hsmusic-media/pull/185