### PR TITLE
Referencing fix for Into the Haunted Place

### DIFF
--- a/album/friendsim-2-volume-2.yaml
+++ b/album/friendsim-2-volume-2.yaml
@@ -290,8 +290,6 @@ Artists:
 Duration: 3:16
 URLs:
 - https://studiojune.bandcamp.com/track/into-the-haunted-place
-Referenced Tracks:
-- English
 ---
 Track: Narrative Entanglement
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -726,6 +726,7 @@ Content: |-
     - fixed [[track:flyfish]] not referencing [[track:murrits-theme]] (thanks, Rainy, Lilith!)
     - fixed [[track:in-it-to-win-it]] not referencing [[track:minute-to-win-it]] (thanks, Rainy, Lilith!)
     - fixed [[track:spiritstriker]] not referencing [[track:hope-for-a-more-radiant-dawn]] (thanks, Rainy, Lilith!)
+    - fixed [[track:into-the-haunted-place]] referencing [[track:english]] (thanks, Lilith!)
     - fixed [[track:coulrocide]] not referencing [[track:jupiter-jebb]] (thanks, Jebb, Lilith!)
     - fixed [[track:endless-ocean]] not referencing [[track:vertigo]] (thanks, Lan!)
     - fixed various [[album:induction]]-related references (thanks, Lilith!)


### PR DESCRIPTION
Removes English (and the referenced tracks field) from Into the Haunted Place. It's not really quite English.