### PR TITLE
Crediting fixes for The Static (Vast Error Vol. 1)

### DIFF
--- a/album/vast-error-vol-1.yaml
+++ b/album/vast-error-vol-1.yaml
@@ -50,6 +50,14 @@ Cover Artists:
 Duration: 01:12
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-2
+Commentary: |-
+    <i>Vast Error:</i> ([Bandcamp about blurb](https://web.archive.org/web/20210318180555/https://vasterror.bandcamp.com/track/the-static))
+
+    Part one of 'The Static'
+Crediting Sources: |-
+    <i>Vast Error:</i> ([Bandcamp credits blurb](https://web.archive.org/web/20210318180555/https://vasterror.bandcamp.com/track/the-static))
+
+    Music by [[artist:kal-la-kal-la]], Mastered by [[artist:sympolite]]
 ---
 Track: A Very Active Imagination
 Artists:

--- a/album/vast-error-vol-1.yaml
+++ b/album/vast-error-vol-1.yaml
@@ -43,8 +43,10 @@ URLs:
 Track: The Static
 Artists:
 - Kal-la-kal-la
+Contributors:
+- sympolite (mastering)
 Cover Artists:
-- Radical Dude 42
+- Vast Error
 Duration: 01:12
 URLs:
 - https://vasterror.bandcamp.com/track/the-static-2

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -445,7 +445,7 @@ Content: |-
     - fixed [[track:gunshow-singalong]] crediting [[artist:ostrichlittledungeon]], [[artist:pipko-fanfare]], and [[artist:yazshu]] as (annotated) album credits, instead of as contributors, and not crediting [[artist:tronald-trumpet]] as the lone album artist (thanks, Lan!)
     - fixed [[album:a-shade-of-blue]] not crediting [[artist:jakkyr]] as an album artist alongside [[artist:cerulean]] (thanks, Lan!)
     - fixed [[track:i-love-hussie]] not crediting [[artist:bambosh]] for vocals (thanks, MoreEpicThanYou747, Whisper!)
-    - fixed [[track:the-static]] track artwork crediting [[artist:radical-dude-42]] instead of [[artist:vast-error]], and not crediting [[artist:sympolite]] for mastering (thanks, Lilith!)
+    - fixed [[track:the-static]] ([[album:vast-error-vol-1]]) track artwork crediting [[artist:radical-dude-42]] instead of [[artist:vast-error]], and not crediting [[artist:sympolite]] for mastering (thanks, Lilith!)
     - fixed [[album:cool-and-new-sonic-team]] crediting [[artist:hadron]] as an album artist instead of only as track artist (thanks, Lan!)
     - fixed [[track:wrapped-around-your-fin]] track artwork crediting [[artist:unknown-artist]] instead of [[artist:chasingstarlightz]] (thanks, Lilith!)
     - fixed [[track:dial-tone]] track artwork crediting [[artist:unknown-artist]] instead of [[artist:radical-dude-42]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -221,10 +221,10 @@ Content: |-
     - added missing paragraph to Tumblr commentary for [[track:through-the-seventh-gate-land-of-heat-and-clockwork]] (thanks, Lilith!)
     - added Tumblr commentary to [[track:the-metamorphosis-of-rose-lalonde]] (thanks, Lilith, Lavender!)
     - added artist commentary to [[track:i-love-hussie]] (thanks, MoreEpicThanYou747, Whisper!)
+    - added Bandcamp commentary & crediting source to [[track:the-static]] (thanks, Lilith!)
     - added YouTube commentary to [[track:end-of-act]] (thanks, Lan!)
     - added SoundCloud commentary to [[track:bloodsucker-brawl]] (thanks, Lan!)
     - added Tumblr commentary to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
-    - added Bandcamp about blurb & crediting source to [[track:the-static]] (thanks, Lilith!)
     - added Bandcamp crediting sources to [[track:empress]], [[track:army-of-the-wicked-god]], [[album:grim-chain-of-feast]], [[album:war-marks]], [[album:rites-of-bloodgrinded]], [[track:his-honorable-tyranny]], [[album:genesis-genocide]], [[album:faces-of-oglogoth]], [[track:im-a-member-of-the-midnight-crew-soapstone]], and [[album:jugglanoids-from-outer-space]] (thanks, Tangle!)
     - added Tumblr commentary to [[track:catscratch]] (thanks, Lilith, Lan!)
     <!-- artwork additions -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -224,6 +224,7 @@ Content: |-
     - added YouTube commentary to [[track:end-of-act]] (thanks, Lan!)
     - added SoundCloud commentary to [[track:bloodsucker-brawl]] (thanks, Lan!)
     - added Tumblr commentary to [[album:comfortable-bugs]] (thanks, Lilith, Lan!)
+    - added Bandcamp about blurb & crediting source to [[track:the-static]] (thanks, Lilith!)
     - added Bandcamp crediting sources to [[track:empress]], [[track:army-of-the-wicked-god]], [[album:grim-chain-of-feast]], [[album:war-marks]], [[album:rites-of-bloodgrinded]], [[track:his-honorable-tyranny]], [[album:genesis-genocide]], [[album:faces-of-oglogoth]], [[track:im-a-member-of-the-midnight-crew-soapstone]], and [[album:jugglanoids-from-outer-space]] (thanks, Tangle!)
     - added Tumblr commentary to [[track:catscratch]] (thanks, Lilith, Lan!)
     <!-- artwork additions -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -444,6 +444,7 @@ Content: |-
     - fixed [[track:gunshow-singalong]] crediting [[artist:ostrichlittledungeon]], [[artist:pipko-fanfare]], and [[artist:yazshu]] as (annotated) album credits, instead of as contributors, and not crediting [[artist:tronald-trumpet]] as the lone album artist (thanks, Lan!)
     - fixed [[album:a-shade-of-blue]] not crediting [[artist:jakkyr]] as an album artist alongside [[artist:cerulean]] (thanks, Lan!)
     - fixed [[track:i-love-hussie]] not crediting [[artist:bambosh]] for vocals (thanks, MoreEpicThanYou747, Whisper!)
+    - fixed [[track:the-static]] track artwork crediting [[artist:radical-dude-42]] instead of [[artist:vast-error]], and not crediting [[artist:sympolite]] for mastering (thanks, Lilith!)
     - fixed [[album:cool-and-new-sonic-team]] crediting [[artist:hadron]] as an album artist instead of only as track artist (thanks, Lan!)
     - fixed [[track:wrapped-around-your-fin]] track artwork crediting [[artist:unknown-artist]] instead of [[artist:chasingstarlightz]] (thanks, Lilith!)
     - fixed [[track:dial-tone]] track artwork crediting [[artist:unknown-artist]] instead of [[artist:radical-dude-42]] (thanks, Lilith!)


### PR DESCRIPTION
Fixes The Static (Vast Error Vol. 1) crediting Radical Dude 42 for its track artwork instead of Vast Error, and not crediting sympolite for mastering.

(plus Vol. 1 crediting sources and about blurb for The Static)

``Part one of 'The Static'``

https://vasterror.bandcamp.com/track/the-static-2 (this is Vol. 1-3's, but Vol. 1's is roughly the same)
(Track by Kal-la-kal-la, Mastering by sympolite)
just without (, Art by Radical Dude 42), and Radical Dude 42's dead Tumblr URL