### PR TITLE
Add tags across The Tapestry

### DIFF
--- a/album/homestuck-vol-10.yaml
+++ b/album/homestuck-vol-10.yaml
@@ -658,6 +658,7 @@ Art Tags:
 - WV
 - Genesis Frog
 - Fenestrology
+- Prospitian ship
 - Pop-a-matic Vrillyhoo Hammer
 - Red Miles
 - Royal Deringer

--- a/album/the-tapestry-vol-1-5.yaml
+++ b/album/the-tapestry-vol-1-5.yaml
@@ -23,6 +23,13 @@ Banner File Extension: png
 Banner Style: |-
     image-rendering: pixelated;
     image-rendering: crisp-edges;
+Art Tags:
+- Alime Lyranell (The Tapestry)
+- Handa Halminth (The Tapestry)
+- Sosav Frauhoul (The Tapestry)
+- Oenia Acanenda (The Tapestry)
+- Deime Lyranell (The Tapestry)
+- Liminocre (The Tapestry)
 Color: '#fdb200'
 Groups:
 - Monckat
@@ -36,6 +43,8 @@ Section: Main album
 ---
 Track: Hollow Skies/Tower Merge
 Duration: 3:27
+Art Tags:
+- Liminocre (The Tapestry)
 Referenced Tracks:
 - Hollow Skies
 - Amnsomnia
@@ -46,6 +55,9 @@ URLs:
 ---
 Track: Siltbound Dragonfly
 Duration: 3:34
