### PR TITLE
Reference fix: Sundering of the Self references Know Thyself, and Oceanfalls Opening references Oceanfalls (Ray of Light)

### DIFF
--- a/album/oceanfalls-vol-6.yaml
+++ b/album/oceanfalls-vol-6.yaml
@@ -66,7 +66,7 @@ Commentary:
 
     *Nights:* My fav part in anime openings is when the Glitch
 Referencing Sources: |-
-    <i>Witch's Cadence:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/935007764042874931/1370210185964027945), excerpt, 5/8/2025)
+    <i>Witch's Cadence:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/935007764042874931/1370210185964027945), 5/8/2025)
 
     Oceanfalls Opening on Vol 6 should say it references [[track:oceanfalls|oceanfalls]] from [[album:oceanfables-ray-of-light|ray of light]]
 ---
@@ -110,7 +110,7 @@ Commentary: |-
     *Nights:* thanks for doing that. I loooove lobcorp<br>
     *leiirue:* thank you for noticinf nights
 Referencing Sources: |-
-    <i>Witch's Cadence:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/935007764042874931/1370210475467345980), excerpt, 5/8/2025)
+    <i>Witch's Cadence:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/935007764042874931/1370210475467345980), 5/8/2025)
 
     Sundering of the self references [[track:know-thyself]]
 ---

--- a/album/oceanfalls-vol-6.yaml
+++ b/album/oceanfalls-vol-6.yaml
@@ -65,6 +65,10 @@ Commentary:
     *Pikarai:* kinda fire tho
 
     *Nights:* My fav part in anime openings is when the Glitch
+Referencing Sources: |-
+    <i>Witch's Cadence:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/935007764042874931/1370210185964027945), excerpt, 5/8/2025)
+
+    Oceanfalls Opening on Vol 6 should say it references [[track:oceanfalls|oceanfalls]] from [[album:oceanfables-ray-of-light|ray of light]]
 ---
 Track: Sundering of the Self
 Duration: 3:04
@@ -105,6 +109,10 @@ Commentary: |-
     *leiirue:* YES THEY ARE<br>
     *Nights:* thanks for doing that. I loooove lobcorp<br>
     *leiirue:* thank you for noticinf nights
+Referencing Sources: |-
+    <i>Witch's Cadence:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/935007764042874931/1370210475467345980), excerpt, 5/8/2025)
+
+    Sundering of the self references [[track:know-thyself]]
 ---
 Track: Unholy Grudge
 Duration: 3:34

--- a/album/oceanfalls-vol-6.yaml
+++ b/album/oceanfalls-vol-6.yaml
@@ -45,6 +45,8 @@ Art Tags:
   # WC: "One of the alternate ninos and kotori"
 - Nino (Oceanfalls)
 - Kotori (Oceanfalls)
+Referenced Tracks:
+- Oceanfalls
 Commentary:
     <i>Nights, Pikarai, Witch's Cadence, Finchlet, leiirue:</i> ([YouTube premiere live chat](https://youtu.be/szfsnqqTy28?t=0))
 
@@ -76,6 +78,8 @@ Art Tags:
 - Nino (Oceanfalls)
 - Nina (Oceanfalls)
 - 'cw: blood'
+Referenced Tracks:
+- Know Thyself
 Commentary: |-
     <i>leiirue, Nights, Witch's Cadence, Pikarai, Nevermind3476, Finchlet:</i> ([YouTube premiere live chat](https://youtu.be/szfsnqqTy28?t=63))
 

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -754,6 +754,8 @@ Content: |-
     - fixed [[track:vs-ridley-ssbu]] ([[album:super-smash-bros-ultimate]]) referencing "Opening (Destroyed Laboratory)", aka "Opening (Destroyed Science Academy Research Station)", instead of [[track:theme-of-super-metroid]] (thanks, ruby!)
     - fixed [[track:christmas-time-is-here-lo-fi]] not referencing [[track:christmas-time-is-here-vocal]] (thanks, Lilith, Tangle, Lan!)
     - fixed [[track:dead-maams-chest]] not referencing [[track:im-your-treasure-box-you-have-found-captain-marine-in-a-treasure-chest]] (thanks, ruby!)
+    - fixed [[track:oceanfalls-opening]] not referencing [[track:oceanfalls]] (thanks, Witch's Cadence, Lilith!)
+    - fixed [[track:sundering-of-the-self]] not referencing [[track:know-thyself]] (thanks, Witch's Cadence, Lilith!)
     - fixed [[track:cats-toby-fox]] not referencing [[track:ending-ii-brandish-snes]] (thanks, Erase, Lan, Lilith, ruby!)
     - fixed [[track:do-the-homestuck-demo]] not referencing [[track:sunsetter]], [[track:sburban-jungle]], and [[track:MeGaLoVania]], nor sampling [[track:amen-brother]] (thanks to an emailer, FF, ruby, and Lan!)
     - fixed [[track:ham-and-steak]] not sampling [[track:oppa-toby-style]] in addition to referencing it; and referencing [[track:calliope-malcolm-brown]] and [[track:youre-so-rad]], rather than sampling them (thanks, Lavender!)


### PR DESCRIPTION
Fixes [Sundering of the Self](https://preview.hsmusic.wiki/track/sundering-of-the-self/) not referencing [Know Thyself](https://preview.hsmusic.wiki/track/know-thyself/), and [Oceanfalls Opening](https://preview.hsmusic.wiki/track/oceanfalls-opening/) not referencing [Oceanfalls](https://preview.hsmusic.wiki/track/oceanfalls/) ([Ray of Light](https://preview.hsmusic.wiki/album/oceanfables-ray-of-light/)).
Thanks again, Witch's Cadence!