### PR TITLE
Slender (Paths) & Chromaestro Bandcamp blurb citations + remaining Bandcamp track blurbs for rest of Paths

### DIFF
--- a/album/paths.yaml
+++ b/album/paths.yaml
@@ -106,7 +106,7 @@ URLs:
 - https://parsecproductions.bandcamp.com/track/chromaestro
 Commentary: |-
     <i>Mark J. Hadley:</i>
-    Originally appeared in "[Chromaestro](https://store.steampowered.com/app/652200/Chromaestro/)"
+    Originally appeared in ["Chromaestro"](https://store.steampowered.com/app/652200/Chromaestro/)
 ---
 Track: Lurk
 Main Release: track:lurk-a-nameless-inheritance
@@ -151,7 +151,7 @@ URLs:
 - https://parsecproductions.bandcamp.com/track/dawn-2
 Commentary: |-
     <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/dawn-2))
-    Originally appeared in "[The Consuming Shadow](https://store.steampowered.com/app/403830/)"
+    Originally appeared in ["The Consuming Shadow"](https://store.steampowered.com/app/403830/)
 ---
 Track: Song of Skaia
 Main Release: track:song-of-skaia

--- a/album/paths.yaml
+++ b/album/paths.yaml
@@ -35,6 +35,9 @@ Main Release: track:aggrievocation
 Duration: 3:39
 URLs:
 - https://parsecproductions.bandcamp.com/track/aggrievocation
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/aggrievocation))
+    Originally appeared in [[album:homestuck-vol-10|"Homestuck Vol. 10"]]
 ---
 Track: Slender
 Main Release: track:slender
@@ -42,7 +45,7 @@ Duration: 2:06
 URLs:
 - https://parsecproductions.bandcamp.com/track/slender
 Commentary: |-
-    <i>Mark J. Hadley:</i>
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/slender))
     Originally appeared in "Slender: The Eight Pages"
 ---
 Track: Forge Multitask
@@ -50,6 +53,9 @@ Main Release: track:forge-multitask
 Duration: 3:28
 URLs:
 - https://parsecproductions.bandcamp.com/track/forge-multitask
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/forge-multitask))
+    Originally appeared in [[album:dare|"Dare"]]
 ---
 Track: Train Hard!
 Suffix Directory: false
@@ -62,24 +68,36 @@ Main Release: track:isolate-slender
 Duration: 2:45
 URLs:
 - https://parsecproductions.bandcamp.com/track/isolate
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/isolate))
+    Originally appeared in "Slender: The Arrival"
 ---
 Track: Carefree Action
 Main Release: track:carefree-action
 Duration: 2:08
 URLs:
 - https://parsecproductions.bandcamp.com/track/carefree-action
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/carefree-action))
+    Originally appeared in [[album:homestuck-vol-8|"Homestuck Vol. 8"]]
 ---
 Track: Edge of Worlds
 Main Release: track:edge-of-worlds
 Duration: 3:25
 URLs:
 - https://parsecproductions.bandcamp.com/track/edge-of-worlds-2
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/edge-of-worlds-2))
+    Originally appeared in [[album:a-nameless-inheritance|"A Nameless Inheritance"]]
 ---
 Track: Galaxy Hearts
 Main Release: track:galaxy-hearts
 Duration: 2:53
 URLs:
 - https://parsecproductions.bandcamp.com/track/galaxy-hearts
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/galaxy-hearts))
+    Originally appeared in [[album:homestuck-vol-8|"Homestuck Vol. 8"]]
 ---
 Track: Chromaestro
 Suffix Directory: false
@@ -95,36 +113,54 @@ Main Release: track:lurk-a-nameless-inheritance
 Duration: 2:32
 URLs:
 - https://parsecproductions.bandcamp.com/track/lurk-2
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/lurk-2))
+    Originally appeared in [[album:a-nameless-inheritance|"A Nameless Inheritance"]]
 ---
 Track: Furni-Chore
 Main Release: track:furni-chore
 Duration: 1:34
 URLs:
 - https://parsecproductions.bandcamp.com/track/furni-chore
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/furni-chore))
+    Originally appeared in [[album:dare|"Dare"]]
 ---
 Track: Bane
 Main Release: track:bane-p-s
 Duration: 6:05
 URLs:
 - https://parsecproductions.bandcamp.com/track/bane
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/bane))
+    Originally appeared in [[album:p-s|"P.[S\]."]]
 ---
 Track: Final Stand
 Main Release: track:final-stand-dare
 Duration: 3:32
 URLs:
 - https://parsecproductions.bandcamp.com/track/final-stand
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/final-stand))
+    Originally appeared in [[album:dare|"Dare"]]
 ---
 Track: Dawn
 Main Release: track:dawn-the-consuming-shadow
 Duration: 1:51
 URLs:
 - https://parsecproductions.bandcamp.com/track/dawn-2
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/dawn-2))
+    Originally appeared in "[The Consuming Shadow](https://store.steampowered.com/app/403830/)"
 ---
 Track: Song of Skaia
 Main Release: track:song-of-skaia
 Duration: 6:27
 URLs:
 - https://parsecproductions.bandcamp.com/track/song-of-skaia-2
+Commentary: |-
+    <i>Mark J. Hadley:</i> ([Bandcamp about blurb](https://parsecproductions.bandcamp.com/track/song-of-skaia-2))
+    Originally appeared in [[album:song-of-skaia|"Song of Skaia"]]
 ---
 Track: The Raddest
 Main Release: track:the-raddest

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -283,6 +283,7 @@ Content: |-
     - added citations for Tumblr and SoundCloud commentary across [[album:7th-gate-project]] (thanks, Lilith!)
     - added citation for booklet commentary ([[artist:thomas-ferkol]]) on [[track:the-metamorphosis-of-rose-lalonde]] (thanks, Lilith, Lavender!)
     - added citations for SoundCloud commentary on [[album:cartographer-symphony]] and [[track:summer-by-the-sea]] (thanks, Lan!)
+    - added citations for Bandcamp commentary on [[track:slender-paths]] and [[track:chromaestro]] (thanks, Lilith!)
     - added citation for newsletter commentary on [[track:skies-forever-blue]] (thanks, Whisper!)
     - added citation for Fangamer commentary on [[track:the-greatest-living-show]] (thanks, Lan!)
     - added citation for Tumblr commentary on [[track:wherever-you-were]] (thanks, Lan!)
@@ -1465,6 +1466,7 @@ Content: |-
     - added Newgrounds commentary to [[track:clockstopper-new-game-plus-all-clocks-percent]] and [[track:deadkidsgodhood]] (thanks, Whisper!)
     - added Tumblr commentary to [[track:dawn-of-man]] (thanks, Lilith!)
     - added commentary blurbs from Bandcamp and YouTube, as well as additional names mostly from YouTube, across [[album:the-funk-mclovin-homestuck-experience]], [[album:class-act]], and [[album:class-act-b-side]]
+    - added Bandcamp commentary blurbs across [[album:paths]] (thanks, Lilith!)
     - added album release commentary to [[album:gravity-makes-the-flame-rise]] and [[album:ulterior-motives]]
     - added Twitter commentary to [[track:welcome-to-the-city]] and [[track:lost-girl]] (thanks, Lan!)
     - added Tumblr commentary to [[track:horsecatska]] (thanks, Lilith!)


### PR DESCRIPTION
Adds Bandcamp citations to Slender (Paths) and Chromaestro; as well as adding the rest of the Bandcamp track blurbs for everything on Paths except for Train Hard!, and The Raddest, which lack blurbs.