+Art Tags:
+- Sosav Frauhoul (The Tapestry)
+- Fata Morgana (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/siltbound-dragonfly
 ---
@@ -53,6 +65,8 @@ Track: Situator
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 3:06
+Art Tags:
+- Amnsomn (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/situator
 Commentary: |-
@@ -61,6 +75,9 @@ Commentary: |-
 ---
 Track: Voidsigh
 Duration: 2:54
+Art Tags:
+- Liminocre (The Tapestry)
+- Carnival Space (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/voidsigh
 ---
@@ -68,16 +85,28 @@ Track: Dissolute
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:33
+Art Tags:
+- Alime Lyranell (The Tapestry)
+- Siltsphere (The Tapestry)
+- Hyphonese Rotary Rocket (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/dissolute
 ---
 Track: Waversoul
 Duration: 3:13
+Art Tags:
+- Typheus
+- Carapaced Despot (The Tapestry)
+- The Wandering Soul (The Tapestry)
+- Spawnlings (The Tapestry)
+- Setyr (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/waversoul
 ---
 Track: Painted Canyon
 Duration: 1:15
+Art Tags:
+- Painted Canyon (The Tapestry)
 Referenced Tracks:
 - track:pickaxe-the-tapestry
 - track:beacon-the-tapestry
@@ -89,6 +118,8 @@ URLs:
 ---
 Track: From Briskwind
 Duration: 1:05
+Art Tags:
+- Briskwind (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/from-briskwind
 ---
@@ -96,6 +127,10 @@ Track: Discovery
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:01
+Art Tags:
+- Fata Morgana (The Tapestry)
+- Hanaway (The Tapestry)
+- Liminocre (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/discovery
 ---
@@ -112,3 +147,5 @@ Referenced Tracks:
 - track:doctor
 #- a song from a karkat goes to a convention flash that i think got removed
 - Sunslammer
+Art Tags:
+- MSPFA Logo

--- a/album/the-tapestry-vol-1.yaml
+++ b/album/the-tapestry-vol-1.yaml
@@ -28,6 +28,22 @@ Wallpaper Style: |-
     background-size: auto calc(max(1080px, 100%));
     background-repeat-x: repeat;
     opacity: 0.7;
+Art Tags:
+- Handa Halminth (The Tapestry)
+- Sosav Frauhoul (The Tapestry)
+- Oenia Acanenda (The Tapestry)
+- Deime Lyranell (The Tapestry)
+- Ophani Agent (The Tapestry)
+- Amnsomn (The Tapestry)
+- Hanaway (The Tapestry)
+- Liminocre (The Tapestry)
+- Mistmarble (The Tapestry)
+- Beacon Station (The Tapestry)
+- LoKaM (The Tapestry)
+- LoVaF (The Tapestry)
+- Sosav's land (The Tapestry)
+- Deime's land (The Tapestry)
+- Bean Cube (The Tapestry)
 Color: '#7affbc'
 Groups:
 - Monckat
@@ -43,6 +59,9 @@ Section: Main album
 Track: Heliotroposphere
 Duration: 1:25
 Cover Art File Extension: png
+Art Tags:
+- Sosav Frauhoul (The Tapestry)
+- Sosav's room (The Tapestry)
 Referenced Tracks:
 - Lotus
 URLs:
@@ -56,11 +75,18 @@ Track: Pickaxe
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:49
+Art Tags:
+- Handa Halminth (The Tapestry)
+- LoKaM (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/pickaxe
 ---
 Track: Vacuum Spark
 Duration: 2:26
+Art Tags:
+- Oenia Acanenda (The Tapestry)
+- Oenia's room (The Tapestry)
+- Horrorterrors
 URLs:
 - https://monckat.bandcamp.com/track/vacuum-spark
 ---
@@ -68,6 +94,9 @@ Track: Beacon
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:24
+Art Tags:
+- Osand Acanenda (The Tapestry)
+- Beacon Station (The Tapestry)
 Referenced Tracks:
 - Vacuum Spark
 URLs:
@@ -77,6 +106,9 @@ Track: Pollinate
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 3:08
+Art Tags:
+- Psycherefectory (The Tapestry)
+- Captcharoid Camera (The Tapestry)
 Referenced Tracks:
 - Heliotroposphere
 URLs:
@@ -86,6 +118,9 @@ Track: Mythos
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:30
+Art Tags:
+- LoKaM (The Tapestry)
+- Psycherefectory (The Tapestry)
 Referenced Tracks:
 - track:pickaxe-the-tapestry
 URLs:
@@ -93,16 +128,23 @@ URLs:
 ---
 Track: Unsettling Energy
 Duration: 1:12
+Art Tags:
+- Archesprite (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/unsettling-energy
 ---
 Track: GLASST Theme
 Duration: 1:41
+Art Tags:
+- Metamateria's planet (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/glasst-theme
 ---
 Track: Modified Adventure
 Duration: 2:20
+Art Tags:
+- LoVaF (The Tapestry)
+- Psycherefectory (The Tapestry)
 Referenced Tracks:
 - Vacuum Spark
 - Heliotroposphere
@@ -111,6 +153,14 @@ URLs:
 ---
 Track: Vacuum Blaze
 Duration: 3:06
+Art Tags:
+- The Grand Princesa (The Tapestry)
+- Sosav's Mom (The Tapestry)
+- Hanaway (The Tapestry)
+- Reaction City (The Tapestry)
+- Serrasword (The Tapestry)
+- Railgun (The Tapestry)
+- Gate # Monckat: "Skaia Defense Portal"
 Referenced Tracks:
 - Heliotroposphere
 - Vacuum Spark
@@ -121,6 +171,10 @@ URLs:
 ---
 Track: Cosmodrome
 Duration: 3:08
+Art Tags:
+- Sosav Frauhoul (The Tapestry)
+- Hanaway (The Tapestry)
+- Reaction City (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/cosmodrome
 Commentary: |-
@@ -129,16 +183,27 @@ Commentary: |-
 ---
 Track: Exodendron
 Duration: 2:23
+Art Tags:
+- Mistmarble (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/exodendron
 ---
 Track: Amnsomnia
 Duration: 2:18
+Art Tags:
+- The Grand Princesa (The Tapestry)
+- Ophani Agent (The Tapestry)
+- Amnsomn (The Tapestry)
+- Transient Lance (The Tapestry)
+- Amnsomniac Dropship (The Tapestry)
+- Serrasword (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/amnsomnia
 ---
 Track: Hollow Skies
 Duration: 3:30
+Art Tags:
+- Liminocre (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/hollow-skies
 ---
@@ -146,6 +211,10 @@ Track: Proletarian Prince
 Duration: 2:13
 Referenced Tracks:
 - Deime's Theme
+Art Tags:
+- Deime Lyranell (The Tapestry)
+- Amnsomn (The Tapestry)
+- Amnsomniac Zeppelin (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/proletarian-prince
 ---

--- a/album/the-tapestry-vol-2.yaml
+++ b/album/the-tapestry-vol-2.yaml
@@ -23,6 +23,17 @@ Banner File Extension: png
 Banner Style: |-
     image-rendering: pixelated;
     image-rendering: crisp-edges;
+Art Tags:
+- Handa Halminth (The Tapestry)
+- Sosav Frauhoul (The Tapestry)
+- Oenia Acanenda (The Tapestry)
+- Deime Lyranell (The Tapestry)
+- Utnapoiesis (The Tapestry)
+- Expansiver Hospitable Driftconch (The Tapestry)
+- Carnival Space (The Tapestry)
+- Liminocre (The Tapestry)
+- Fata Morgana (The Tapestry)
+- Transient Lance (The Tapestry)
 Color: '#fe2b57'
 Groups:
 - Monckat
@@ -40,6 +51,9 @@ Duration: 4:15
 Referenced Tracks:
 - Cosmodrome
 - Proletarian Prince
+Art Tags:
+- Carnival Space (The Tapestry)
+- Setyr (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/interstellar-medium
 Commentary: |-
@@ -51,6 +65,9 @@ Referencing Sources: |-
 ---
 Track: Redout Redoubt
 Duration: 3:34
+Art Tags:
+- Sosav Frauhoul (The Tapestry)
+- Fata Morgana (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/redout-redoubt
 Commentary: |-
@@ -59,6 +76,9 @@ Commentary: |-
 ---
 Track: Siltsphere
 Duration: 4:01
+Art Tags:
+- Siltsphere (The Tapestry)
+- Swiftstar (The Tapestry)
 Referenced Tracks:
 - track:discovery-the-tapestry
 URLs:
@@ -72,6 +92,8 @@ Referencing Sources: |-
 ---
 Track: Shimmerserene
 Duration: 6:45
+Art Tags:
+- Oenia Acanenda (The Tapestry)
 Referenced Tracks:
 - Vacuum Spark
 Sampled Tracks:
@@ -89,6 +111,10 @@ Track: Apprentice
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 3:07
+Art Tags:
+- Deime Lyranell (The Tapestry)
+- The Grand Princesa (The Tapestry)
+- Amnsomn (The Tapestry)
 Referenced Tracks:
 - Deime's Theme
 URLs:
@@ -102,6 +128,13 @@ Referencing Sources: |-
 ---
 Track: Home Amidst Chaos
 Duration: 3:16
+Art Tags:
+- Handa's Dad (The Tapestry)
+- Sosav's Mom (The Tapestry)
+- Osand Acanenda (The Tapestry)
+- Alime Lyranell (The Tapestry)
+- The Grand Princesa (The Tapestry)
+- Carnival Space (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/home-amidst-chaos
 Commentary: |-
@@ -113,6 +146,8 @@ Referencing Sources: |-
 ---
 Track: Wingchime
 Duration: 0:53
+Art Tags:
+- Wingchime (The Tapestry)
 Referenced Tracks:
 - Driftjam
 URLs:
@@ -126,6 +161,8 @@ Referencing Sources: |-
 ---
 Track: Kaleidoacoustic
 Duration: 1:18
+Art Tags:
+- Sedranovel Precarious Skrawnhall (The Tapestry)
 Referenced Tracks:
 - Driftjam
 URLs:
@@ -139,6 +176,8 @@ Referencing Sources: |-
 ---
 Track: Legendarium
 Duration: 2:27
+Art Tags:
+- LoKaM (The Tapestry)
 Referenced Tracks:
 - track:pickaxe-the-tapestry
 URLs:
@@ -152,6 +191,10 @@ Referencing Sources: |-
 ---
 Track: Actioni Contrariam
 Duration: 2:45
+Art Tags:
+- Reaction City (The Tapestry)
+- Siltsphere (The Tapestry)
+- Spawnling Giant (The Tapestry)
 Referenced Tracks:
 - Ventus Teratodis
 URLs:
@@ -165,6 +208,10 @@ Referencing Sources: |-
 ---
 Track: Espiospectre
 Duration: 2:43
+Art Tags:
+- Sosav's Mom (The Tapestry)
+- Reaction City (The Tapestry)
+- Skaia
 Referenced Tracks:
 - Heliotroposphere
 URLs:
@@ -178,6 +225,9 @@ Referencing Sources: |-
 ---
 Track: One We Will Become
 Duration: 3:37
+Art Tags:
+- The God We Will Become (The Tapestry)
+- Carnival Space (The Tapestry)
 Referenced Tracks:
 - Waversoul
 URLs:
@@ -191,6 +241,8 @@ Referencing Sources: |-
 ---
 Track: Driftjam
 Duration: 1:13
+Art Tags:
+- Expansiver Hospitable Driftconch (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/driftjam
 Commentary: |-
@@ -199,6 +251,9 @@ Commentary: |-
 ---
 Track: Homologite
 Duration: 2:45
+Art Tags:
+- Utnapoiesis (The Tapestry)
+- Limeweld Juniper (The Tapestry)
 Referenced Tracks:
 - Driftjam
 - track:discovery-the-tapestry
@@ -212,6 +267,8 @@ Track: Keystone
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 3:18
+Art Tags:
+- Carnival Space (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/keystone
 Commentary: |-
@@ -220,6 +277,10 @@ Commentary: |-
 ---
 Track: Cytherean Isolate
 Duration: 2:57
+Art Tags:
+- Alime Lyranell (The Tapestry)
+- Mistmarble (The Tapestry)
+- Siltsphere (The Tapestry)
 Referenced Tracks:
 - Lunar Solace
 URLs:
@@ -235,6 +296,13 @@ Track: Quiescent Conquest
 Artists:
 - Chuck Salamone
 Duration: 3:34
+Art Tags:
+- The Grand Princesa (The Tapestry)
+- Handa Halminth (The Tapestry)
+- Sosav Frauhoul (The Tapestry)
+- Oenia Acanenda (The Tapestry)
+- Deime Lyranell (The Tapestry)
+- Serrasword (The Tapestry)
 Referenced Tracks:
 - Amnsomnia
 URLs:
@@ -251,6 +319,9 @@ Referencing Sources: |-
 ---
 Track: Ventus Teratodis
 Duration: 4:13
+Art Tags:
+- Ventus (The Tapestry)
+- Knife-Wing Spawnling (The Tapestry)
 URLs:
 - https://monckat.bandcamp.com/track/ventus-teratodis
 Commentary: |-
@@ -262,6 +333,9 @@ Duration: 5:57
 Contributors:
 - Elefinch (first violin)
 - Monckat (second violin)
+Art Tags:
+- Siltsphere (The Tapestry)
+- Liminocre (The Tapestry)
 Referenced Tracks:
 - Siltsphere
 - Homologite
@@ -280,3 +354,5 @@ Section: Bonus track
 ---
 Track: Ogamand
 Duration: 1:41
+Art Tags:
+- Ogamand (The Tapestry)

--- a/art-tags/archetypes.yaml
+++ b/art-tags/archetypes.yaml
@@ -354,6 +354,7 @@ Tag: Derse (archetype)
 Direct Descendant Tags:
 - Derse
 - Durst
+- Liminocre (The Tapestry)
 ---
 Tag: Earth (archetype)
 Direct Descendant Tags:
@@ -377,6 +378,7 @@ Tag: Prospit (archetype)
 Direct Descendant Tags:
 - Prospit
 - Prostit
+- Liminocre (The Tapestry)
 ---
 Tag: Skaia (archetype)
 Direct Descendant Tags:

--- a/art-tags/iconography-classifications.yaml
+++ b/art-tags/iconography-classifications.yaml
@@ -11,6 +11,8 @@ Direct Descendant Tags:
 - More general iconography
 ---
 Tag: More general iconography
+Direct Descendant Tags:
+- MSPFA Logo
 ---
 Tag: Musical iconography
 Direct Descendant Tags:

--- a/art-tags/location-classifications.yaml
+++ b/art-tags/location-classifications.yaml
@@ -23,6 +23,7 @@ Direct Descendant Tags:
 - Astronomical bodies (Desynced)
 - Astronomical bodies (Homestuck)
 - 'Astronomical bodies (Homestuck: Beyond Canon)'
+- Astronomical bodies (The Tapestry)
 - Astronomical bodies (Vast Error)
 - More astronomical bodies
 ---
@@ -51,6 +52,7 @@ Direct Descendant Tags:
 - Mobile locations (Cheezquest)
 - Mobile locations (Homestuck)
 - 'Mobile locations (Homestuck: Beyond Canon)'
+- Mobile locations (The Tapestry)
 ---
 Tag: Recurring game locations
 Direct Descendant Tags:

--- a/art-tags/media.yaml
+++ b/art-tags/media.yaml
@@ -38,6 +38,7 @@ Direct Descendant Tags:
 - Shackstuck (media)
 - SVERT (media)
 - Synodic Reboot (media)
+- The Tapestry (media)
 - Team Paradox (media)
 - Tumblrstuck (media)
 - Vast Error (media)

--- a/art-tags/media/homestuck/location-entries.yaml
+++ b/art-tags/media/homestuck/location-entries.yaml
@@ -257,6 +257,9 @@ Direct Descendant Tags:
 Tag: Pink Moon
 Color: '#fb889a'
 ---
+Tag: Prospitian ship
+Color: '#ffff01'
+---
 Tag: Ruined Earth
 Color: '#d9cbab'
 ---

--- a/art-tags/media/homestuck/object-classification.yaml
+++ b/art-tags/media/homestuck/object-classification.yaml
@@ -2,6 +2,7 @@ Tag: Objects from Homestuck
 Direct Descendant Tags:
 - General objects (Homestuck)
 - Musical instruments (Homestuck)
+- Vehicles (Homestuck)
 - Weapons (Homestuck)
 - More objects (Homestuck)
 ---
@@ -71,6 +72,13 @@ Direct Descendant Tags:
 Extra Reading URLs:
 - https://mspaintadventures.fandom.com/wiki/Spoonkind
 ---
+Tag: Game objects (Homestuck)
+Direct Descendant Tags:
+- Grist
+- Queen's Ring
+- Red Miles
+- Tumor
+---
 Tag: General objects (Homestuck)
 Direct Descendant Tags:
 - Clocks (Homestuck)
@@ -108,6 +116,7 @@ Direct Descendant Tags:
 - Fenestrology
 - Gate
 - Lotus
+- Reckoning
 ---
 Tag: More instruments (Homestuck)
 Direct Descendant Tags:
@@ -166,6 +175,14 @@ Tag: Turntables (Homestuck)
 Direct Descendant Tags:
 - Timetables
 ---
+Tag: Vehicles (Homestuck)
+Direct Descendant Tags:
+- Battleship Condescension # treated as location
+- Command stations # treated as location
+- Dersite ship # treated as location
+- Prospitian ship # treated as location
+- Trolls' meteor # treated as location
+---
 Tag: Wandkind
 Direct Descendant Tags:
 - Empiricist's Wand
@@ -201,11 +218,6 @@ Direct Descendant Tags:
 - Smuppets
 - Squiddles
 - What Pumpkin?
-- Grist
 - Matriorb
-- Queen's Ring
 - Rag of Souls
-- Reckoning
-- Red Miles
 - Remote Ghost Gauntlets
-- Tumor

--- a/art-tags/media/the-tapestry.yaml
+++ b/art-tags/media/the-tapestry.yaml
@@ -1,0 +1,285 @@
+Tag: The Tapestry (media)
+Direct Descendant Tags:
+- Characters from The Tapestry
+- Locations from The Tapestry
+- Objects from The Tapestry
+
+# Character classifications
+
+---
+Tag: Characters from The Tapestry
+Direct Descendant Tags:
+- Setyr (The Tapestry)
+- Galfany (The Tapestry)
+- Spawnlings (The Tapestry)
+- Carapacians (The Tapestry)
+- Sprites (The Tapestry)
+- More characters from The Tapestry
+---
+Tag: Setyr (The Tapestry)
+Direct Descendant Tags:
+- Players (The Tapestry)
+- Guardians (The Tapestry)
+- Ophani Agent (The Tapestry)
+---
+Tag: Players (The Tapestry)
+Direct Descendant Tags:
+- Handa Halminth (The Tapestry)
+- Sosav Frauhoul (The Tapestry)
+- Oenia Acanenda (The Tapestry)
+- Deime Lyranell (The Tapestry)
+---
+Tag: Guardians (The Tapestry)
+Direct Descendant Tags:
+- Handa's Dad (The Tapestry)
+- Sosav's Mom (The Tapestry)
+- Osand Acanenda (The Tapestry)
+- Alime Lyranell (The Tapestry)
+- The Grand Princesa (The Tapestry)
+---
+Tag: Galfany (The Tapestry)
+Direct Descendant Tags:
+- Sedranovel Precarious Skrawnhall (The Tapestry)
+- Limeweld Juniper (The Tapestry)
+- Expansiver Hospitable Driftconch (The Tapestry)
+- Utnapoiesis (The Tapestry)
+---
+Tag: Spawnlings (The Tapestry)
+Direct Descendant Tags:
+- Knife-Wing Spawnling (The Tapestry)
+- Spawnling Giant (The Tapestry)
+---
+Tag: Carapacians (The Tapestry)
+Direct Descendant Tags:
+- Carapaced Despot (The Tapestry)
+---
+Tag: Sprites (The Tapestry)
+Direct Descendant Tags:
+- Archesprite (The Tapestry)
+---
+Tag: More characters from The Tapestry
+Direct Descendant Tags:
+- The Wandering Soul (The Tapestry) # Monckat: "religious figure"
+- The God We Will Become (The Tapestry) # Monckat: "religious figure"
+
+# Character entries
+
+---
+Tag: Alime Lyranell (The Tapestry)
+Short Name: Alime
+Color: '#c42d2d'
+---
+Tag: Archesprite (The Tapestry)
+Color: '#00edb8'
+---
+Tag: Carapaced Despot (The Tapestry)
+---
+Tag: Deime Lyranell (The Tapestry)
+Short Name: Deime
+Color: '#feff68'
+---
+Tag: The God We Will Become (The Tapestry)
+---
+Tag: The Grand Princesa (The Tapestry)
+Color: '#4a6600'
+---
+Tag: Handa Halminth (The Tapestry)
+Short Name: Handa
+Color: '#00afc3'
+---
+Tag: Handa's Dad (The Tapestry)
+---
+Tag: Knife-Wing Spawnling (The Tapestry) # Monckat: "placeholder name"
+---
+Tag: Limeweld Juniper (The Tapestry)
+---
+Tag: Oenia Acanenda (The Tapestry)
+Short Name: Oenia
+Color: '#ff6600'
+---
+Tag: Ophani Agent (The Tapestry)
+---
+Tag: Osand Acanenda (The Tapestry)
+Short Name: Osand
+---
+Tag: Sedranovel Precarious Skrawnhall (The Tapestry)
+Short Name: Sedranovel
+Color: '#8d6732'
+---
+Tag: Sosav Frauhoul (The Tapestry)
+Short Name: Sosav
+Color: '#5a35c0'
+---
+Tag: Sosav's Mom (The Tapestry)
+---
+Tag: Spawnling Giant (The Tapestry)
+---
+Tag: The Wandering Soul (The Tapestry)
+
+# Character entries who are also locations though
+
+---
+Tag: Expansiver Hospitable Driftconch (The Tapestry)
+Color: '#009e6c'
+---
+Tag: Utnapoiesis (The Tapestry)
+Color: '#ff1686'
+
+# Location classifications
+
+---
+Tag: Locations from The Tapestry
+Direct Descendant Tags:
+- Astronomical bodies (The Tapestry)
+- Mobile locations (The Tapestry)
+- Session locations (The Tapestry)
+- Locations on Siltsphere (The Tapestry)
+- More locations from The Tapestry
+---
+Tag: Astronomical bodies (The Tapestry)
+Direct Descendant Tags:
+- Siltsphere (The Tapestry) # Monckat: "planet"
+- Briskwind (The Tapestry) # Monckat: "planet"
+- Ventus (The Tapestry) # Monckat: "planet"
+- Ogamand (The Tapestry) # Monckat: "planet"
+- Mistmarble (The Tapestry) # Monckat: "moon"
+- Swiftstar (The Tapestry) # Monckat: "moon"
+- Metamateria's planet (The Tapestry) # Monckat: "in-universe fictional planet"
+---
+Tag: Mobile locations (The Tapestry)
+Direct Descendant Tags:
+- Beacon Station (The Tapestry)
+- Fata Morgana (The Tapestry) # Monckat: "spacecraft"
+- Transient Lance (The Tapestry) # Monckat: "building that turns into a spacecraft"
+- Liminocre (The Tapestry)
+- Reaction City (The Tapestry) # Monckat: "giant rocket with a city on top"
+---
+Tag: Session locations (The Tapestry)
+Direct Descendant Tags:
+- LoKaM (The Tapestry)
+- LoVaF (The Tapestry)
+- Sosav's land (The Tapestry)
+- Deime's land (The Tapestry)
+- Liminocre (The Tapestry)
+---
+Tag: Locations on Siltsphere (The Tapestry)
+Direct Descendant Tags:
+- Painted Canyon (The Tapestry) # Monckat: "city"
+- Amnsomn (The Tapestry) # Monckat: "country"
+- Hanaway (The Tapestry) # Monckat: "country"
+---
+Tag: More locations from The Tapestry
+Direct Descendant Tags:
+- Carnival Space (The Tapestry)
+- Expansiver Hospitable Driftconch (The Tapestry)
+- Utnapoiesis (The Tapestry)
+
+# Location entries
+
+---
+Tag: Amnsomn (The Tapestry)
+---
+Tag: Beacon Station (The Tapestry)
+Direct Descendant Tags:
+- Oenia's room (The Tapestry)
+---
+Tag: Briskwind (The Tapestry)
+---
+Tag: Carnival Space (The Tapestry)
+---
+Tag: Deime's land (The Tapestry)
+---
+Tag: Fata Morgana (The Tapestry)
+---
+Tag: Hanaway (The Tapestry)
+Direct Descendant Tags:
+- Sosav's room (The Tapestry)
+---
+Tag: Liminocre (The Tapestry) # Monckat: "within prospit and derse categories"
+---
+Tag: LoKaM (The Tapestry)
+---
+Tag: LoVaF (The Tapestry)
+---
+Tag: Metamateria's planet (The Tapestry)
+---
+Tag: Mistmarble (The Tapestry)
+---
+Tag: Oenia's room (The Tapestry)
+---
+Tag: Ogamand (The Tapestry)
+---
+Tag: Painted Canyon (The Tapestry)
+---
+Tag: Reaction City (The Tapestry)
+---
+Tag: Siltsphere (The Tapestry)
+---
+Tag: Sosav's land (The Tapestry)
+---
+Tag: Sosav's room (The Tapestry)
+---
+Tag: Swiftstar (The Tapestry)
+---
+Tag: Transient Lance (The Tapestry)
+---
+Tag: Ventus (The Tapestry)
+
+# Object classifications
+
+---
+Tag: Objects from The Tapestry
+Direct Descendant Tags:
+- Foodstuffs (The Tapestry)
+- Game objects (The Tapestry)
+- Musical instruments (The Tapestry)
+- Vehicles (The Tapestry)
+- Weapons (The Tapestry)
+---
+Tag: Foodstuffs (The Tapestry)
+Direct Descendant Tags:
+- Bean Cube (The Tapestry)
+---
+Tag: Game objects (The Tapestry)
+Direct Descendant Tags:
+- Psycherefectory (The Tapestry)
+---
+Tag: Musical instruments (The Tapestry)
+Direct Descendant Tags:
+- Keyboard instruments (The Tapestry)
+---
+Tag: Keyboard instruments (The Tapestry)
+Direct Descendant Tags:
+- Wingchime (The Tapestry)
+---
+Tag: Vehicles (The Tapestry)
+Direct Descendant Tags:
+- Amnsomniac Dropship (The Tapestry) # Monckat: "vehicle"
+- Amnsomniac Zeppelin (The Tapestry) # Monckat: "vehicle"
+- Hyphonese Rotary Rocket (The Tapestry) # Monckat: "spacecraft"
+---
+Tag: Weapons (The Tapestry)
+Direct Descendant Tags:
+- Railgun (The Tapestry)
+- Serrasword (The Tapestry)
+
+# Object entries
+
+---
+Tag: Amnsomniac Dropship (The Tapestry)
+---
+Tag: Amnsomniac Zeppelin (The Tapestry)
+---
+Tag: Bean Cube (The Tapestry)
+---
+Tag: Captcharoid Camera (The Tapestry)
+---
+Tag: Hyphonese Rotary Rocket (The Tapestry)
+---
+Tag: Psycherefectory (The Tapestry)
+---
+Tag: Railgun (The Tapestry)
+---
+Tag: Serrasword (The Tapestry)
+---
+Tag: Wingchime (The Tapestry)

--- a/art-tags/object-classifications.yaml
+++ b/art-tags/object-classifications.yaml
@@ -1,8 +1,19 @@
 Tag: Object classifications
 Direct Descendant Tags:
+- Foodstuffs
+- Game objects
 - General objects
 - Musical instruments
+- Vehicles
 - Weapons
+---
+Tag: Foodstuffs
+Direct Descendant Tags:
+- Foodstuffs (The Tapestry)
+---
+Tag: Game objects
+Direct Descendant Tags:
+- Game objects (The Tapestry)
 ---
 Tag: General objects
 Direct Descendant Tags:
@@ -28,12 +39,14 @@ Direct Descendant Tags:
 - Percussion instruments
 - Woodwind instruments
 - Musical instruments (Homestuck)
+- Musical instruments (The Tapestry)
 ---
 Tag: Keyboard instruments
 Direct Descendant Tags:
 - Keyboard
 - Piano
 - Organ
+- Keyboard instruments (The Tapestry)
 ---
 Tag: String instruments
 Direct Descendant Tags:
@@ -56,6 +69,11 @@ Direct Descendant Tags:
 Tag: Percussion instruments
 Direct Descendant Tags:
 - Marimba
+---
+Tag: Vehicles
+Direct Descendant Tags:
+- Vehicles (Homestuck)
+- Vehicles (The Tapestry)
 ---
 Tag: Weapons
 Direct Descendant Tags:

--- a/art-tags/species.yaml
+++ b/art-tags/species.yaml
@@ -67,6 +67,7 @@ Direct Descendant Tags:
 - Carapacians (Homestuck)
 - Carapacians (Desynced)
 - 'Carapacians (MIDNIGHT CREW: Beginning Of The End!)'
+- Carapacians (The Tapestry)
 - Carapacians (Vast Error)
 Extra Reading URLs:
 - https://mspaintadventures.fandom.com/wiki/Carapacian
@@ -156,6 +157,7 @@ Direct Descendant Tags:
 - Sprites (CaNWC)
 - Sprites (Homestuck)
 - Sprites (Redditstuck)
+- Sprites (The Tapestry)
 Extra Reading URLs:
 - https://mspaintadventures.fandom.com/wiki/Sprite
 ---

--- a/art-tags/standalone-iconography.yaml
+++ b/art-tags/standalone-iconography.yaml
@@ -1,3 +1,6 @@
+Tag: MSPFA Logo
+Color: '#01F61F'
+---
 Tag: Music Staff
 Color: '#FFFFFF'
 Extra Reading URLs:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -269,7 +269,9 @@ Content: |-
     <!-- background additions -->
     - added background to [[album:waiting-for-the-night-svix-mix]] (thanks, Jebb!)
     <!-- art tag additions -->
-    - added character tags: [[tag:ethan-adminstuck]], [[tag:jackson-adminstuck]], [[tag:jane-dave-janestuck]], [[tag:jane-jade-janestuck]], [[tag:jane-john-janestuck]], [[tag:jane-rose-janestuck]], [[tag:jane-roxy-janestuck]], [[tag:jordan-adminstuck]], [[tag:matt-adminstuck]] (thanks, Lan, Lilith!)
+    - added all-new tags for [[tag:adminstuck-media|Adminstuck]], [[tag:cheezquest-media|Cheezquest]], [[tag:janestuck-media|Janestuck]], [[tag:sbargv2-media|SBARGv2]], [[tag:the-tapestry-media|The Tapestry]] (thanks, <<Lan:review>>, <<Jebb:Cheezquest>>, <<Lilith:Adminstuck, Janestuck>>, <<wertercatt:SBARGv2>>, <<Monckat:The Tapestry>>!)
+    - added classification tags: [[tag:foodstuffs]], [[tag:game-objects]], [[tag:vehicles]] (thanks, Lan!)
+    - added tags for Homestuck: [[tag:prospitian-ship]] (thanks, Lan!)
     <!-- additional name additions -->
     - added additional names to tracks: (thanks, Lan, Jackie, Whisper, Lilith!)
         - [[track:squiddle-march]] and [[track:dord-waltz]] (SoundCloud)
@@ -362,6 +364,8 @@ Content: |-
         - [[track:another-noir]]: fixed track not crediting [[artist:cristata]] at all (now co-artist), and removed [[artist:cristata]] credit on the (mostly internal) album entry; other Cristata releases ([[album:are-you-lost]], [[album:cyber-city-sound-pak]]) aleady fit the new pattern
     <!-- structural or organizational changes for art tags -->
     - sorted tags which fall under various [[tag:location-classifications]], including [[tag:astronomical-bodies]] and [[tag:locations-in-the-medium]], alphabetically (thanks, Lan!)
+    - moved [[tag:reckoning]] tag from [[tag:more-objects-homestuck]], to [[tag:more-general-objects-homestuck]] (thanks, Lan!)
+    - moved [[tag:grist]], [[tag:queens-ring]], [[tag:red-miles]], and [[tag:tumor]] tags from [[tag:more-objects-homestuck]], to new tag [[tag:game-objects-homestuck]] (thanks, Lan!)
     - moved [[tag:deer-desynced]] tag out of removed "Consorts (Desynced)" tag, now directly under [[tag:characters-from-desynced]] instead (thanks, Lan, Jebb!)
     - reorganized character tags under [[tag:undertale-and-deltarune-media]] across the board (thanks, ruby, Lan!)
     <!-- miscellaneous data changes -->


### PR DESCRIPTION
Loads of credits to Monckat and Jebb!

- [ ] Make sure Monckat's in the changelog for The Tapestry album additions, and credited for tagging
- [ ] Add "Supposed to be Icy GIrl" and [[S] Karkat: Boogie woogie.](https://www.youtube.com/watch?v=D7VRdhC9Fdc) (to RBH and KGTAC), and fill that reference in MSPFA Theme Fragment
- [ ] Colorize at least the rest of the character tags, hopefully all object tags, and ideally all (non-classification) location tags
    - Adjust low-contrast character colors (they're just the ones we were given atm)
    - Pass everything back to Monckat for color review
- [ ] Correct 'The God We Will Become' -> 'The One We Will Become', if we haven't yet
- [ ] Move 'Captcharoid Camera' out of The Tapestry and into Homestuck
    - This is a new Homestuck tag, note as much in the changelog
    - It's not actually networked at all yet, don't freak out
- [ ] Freak out over 'Trolls' meteor' being an object (in addition to location) now