### PR TITLE
Vast Error Vol. 3 album section fix

### DIFF
--- a/album/vast-error-vol-3.yaml
+++ b/album/vast-error-vol-3.yaml
@@ -13,6 +13,8 @@ Groups:
 - Deconreconstruction
 - Fandom
 ---
+Section: Main album
+---
 Track: Sunrise
 Directory: sunrise-vast-error
 Artists:


### PR DESCRIPTION
Fixes Vast Error Vol. 3 not having a main album section (which, alongside having a Bonus track section, but no Main album section, was causing it to display Default Track Section)