### PR TITLE
readd Liquid Negrocity to Black's referenced tracks, keep Plasmatic Blaquaciousness in Black's referenced tracks

### DIFF
--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -634,8 +634,10 @@ Duration: 2:24
 URLs:
 - https://homestuck.bandcamp.com/track/black-2
 - https://youtu.be/5NACWZBDtN8
-Referenced Tracks:
+Previous Productions:
 - Plasmatic Blaquaciousness
+Referenced Tracks:
+- Liquid Negrocity
 - track:im-a-member-of-the-midnight-crew
 Sampled Tracks:
 - track:im-a-member-of-the-midnight-crew
@@ -673,3 +675,7 @@ Commentary: |-
     <i>Toby Fox:</i> ([toby fox portfolio page 2011 wip](https://web.archive.org/web/20111107184748/http://tobyfox.net/portfolio) - "Finished Tracks")
 
     The secretary to the evil queen (who is the piano player in a gangster-jazz combo in an alternate universe in a prohibition-era dark city he built on the moon) goes crazy and ascends to power. Other crazy stuff happens. My most popular song even though it's old, but it's still pretty badass so... alright!! The voice sample is from Eddie Morton's [["I'm a Member of the Midnight Crew."]]
+Referencing Sources: |-
+    <i>Andrew Hussie:</i> ([MSPA news post](https://web.archive.org/web/20100521000716/http://mspaintadventures.com/), excerpt)
+
+    [...] But especially pointed thanks right now to [[artist:toby-fox]] for making this cool remix ("Black") of his own song from [[album:midnight-crew-drawing-dead|the MC album]] ([[track:liquid-negrocity|"Liquid Negrocity"]]), [...]

--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -634,10 +634,9 @@ Duration: 2:24
 URLs:
 - https://homestuck.bandcamp.com/track/black-2
 - https://youtu.be/5NACWZBDtN8
-Previous Productions:
-- Plasmatic Blaquaciousness
 Referenced Tracks:
 - Liquid Negrocity
+- Plasmatic Blaquaciousness
 - track:im-a-member-of-the-midnight-crew
 Sampled Tracks:
 - track:im-a-member-of-the-midnight-crew

--- a/album/homestuck-vol-4.yaml
+++ b/album/homestuck-vol-4.yaml
@@ -635,8 +635,8 @@ URLs:
 - https://homestuck.bandcamp.com/track/black-2
 - https://youtu.be/5NACWZBDtN8
 Referenced Tracks:
-- Liquid Negrocity
 - Plasmatic Blaquaciousness
+- Liquid Negrocity
 - track:im-a-member-of-the-midnight-crew
 Sampled Tracks:
 - track:im-a-member-of-the-midnight-crew

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -334,8 +334,7 @@ Content: |-
         - fixed [[track:the-final-battle-super-mario-64]] not referencing [[track:toccata-and-fugue-in-d-minor]]
         - added notes in [[track:scratch]] regarding its reference to [[track:the-final-battle-super-mario-64]]
     - fixed [[track:liquid-negrocity]] not referencing [[track:liquid-negrocity-original]] (thanks, Lilith, Jackie!)
-    - <s>fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie!)</s>
-        - fixed [[track:black]] not referencing [[track:plasmatic-blaquaciousness]] (thanks, Lilith!)
+    - fixed [[track:black]] not referencing [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie, Lan!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)
     - fixed [[track:frog-hunt]] not referencing [[track:homestuck-anthem]] (thanks, Bowman, Celeste, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -161,6 +161,7 @@ Content: |-
     - added series for [[group:michael-guy-bowman]] (thanks, Lilith, plus <<Lan:categorization help>>!)
     <!-- commentary additions -->
     - added Skaianet Radio commentary to [[track:liquid-negrocity]] (thanks, Lilith, Jackie!)
+    - added MSPA news post referencing source to [[track:black]] (thanks, Lilith!)
     - added SoundCloud commentary to [[track:squiddle-march]] (thanks, Lilith, Lan!)
     - added 2011 portfolio commentary to [[track:black]], [[track:sunsetter]], [[track:theme]], [[track:a-tender-moment]], [[track:karkats-theme]], [[track:darling-kanaya]], [[track:eridans-theme]], [[track:killed-by-br8k-spider]], [[track:catapult-capuchin]], [[track:earthsea-borealis]], [[track:mayor-maynot]], [[track:judgment-day]], [[track:do-the-homestuck-demo]], and [[track:lets-read-a-webcomic]] (thanks to an emailer and Lan!)
     - added DeviantArt commentary to [[track:emerald-terror]] (thanks, Makin, Lan!)
@@ -333,7 +334,8 @@ Content: |-
         - fixed [[track:the-final-battle-super-mario-64]] not referencing [[track:toccata-and-fugue-in-d-minor]]
         - added notes in [[track:scratch]] regarding its reference to [[track:the-final-battle-super-mario-64]]
     - fixed [[track:liquid-negrocity]] not referencing [[track:liquid-negrocity-original]] (thanks, Lilith, Jackie!)
-    - fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie!)
+    - <s>fixed [[track:black]] referencing [[track:liquid-negrocity]] instead of [[track:plasmatic-blaquaciousness]] (thanks, Lilith, Jackie!)</s>
+        - fixed [[track:black]] not referencing [[track:plasmatic-blaquaciousness]] (thanks, Lilith!)
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Lilith!)
     - fixed [[track:frog-hunt]] not referencing [[track:homestuck-anthem]] (thanks, Bowman, Celeste, Lilith!)


### PR DESCRIPTION
Readds Liquid Negrocity to Black's referenced tracks, and adds MSPA news post referencing source excerpt for Black.

strikethroughs previous "fixed black referencing liquid negrocity instead of plasmatic blaquaciousness" changelog entry, and adds a new one in lieu of it: "fixed black not referencing plasmatic blaquaciousness"
as well as a changelog entry for adding the MSPA news post referencing source for black
