### PR TITLE
Flash addition: [S][A6A6I5] ====> (page 7823) (Homestuck)

### DIFF
--- a/flashes.yaml
+++ b/flashes.yaml
@@ -1732,6 +1732,13 @@ Featured Tracks:
 - Echidna
 ---
 Flash: '[S][A6A6I5] ====>'
+Page: '7823'
+Date: July 6, 2015
+# Not in [S] 'Homestuck - All flashes' list
+Featured Tracks:
+- Killed by BR8K Spider!!!!!!!!
+---
+Flash: '[S][A6A6I5] ====>'
 Page: '7928'
 Contributors:
 - ipgd (art)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -244,6 +244,7 @@ Content: |-
     <h3>other additions</h3>
     <!-- flash additions -->
     - added [[flash:6943]] (thanks, Meulanie, Lavender!)
+    - added [[flash:7823]] (thanks, AirPrime, Lilith!)
     - added [[flash:darkcage]] and [[flash:darkcage2]] secret pages (thanks, Tangle!)
     - added [[flash:combustion]] and [[flash:body-mind-soul]] flashes from [[group:desynced]] (thanks, Jebb!)
     - added [[flash:street-strifer-op-movie]] (thanks, ruby, Makin, Lan!)


### PR DESCRIPTION
Adds [S][A6A6I5] ====> (page 7823) (which uses Killed by BR8K Spider!!!!!!!!), which was missing from the Homestuck flashes list!
https://discord.com/channels/749042497610842152/935007764042874931/1454272188990357524
Thanks, AirPrime!

Merge with: https://github.com/hsmusic/hsmusic-media/pull/193
