### PR TITLE
D--> Break the Bow (-->) D --> Break the Bow name fix

### DIFF
--- a/album/alternate-hues-and-melodies.yaml
+++ b/album/alternate-hues-and-melodies.yaml
@@ -197,7 +197,7 @@ Color: '#3796c6'
 URLs:
 - https://www.youtube.com/watch?v=o8mLZwFU2Oc
 ---
-Track: D--> Break the Bow
+Track: D --> Break the Bow
 Directory: break-the-bow
 Artists:
 - Caelan Kier

--- a/album/gba-pokemon-unbound-super-music-collection.yaml
+++ b/album/gba-pokemon-unbound-super-music-collection.yaml
@@ -205,7 +205,7 @@ URLs:
 - https://pascalpotatovandenbos.bandcamp.com/track/victory-against-the-shadows
 - https://www.youtube.com/watch?v=mVNQ7i6UW7g
 Referenced Tracks:
-- D--> Break the Bow
+- D --> Break the Bow
 ---
 Track: Zeph
 Duration: 0:49

--- a/album/lofam5.yaml
+++ b/album/lofam5.yaml
@@ -1223,7 +1223,7 @@ Referenced Tracks:
 - track:collapse-stlap3
 - Distortion Navigator
 - Temporal Virtuoso
-- D--> Break the Bow
+- D --> Break the Bow
 - Fate of the Heir
 - Gentle Heat
 - Dwelling Among the Dream Bubbles

--- a/album/stlap3.yaml
+++ b/album/stlap3.yaml
@@ -1158,7 +1158,7 @@ Cover Artists:
 Referenced Tracks:
 - Distortion Navigator
 - Temporal Virtuoso
-- D--> Break the Bow
+- D --> Break the Bow
 - Fate of the Heir
 - Gentle Heat
 - Dwelling Among the Dream Bubbles

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -522,8 +522,8 @@ Content: |-
         - fixed [[track:title-theme-the-legend-of-zelda]] being named "Title (The Legend of Zelda)"
         - fixed [[track:underworld-theme]] being named "Dungeon Theme"
     <!-- name fixes (single-lines) -->
-    - fixed [[track:break-the-bow]] being named "D--> Break the Bow" (thanks, Lilith!)
     - fixed [[track:riches-to-ruins-movements-pt-ii]] ([[album:pesterquest-soundtrack]]) missing an "in-game credits" annotation on one of its additional names (thanks, Surge!)
+    - fixed [[track:break-the-bow]] ([[album:alternate-hues-and-melodies]]) being named "D--> Break the Bow" (thanks, Lilith!)
     - fixed [[track:catscratch]] being named "Catscratch" (capitalized; thanks, Lan!)
     - fixed [[track:do-the-homestuck-demo]] being named "Do the Homestuck" (thanks, Lan!)
     - fixed [[track:home-keys-of-a-piano]] being named "Home (Keys of a PIano)" (thanks, Lilith!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -522,6 +522,7 @@ Content: |-
         - fixed [[track:title-theme-the-legend-of-zelda]] being named "Title (The Legend of Zelda)"
         - fixed [[track:underworld-theme]] being named "Dungeon Theme"
     <!-- name fixes (single-lines) -->
+    - fixed [[track:break-the-bow]] being named "D--> Break the Bow" (thanks, Lilith!)
     - fixed [[track:riches-to-ruins-movements-pt-ii]] ([[album:pesterquest-soundtrack]]) missing an "in-game credits" annotation on one of its additional names (thanks, Surge!)
     - fixed [[track:catscratch]] being named "Catscratch" (capitalized; thanks, Lan!)
     - fixed [[track:do-the-homestuck-demo]] being named "Do the Homestuck" (thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -523,10 +523,10 @@ Content: |-
         - fixed [[track:underworld-theme]] being named "Dungeon Theme"
     <!-- name fixes (single-lines) -->
     - fixed [[track:riches-to-ruins-movements-pt-ii]] ([[album:pesterquest-soundtrack]]) missing an "in-game credits" annotation on one of its additional names (thanks, Surge!)
-    - fixed [[track:break-the-bow]] ([[album:alternate-hues-and-melodies]]) being named "D--> Break the Bow" (thanks, Lilith!)
+    - fixed [[track:break-the-bow]] ([[album:alternate-hues-and-melodies]]) being named "D--> Break the Bow" (no space between bow and arrow; thanks, Lilith!)
     - fixed [[track:catscratch]] being named "Catscratch" (capitalized; thanks, Lan!)
     - fixed [[track:do-the-homestuck-demo]] being named "Do the Homestuck" (thanks, Lan!)
-    - fixed [[track:home-keys-of-a-piano]] being named "Home (Keys of a PIano)" (thanks, Lilith!)
+    - fixed [[track:home-keys-of-a-piano]] being named "Home (Keys of a PIano)" (uppercase "I" in "PIano"; thanks, Lilith!)
     - fixed [[track:bad-apple-lovelight]] (feat. [[artist:nomico]]) being named "Bad Apple!! feat. nomico" (thanks, Lan!)
     - fixed [[track:danger-on-the-dance-floor-mid-boss]] being named "Danger on the Dance Floor (Mid-Boss)" (to align with soundtrack release; thanks, ruby!)
     - fixed [[track:chasing-it-down]] being named "Chasing It down" (lowercase "Down"; thanks, Lan!)


### PR DESCRIPTION
Fixes D --> Break the Bow being named D--> Break the Bow.

This is _specifically_ for the original release of it on the delisted Alternate Hues and Melodies album, not for its PMT Classic Selection rerelease.

