### PR TITLE
Referencing fixes for In Medias Res (Twice as Bright, Flyfish, IN IT TO WIN IT, Spiritstriker)

### DIFF
--- a/album/in-medias-res.yaml
+++ b/album/in-medias-res.yaml
@@ -79,6 +79,16 @@ Cover Artists:
 - Divo
 URLs:
 - https://vasterror.bandcamp.com/track/twice-as-bright
+Referenced Tracks:
+- track:torchlight-vast-error
+Referencing Sources: |-
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), excerpt, 12/4/2025)
+
+    No problem. In order it's this:
+
+    Twice as Bright references [[track:torchlight-vast-error]] by Me
+
+    [...]
 ---
 Track: DYNAMISM
 Suffix Directory: true
@@ -160,6 +170,12 @@ Art Tags:
 - 'cw: blood'
 URLs:
 - https://vasterror.bandcamp.com/track/flyfish
+Referenced Tracks:
+- Murrit's Theme
+Referencing Sources: |-
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446182715954302996), 12/4/2025)
+
+    Flyfish references [[track:murrits-theme|murrits theme]] by [[artist:splitsuns]]
 ---
 Track: IN IT TO WIN IT
 Duration: 4:09
@@ -169,6 +185,14 @@ Cover Artists:
 - captkirkland
 URLs:
 - https://vasterror.bandcamp.com/track/in-it-to-win-it
+Referenced Tracks:
+- Minute To Win It
+Referencing Sources: |-
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), excerpt, 12/4/2025)
+
+    [...]
+
+    In it to win it references [[Minute To Win It|Minute to Win it]] By [[artist:splitsuns]]
 ---
 Track: The Respect You Rightfully Deserve
 Duration: 7:17
@@ -192,6 +216,14 @@ Cover Artists:
 - verprost
 URLs:
 - https://vasterror.bandcamp.com/track/spiritstriker
+Referenced Tracks:
+- Hope For A More Radiant Dawn
+Referencing Sources: |-
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), excerpt, 12/4/2025)
+
+    [...]
+
+    Spiritstriker references [[track:hope-for-a-more-radiant-dawn|A Hope for a More Radiant Dawn]] by me
 ---
 Track: The Stars Speak Back
 Duration: 3:20

--- a/album/in-medias-res.yaml
+++ b/album/in-medias-res.yaml
@@ -82,13 +82,9 @@ URLs:
 Referenced Tracks:
 - track:torchlight-vast-error
 Referencing Sources: |-
-    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), excerpt, 12/4/2025)
-
-    No problem. In order it's this:
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), 12/4/2025)
 
     Twice as Bright references [[track:torchlight-vast-error]] by Me
-
-    [...]
 ---
 Track: DYNAMISM
 Suffix Directory: true
@@ -188,9 +184,7 @@ URLs:
 Referenced Tracks:
 - Minute To Win It
 Referencing Sources: |-
-    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), excerpt, 12/4/2025)
-
-    [...]
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), 12/4/2025)
 
     In it to win it references [[Minute To Win It|Minute to Win it]] By [[artist:splitsuns]]
 ---
@@ -219,9 +213,7 @@ URLs:
 Referenced Tracks:
 - Hope For A More Radiant Dawn
 Referencing Sources: |-
-    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), excerpt, 12/4/2025)
-
-    [...]
+    <i>Rainy:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1446179319855710311), 12/4/2025)
 
     Spiritstriker references [[track:hope-for-a-more-radiant-dawn|A Hope for a More Radiant Dawn]] by me
 ---

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -369,7 +369,7 @@ Content: |-
     - added various referencing sources to [[track:dissension-remix]], [[track:white]], [[track:octoroon-rangoon]], [[track:clockwork-sorrow]], [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] (thanks, Lan!)
     - added Discord referencing sources to [[track:good-old-hornless-jerryatric]] and [[track:the-worlds-heel]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:teleports-behind-you]] (thanks, Lan!)
-    - added referencing sources to [[track:twice-as-bright]], [[track:flyfish]], [[track:in-it-to-win-it]], and [[track:spiritstriker]] (thanks, Lilith!)
+    - added Discord referencing sources to [[track:twice-as-bright]], [[track:flyfish]], [[track:in-it-to-win-it]], and [[track:spiritstriker]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:penumbra-phantasm]] (thanks, Lilith, Lan!)
     <!-- citation additions -->
     - added citations for SoundCloud and Tumblr commentary on [[track:dord-waltz]] (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -369,6 +369,7 @@ Content: |-
     - added various referencing sources to [[track:dissension-remix]], [[track:white]], [[track:octoroon-rangoon]], [[track:clockwork-sorrow]], [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] (thanks, Lan!)
     - added Discord referencing sources to [[track:good-old-hornless-jerryatric]] and [[track:the-worlds-heel]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:teleports-behind-you]] (thanks, Lan!)
+    - added referencing sources to [[track:twice-as-bright]], [[track:flyfish]], [[track:in-it-to-win-it]], and [[track:spiritstriker]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:penumbra-phantasm]] (thanks, Lilith, Lan!)
     <!-- citation additions -->
     - added citations for SoundCloud and Tumblr commentary on [[track:dord-waltz]] (thanks, Lilith!)
@@ -567,6 +568,10 @@ Content: |-
     - fixed [[track:mx-misery]] referencing [[track:heat]] ([[album:medium]]) instead of [[track:heat-brock-hampton]] ([[artist:brockhampton]]; thanks, Lan!)
     - fixed [[track:the-worlds-heel]] not referencing [[track:production-line-of-the-holy-clown]] (thanks, Gryotharian, Lilith!)
     - fixed [[track:duodenary]] not referencing [[track:six-by-six]] (thanks, Lilith, Rainy!)
+    - fixed [[track:twice-as-bright]] not referencing [[track:torchlight-vast-error]] (thanks, Rainy, Lilith!)
+    - fixed [[track:flyfish]] not referencing [[track:murrits-theme]] (thanks, Rainy, Lilith!)
+    - fixed [[track:in-it-to-win-it]] not referencing [[track:minute-to-win-it]] (thanks, Rainy, Lilith!)
+    - fixed [[track:spiritstriker]] not referencing [[track:hope-for-a-more-radiant-dawn]] (thanks, Rainy, Lilith!)
     - fixed [[track:coulrocide]] not referencing [[track:jupiter-jebb]] (thanks, Jebb, Lilith!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)
         - fixed [[track:verisimilitude-induction]] not referencing [[track:verisimilitude-original]] (original single)


### PR DESCRIPTION
Fixes Twice As Bright not referencing Torchlight
Fixes Flyfish not referencing Murrit's Theme
Fixes IN IT TO WIN IT not referencing Minute To Win It
Fixes Spiritstriker not referencing Hope For A More Radiant Dawn

Thanks so much, Rainy!