### PR TITLE
UTDR & Pokémon JP titles

### DIFF
--- a/album/deltarune-ch1-ost.yaml
+++ b/album/deltarune-ch1-ost.yaml
@@ -1,4 +1,9 @@
 Album: DELTARUNE Chapter 1 OST
+Additional Names:
+- Name: >-
+    UNDERTALE DELTARUNE Chapter 1 オリジナルサウンドトラック
+  Annotation: >-
+    [Japanese release (YouTube Music)](https://music.youtube.com/playlist?list=OLAK5uy_kdJzrU7aXtEuAs4fkqCHwm5RPSPTg4sSY)
 Directory: deltarune-ch1-ost
 Suffix Track Directories: true
 Directory Suffix: ch1
@@ -28,6 +33,11 @@ Wallpaper Style: |-
 Wallpaper File Extension: png
 ---
 Track: ANOTHER HIM
+Additional Names:
+- Name: >-
+    もうひとりの彼
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:48
 URLs:
@@ -36,6 +46,11 @@ URLs:
 - https://open.spotify.com/track/63K6koyn1kUIXj4soQ9wNl
 ---
 Track: Beginning
+Additional Names:
+- Name: >-
+    BEGINNING
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:57
 URLs:
@@ -44,6 +59,11 @@ URLs:
 - https://open.spotify.com/track/5NiD264RGry4WmWRRAZ0uN
 ---
 Track: School
+Additional Names:
+- Name: >-
+    学校
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:20
 URLs:
@@ -52,6 +72,11 @@ URLs:
 - https://open.spotify.com/track/1xIYcuzRrYEfMkh7CjSKoF
 ---
 Track: Susie
+Additional Names:
+- Name: >-
+    スージィ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:27
 URLs:
@@ -60,6 +85,11 @@ URLs:
 - https://open.spotify.com/track/72tN7vUHvkke6lUwCb2lDy
 ---
 Track: The Door
+Additional Names:
+- Name: >-
+    とびら
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:41
 URLs:
@@ -68,6 +98,11 @@ URLs:
 - https://open.spotify.com/track/0r1IrLoXomZ3JFSd4Khp1h
 ---
 Track: Cliffs
+Additional Names:
+- Name: >-
+    絶壁
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:35
 URLs:
@@ -76,6 +111,11 @@ URLs:
 - https://open.spotify.com/track/5PiPRr9KGpqWW12Kwq3FsV
 ---
 Track: The Chase
+Additional Names:
+- Name: >-
+    追跡
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:33
 URLs:
@@ -84,6 +124,11 @@ URLs:
 - https://open.spotify.com/track/1PnxSUmMmpIDWWBhMEY56C
 ---
 Track: The Legend
+Additional Names:
+- Name: >-
+    伝説
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: track:the-legend
 Duration: 1:51
 URLs:
@@ -92,6 +137,15 @@ URLs:
 - https://open.spotify.com/track/1ZA8wuVp91YbS1uif1hyYR
 ---
 Track: Lancer
+Additional Names:
+- Name: >-
+    I'm The Bad Guy!
+  Annotation: >-
+    In-game
+- Name: >-
+    ボクさま、ランサー！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:48
 URLs:
@@ -100,6 +154,11 @@ URLs:
 - https://open.spotify.com/track/2uE9ZTSf2wJINqCHOrV6a0
 ---
 Track: Rude Buster
+Additional Names:
+- Name: >-
+    ルードバスター
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:15
 URLs:
@@ -108,6 +167,11 @@ URLs:
 - https://open.spotify.com/track/322mgWaD4DetiHmoDVlwWc
 ---
 Track: Empty Town
+Additional Names:
+- Name: >-
+    誰もいない町
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:23
 URLs:
@@ -116,6 +180,11 @@ URLs:
 - https://open.spotify.com/track/6Z9eoMfegGE6pQc9Toawnd
 ---
 Track: Weird Birds
+Additional Names:
+- Name: >-
+    不思議な鳥たち
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:16
 URLs:
@@ -124,6 +193,15 @@ URLs:
 - https://open.spotify.com/track/3XFaNF6EbDJdSr3InmAxJO
 ---
 Track: Field of Hopes and Dreams
+Additional Names:
+- Name: >-
+    The Field of Hopes and Dreams
+  Annotation: >-
+    In-game
+- Name: >-
+    夢と希望の平原
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:41
 URLs:
@@ -132,6 +210,11 @@ URLs:
 - https://open.spotify.com/track/2W90IO8eRnFg1qsPunKm9B
 ---
 Track: Fanfare (from Rose of Winter)
+Additional Names:
+- Name: >-
+    ファンファーレ （『Rose of Winter』より）
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:15
 URLs:
@@ -140,6 +223,11 @@ URLs:
 - https://open.spotify.com/track/1r3DdJ79HTJ2V62OipRyoC
 ---
 Track: Lantern
+Additional Names:
+- Name: >-
+    灯火
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:08
 URLs:
@@ -148,6 +236,11 @@ URLs:
 - https://open.spotify.com/track/0fBXFpNA9Movn5G2WHPgbM
 ---
 Track: I'm Very Bad
+Additional Names:
+- Name: >-
+    ボクさま、悪モノ！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:13
 URLs:
@@ -156,6 +249,11 @@ URLs:
 - https://open.spotify.com/track/6actYECaeFH1vOyOUCvTT9
 ---
 Track: Checker Dance
+Additional Names:
+- Name: >-
+    チェッカーダンス
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:18
 URLs:
@@ -164,6 +262,11 @@ URLs:
 - https://open.spotify.com/track/6p3ckEGHB7tIiBmHLWZlVf
 ---
 Track: Quiet Autumn
+Additional Names:
+- Name: >-
+    やすらぎの秋
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:49
 URLs:
@@ -172,6 +275,11 @@ URLs:
 - https://open.spotify.com/track/6jNxEc8nmpFBj3Pje7BVbx
 ---
 Track: Scarlet Forest
+Additional Names:
+- Name: >-
+    紅の森
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:08
 URLs:
@@ -180,6 +288,11 @@ URLs:
 - https://open.spotify.com/track/4zLEqCe2KCWBJLKN3RyWAG
 ---
 Track: Thrash Machine
+Additional Names:
+- Name: >-
+    ボコリングマシン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:54
 URLs:
@@ -188,6 +301,11 @@ URLs:
 - https://open.spotify.com/track/2gafFAtDIGgDQLiEpRokIx
 ---
 Track: Vs. Lancer
+Additional Names:
+- Name: >-
+    ランサー戦
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:42
 URLs:
@@ -196,6 +314,11 @@ URLs:
 - https://open.spotify.com/track/2LsYIw2gn24nkzgwA2g4gw
 ---
 Track: Basement
+Additional Names:
+- Name: >-
+    地下牢
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:27
 URLs:
@@ -204,6 +327,11 @@ URLs:
 - https://open.spotify.com/track/1XfSpjUBuZwrNUDV8AbYpZ
 ---
 Track: Imminent Death
+Additional Names:
+- Name: >-
+    死の警報
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:20
 URLs:
@@ -212,6 +340,11 @@ URLs:
 - https://open.spotify.com/track/1aSimBo97eJ6bHr5vrpoKd
 ---
 Track: Vs. Susie
+Additional Names:
+- Name: >-
+    スージィ戦
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:21
 URLs:
@@ -220,6 +353,11 @@ URLs:
 - https://open.spotify.com/track/5ydKiJ69LWOzfSya9ojhE4
 ---
 Track: Card Castle
+Additional Names:
+- Name: >-
+    カルタス城
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:01
 URLs:
@@ -228,6 +366,11 @@ URLs:
 - https://open.spotify.com/track/6JuC5mhOzqPt8lEGfQJQ05
 ---
 Track: Rouxls Kaard
+Additional Names:
+- Name: >-
+    ルールノー・カァドー
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:19
 URLs:
@@ -244,6 +387,11 @@ URLs:
 - https://open.spotify.com/track/0HuvIX3Jul87KRTOGpGr9P
 ---
 Track: Hip Shop
+Additional Names:
+- Name: >-
+    プリティショップ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:39
 URLs:
@@ -252,6 +400,11 @@ URLs:
 - https://open.spotify.com/track/2ASkgao4Nv7FtY9AjASDNQ
 ---
 Track: Gallery
+Additional Names:
+- Name: >-
+    ギャラリー
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:12
 URLs:
@@ -260,6 +413,11 @@ URLs:
 - https://open.spotify.com/track/5zDC9xOmwH1yb7KttqbaDH
 ---
 Track: Chaos King
+Additional Names:
+- Name: >-
+    カオスの王
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:46
 URLs:
@@ -268,6 +426,11 @@ URLs:
 - https://open.spotify.com/track/5Y8awVkb5cXvlDyH1kIXaN
 ---
 Track: Darkness Falls
+Additional Names:
+- Name: >-
+    闇の降るとき
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:06
 URLs:
@@ -276,6 +439,11 @@ URLs:
 - https://open.spotify.com/track/1eodgnlUYiH3s0q99vk18p
 ---
 Track: The Circus
+Additional Names:
+- Name: >-
+    サーカス
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:51
 URLs:
@@ -292,6 +460,11 @@ URLs:
 - https://open.spotify.com/track/5QBozbgRWIYDSriHCRTsXd
 ---
 Track: Friendship
+Additional Names:
+- Name: >-
+    みんな友だち
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:40
 URLs:
@@ -308,6 +481,11 @@ URLs:
 - https://open.spotify.com/track/2DORTEXJd9o5Gdhr57M5yC
 ---
 Track: Your Power
+Additional Names:
+- Name: >-
+    キミの力
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:13
 URLs:
@@ -316,6 +494,11 @@ URLs:
 - https://open.spotify.com/track/4eLHWCv6pLrxvpKomdGx5w
 ---
 Track: A Town Called Hometown
+Additional Names:
+- Name: >-
+    「ホームタウン」という名の町
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:53
 URLs:
@@ -324,6 +507,11 @@ URLs:
 - https://open.spotify.com/track/1He6isaU9SoB6GzIM2lx6Z
 ---
 Track: You Can Always Come Home
+Additional Names:
+- Name: >-
+    いつでも帰れる場所
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:40
 URLs:
@@ -342,6 +530,11 @@ URLs:
 - https://open.spotify.com/track/7y6NbGuLZuNW0lVaPnYx22
 ---
 Track: Before the Story
+Additional Names:
+- Name: >-
+    はじまりの前
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-1-ost)
 Main Release: UNDERTALE Collector's Edition Soundtrack
 Duration: 1:28
 URLs:

--- a/album/deltarune-ch1-ost.yaml
+++ b/album/deltarune-ch1-ost.yaml
@@ -141,7 +141,7 @@ Additional Names:
 - Name: >-
     I'm The Bad Guy!
   Annotation: >-
-    In-game
+    in-game
 - Name: >-
     ボクさま、ランサー！
   Annotation: >-
@@ -197,7 +197,7 @@ Additional Names:
 - Name: >-
     The Field of Hopes and Dreams
   Annotation: >-
-    In-game
+    in-game
 - Name: >-
     夢と希望の平原
   Annotation: >-
@@ -211,6 +211,10 @@ URLs:
 ---
 Track: Fanfare (from Rose of Winter)
 Additional Names:
+- Name: >-
+    Fanfare (from "Rose of Winter")
+  Annotation: >-
+    digital music platforms
 - Name: >-
     ファンファーレ （『Rose of Winter』より）
   Annotation: >-

--- a/album/deltarune-ch2-ost.yaml
+++ b/album/deltarune-ch2-ost.yaml
@@ -30,6 +30,11 @@ Wallpaper File Extension: png
 Section: Main album
 ---
 Track: Faint Glow
+Additional Names:
+- Name: >-
+    ほのかな光
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:17
 URLs:
@@ -38,6 +43,11 @@ URLs:
 - https://open.spotify.com/track/0wntsmQSoI55KsAD56KEAq
 ---
 Track: Girl Next Door
+Additional Names:
+- Name: >-
+    となりのあのコ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:54
 URLs:
@@ -46,6 +56,15 @@ URLs:
 - https://open.spotify.com/track/3elKCP0PpuipOtLn7K8FXT
 ---
 Track: My Castle Town
+Additional Names:
+- Name: >-
+    My Castle
+  Annotation: >-
+    in-game
+- Name: >-
+    マイ キャッスルタウン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:07
 URLs:
@@ -54,6 +73,11 @@ URLs:
 - https://open.spotify.com/track/6g0y8cpi8c9eCPfz5XvW5T
 ---
 Track: Ohhhhohohoho!
+Additional Names:
+- Name: >-
+    オーッホホホホ！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:09
 URLs:
@@ -62,6 +86,11 @@ URLs:
 - https://open.spotify.com/track/2rZU9qk1HWqWrKA7BKOWyy
 ---
 Track: Queen
+Additional Names:
+- Name: >-
+    クイーン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:56
 URLs:
@@ -70,6 +99,11 @@ URLs:
 - https://open.spotify.com/track/4fXX61n4gV1yfPbAdDmdcz
 ---
 Track: A CYBER'S WORLD?
+Additional Names:
+- Name: >-
+    CYBER WORLD
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:46
 URLs:
@@ -78,6 +112,11 @@ URLs:
 - https://open.spotify.com/track/0BE2Lbu4GgcCT6kgB1tDTc
 ---
 Track: A Simple Diversion
+Additional Names:
+- Name: >-
+    子どもだましのツール
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:31
 URLs:
@@ -86,6 +125,11 @@ URLs:
 - https://open.spotify.com/track/7CaYooLVhBdkhRjSHrntgD
 ---
 Track: Almost To The Guys!
+Additional Names:
+- Name: >-
+    ヤツらに会える！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:17
 URLs:
@@ -94,6 +138,11 @@ URLs:
 - https://open.spotify.com/track/3nVfeoR3BDeBqZhkxZTwFp
 ---
 Track: Cool Beat
+Additional Names:
+- Name: >-
+    クールなビート
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:17
 URLs:
@@ -102,6 +151,11 @@ URLs:
 - https://open.spotify.com/track/1GDlWTtvFLS0ii1lNeG8lL
 ---
 Track: When I Get Mad I Dance Like This
+Additional Names:
+- Name: >-
+    アングリー ダンスバトル
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:10
 URLs:
@@ -110,6 +164,11 @@ URLs:
 - https://open.spotify.com/track/3eZk3GxGcwVDPa1xIK4Fnp
 ---
 Track: Cyber Battle (Solo)
+Additional Names:
+- Name: >-
+    サイバーバトル（ソロ）
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Artists:
 - Toby Fox
@@ -121,6 +180,11 @@ URLs:
 - https://open.spotify.com/track/6VpzCI5KbudaEYSKPNwzY1
 ---
 Track: When I Get Happy I Dance Like This
+Additional Names:
+- Name: >-
+    ハッピー ダンスバトル
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:19
 URLs:
@@ -129,6 +193,11 @@ URLs:
 - https://open.spotify.com/track/5ZBgN5tJHXUxQLv40xGe39
 ---
 Track: Sound Studio
+Additional Names:
+- Name: >-
+    サウンドスタジオ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:08
 URLs:
@@ -137,6 +206,11 @@ URLs:
 - https://open.spotify.com/track/51XshBkYoRNSL5iRQD1SJF
 ---
 Track: Berdly
+Additional Names:
+- Name: >-
+    バードリー
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:46
 URLs:
@@ -145,6 +219,11 @@ URLs:
 - https://open.spotify.com/track/3GtA0wC7ZV1LtiaKVcFARJ
 ---
 Track: Smart Race
+Additional Names:
+- Name: >-
+    IQチキンレース
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:06
 URLs:
@@ -153,6 +232,11 @@ URLs:
 - https://open.spotify.com/track/1GdTlOlPxxXhuA1Z4Tbf5H
 ---
 Track: Faint Courage (Game Over)
+Additional Names:
+- Name: >-
+    ほのかな勇気（ゲームオーバー）
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:52
 URLs:
@@ -161,6 +245,11 @@ URLs:
 - https://open.spotify.com/track/1RDnckI3aDh19h9TJAUm3N
 ---
 Track: WELCOME TO THE CITY
+Additional Names:
+- Name: >-
+    Welcome To The City
+  Annotation: >-
+    in-game
 Main Release: DELTARUNE Soundtrack
 Duration: 1:54
 URLs:
@@ -177,6 +266,11 @@ Commentary: |-
     (Note: the City is extremely small.)
 ---
 Track: Mini Studio
+Additional Names:
+- Name: >-
+    ミニスタジオ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:51
 URLs:
@@ -185,6 +279,11 @@ URLs:
 - https://open.spotify.com/track/2Y5yRdf42KyABdwUaafUgp
 ---
 Track: Holiday Studio
+Additional Names:
+- Name: >-
+    ホリデースタジオ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:08
 URLs:
@@ -193,6 +292,11 @@ URLs:
 - https://open.spotify.com/track/67ER6SEIRevkaLsLhJCVzZ
 ---
 Track: Cool Mixtape
+Additional Names:
+- Name: >-
+    イカしたミックステープ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:26
 URLs:
@@ -201,6 +305,11 @@ URLs:
 - https://open.spotify.com/track/5UDxDGERH44CfeecPnpPLY
 ---
 Track: HEY EVERY !
+Additional Names:
+- Name: >-
+    はい みなさn！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:18
 URLs:
@@ -209,6 +318,11 @@ URLs:
 - https://open.spotify.com/track/3FwU0oJcpuWnu0eECt65jC
 ---
 Track: Spamton
+Additional Names:
+- Name: >-
+    スパムトン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:42
 URLs:
@@ -217,6 +331,11 @@ URLs:
 - https://open.spotify.com/track/1dWgRROqpijnPVQS0LNJMf
 ---
 Track: NOW'S YOUR CHANCE TO BE A
+Additional Names:
+- Name: >-
+    いまがﾁｬｿｽ！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:07
 URLs:
@@ -225,6 +344,11 @@ URLs:
 - https://open.spotify.com/track/4RZCenPPiY28As8ZzeMYyv
 ---
 Track: Elegant Entrance
+Additional Names:
+- Name: >-
+    豪奢な館
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:18
 URLs:
@@ -233,6 +357,11 @@ URLs:
 - https://open.spotify.com/track/0v32fKwN5VpiZYEW9bwcmI
 ---
 Track: Bluebird of Misfortune
+Additional Names:
+- Name: >-
+    不幸せの青いトリ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:49
 URLs:
@@ -241,6 +370,11 @@ URLs:
 - https://open.spotify.com/track/3XfcINMr19vye9Imaazx0T
 ---
 Track: Pandora Palace
+Additional Names:
+- Name: >-
+    パンドラパレス
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:39
 URLs:
@@ -249,6 +383,11 @@ URLs:
 - https://open.spotify.com/track/7tNsMfItoswjCO5oOQgbBB
 ---
 Track: KEYGEN
+Additional Names:
+- Name: >-
+    キー生成キ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:15
 URLs:
@@ -257,6 +396,11 @@ URLs:
 - https://open.spotify.com/track/4GyPLAUgO1JdKe48giXBQo
 ---
 Track: Acid Tunnel of Love
+Additional Names:
+- Name: >-
+    愛の酸液川トンネル
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:30
 URLs:
@@ -265,6 +409,11 @@ URLs:
 - https://open.spotify.com/track/3M1Xiw8PplJsehXCUdlGi2
 ---
 Track: It's Pronounced "Rules"
+Additional Names:
+- Name: >-
+    ルールノー・ルール
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:01
 URLs:
@@ -293,6 +442,11 @@ Commentary: |-
     <video src="media/misc/lost-girl-alt.mp4" width="450" pixelate>
 ---
 Track: Ferris Wheel
+Additional Names:
+- Name: >-
+    観覧車に乗って
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:19
 URLs:
@@ -301,6 +455,11 @@ URLs:
 - https://open.spotify.com/track/7JGkl7TSwWcVlwtDuoHDLj
 ---
 Track: Attack of the Killer Queen
+Additional Names:
+- Name: >-
+    進撃のキラークイーン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Artists:
 - Toby Fox
@@ -313,6 +472,11 @@ URLs:
 - https://open.spotify.com/track/1K45maA9jDR1kBRpojtPmO
 ---
 Track: Giga Size
+Additional Names:
+- Name: >-
+    GIGA Size
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:47
 URLs:
@@ -321,6 +485,11 @@ URLs:
 - https://open.spotify.com/track/7gRPYFtMaq0KIOO7vIxCLd
 ---
 Track: Powers Combined
+Additional Names:
+- Name: >-
+    パワー合体！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:16
 URLs:
@@ -337,6 +506,11 @@ URLs:
 - https://open.spotify.com/track/7ARvBQv5g2gDmBGXM6VDCR
 ---
 Track: The Dark Truth
+Additional Names:
+- Name: >-
+    闇の真実
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:12
 URLs:
@@ -345,6 +519,11 @@ URLs:
 - https://open.spotify.com/track/49vU3wEaRNGzZIy1TATOlW
 ---
 Track: Digital Roots
+Additional Names:
+- Name: >-
+    デジタルルーツ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:33
 URLs:
@@ -353,6 +532,11 @@ URLs:
 - https://open.spotify.com/track/21JQ1y4y0tBSwSJv0zV9K7
 ---
 Track: Deal Gone Wrong
+Additional Names:
+- Name: >-
+    商談決裂
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:31
 URLs:
@@ -361,6 +545,11 @@ URLs:
 - https://open.spotify.com/track/6pZ84L82buMFjAqev002Tv
 ---
 Track: BIG SHOT
+Additional Names:
+- Name: >-
+    [[BIG]]の力
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:22
 URLs:
@@ -369,6 +558,11 @@ URLs:
 - https://open.spotify.com/track/2hpQl8ryv3IonCg9LiAtGT
 ---
 Track: A Real Boy!
+Additional Names:
+- Name: >-
+    ホンモノの男の子
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:15
 URLs:
@@ -377,6 +571,11 @@ URLs:
 - https://open.spotify.com/track/0LtRb6SfD9zAm1mZqfzsd1
 ---
 Track: Dialtone
+Additional Names:
+- Name: >-
+    黒電話
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:44
 URLs:
@@ -385,6 +584,11 @@ URLs:
 - https://open.spotify.com/track/5Z4bnMj3gxU2a07jaiRwzs
 ---
 Track: sans.
+Additional Names:
+- Name: >-
+    サンズ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: UNDERTALE Soundtrack
 Duration: 0:50
 URLs:
@@ -393,6 +597,11 @@ URLs:
 - https://open.spotify.com/track/3QrQeftqohPVWkqO0Dyj0u
 ---
 Track: Chill Jailbreak Alarm To Study And Relax To
+Additional Names:
+- Name: >-
+    ききながら べんきょうしたり マッタリしたりするのに ピッタリな だつごく けいほう
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:24
 URLs:
@@ -401,6 +610,11 @@ URLs:
 - https://open.spotify.com/track/3RhudFHKBLdUqcwTwRWSfm
 ---
 Track: You Can Always Come Home
+Additional Names:
+- Name: >-
+    いつでも帰れる場所
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Suffix Directory: false
 Directory: you-can-always-come-home-ch2-ch2
 Main Release: DELTARUNE Soundtrack
@@ -411,6 +625,11 @@ URLs:
 - https://open.spotify.com/track/2Rf33bpATyDiqTGm0NvlNb
 ---
 Track: Until Next Time
+Additional Names:
+- Name: >-
+    また会うときまで
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:02
 URLs:
@@ -419,6 +638,11 @@ URLs:
 - https://open.spotify.com/track/4O0JVgOSsdJrj6Tao1ViEY
 ---
 Track: Before The Story
+Additional Names:
+- Name: >-
+    はじまりの前
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Suffix Directory: false
 Directory: before-the-story-ch2-ch2
 Main Release: UNDERTALE Collector's Edition Soundtrack
@@ -431,6 +655,11 @@ URLs:
 Section: Bonus track
 ---
 Track: Berdly (Rejected Concept)
+Additional Names:
+- Name: >-
+    バードリー（没バージョン）
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapter-2-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:20
 URLs:

--- a/album/deltarune-ch2-rejected-tracks.yaml
+++ b/album/deltarune-ch2-rejected-tracks.yaml
@@ -1,4 +1,9 @@
 Album: CHAPTER 2 REJECTED TRACKS
+Additional Names:
+- Name: >-
+    『DELTARUNE Chapter 2』ボツ曲集
+  Annotation: >-
+    [Japanese version](https://toby.fangamer.jp/interviews/chapter2_music/)
 Directory: deltarune-ch2-rejected-tracks
 Has Track Numbers: false
 Artists:

--- a/album/deltarune-ch3-4-ost.yaml
+++ b/album/deltarune-ch3-4-ost.yaml
@@ -448,6 +448,11 @@ Section: 'Chapter 4: Prophecy'
 Color: '#3165ff'
 ---
 Track: Old wooden rafters
+Additional Names:
+- Name: >-
+    木造の古い天井
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:38
 URLs:
@@ -456,6 +461,11 @@ URLs:
 - https://open.spotify.com/track/0KqDYr4qjE4aQ4MdiYAHSu
 ---
 Track: Hymn
+Additional Names:
+- Name: >-
+    賛美歌
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:33
 URLs:
@@ -464,6 +474,11 @@ URLs:
 - https://open.spotify.com/track/0MyDcubBn6rtcYxqKA0k5f
 ---
 Track: Another day in hometown
+Additional Names:
+- Name: >-
+    ある日のホームタウン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:19
 URLs:
@@ -472,6 +487,11 @@ URLs:
 - https://open.spotify.com/track/7ttAYAA9xgN9X2pKgE6D2w
 ---
 Track: Friends
+Additional Names:
+- Name: >-
+    ダチ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:25
 URLs:
@@ -480,6 +500,11 @@ URLs:
 - https://open.spotify.com/track/42gE8OCT3DiFUg6F6heHKL
 ---
 Track: Castle Funk
+Additional Names:
+- Name: >-
+    キャッスルファンク
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:56
 URLs:
@@ -488,6 +513,11 @@ URLs:
 - https://open.spotify.com/track/580rGEvaWqalvq6sXo7qcI
 ---
 Track: Knock You Down!! (Rhythm Ver.)
+Additional Names:
+- Name: >-
+    Knock You Down!! (Minigame Ver.)
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:17
 URLs:
@@ -496,6 +526,11 @@ URLs:
 - https://open.spotify.com/track/12W8e5qsinrzV6vhqN3wWl
 ---
 Track: Gingerbread House
+Additional Names:
+- Name: >-
+    ホリデーハウス
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:27
 URLs:
@@ -504,6 +539,11 @@ URLs:
 - https://open.spotify.com/track/55JVCXdcI0FpG1XfVK7QH6
 ---
 Track: The distance between two
+Additional Names:
+- Name: >-
+    ふたりの距離
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:42
 URLs:
@@ -528,6 +568,11 @@ URLs:
 - https://open.spotify.com/track/34J8FvGXDEittDb6CpV1Qs
 ---
 Track: Dark Sanctuary
+Additional Names:
+- Name: >-
+    闇の聖域
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:46
 URLs:
@@ -544,6 +589,11 @@ URLs:
 - https://open.spotify.com/track/4Hjl9fN4GFjwumSSwzfnoF
 ---
 Track: Gyaa Ha ha!
+Additional Names:
+- Name: >-
+    ガーッハッハ！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Artists:
 - Toby Fox (composer)
@@ -555,6 +605,11 @@ URLs:
 - https://open.spotify.com/track/6gecazaYAnbY23qNXXmgb2
 ---
 Track: Fireplace
+Additional Names:
+- Name: >-
+    暖炉
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:37
 URLs:
@@ -563,6 +618,11 @@ URLs:
 - https://open.spotify.com/track/2L5nTpQVL0uAOC3D9EAgOo
 ---
 Track: A DARK ZONE
+Additional Names:
+- Name: >-
+    ダークゾーン
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:18
 URLs:
@@ -571,6 +631,11 @@ URLs:
 - https://open.spotify.com/track/4xWndE8mpwxptsiImg8NML
 ---
 Track: Mysterious Ringing
+Additional Names:
+- Name: >-
+    怪しい鐘の音
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:22
 URLs:
@@ -579,6 +644,11 @@ URLs:
 - https://open.spotify.com/track/6ryg7xffWWiM2k3vSaeovv
 ---
 Track: Ever Higher
+Additional Names:
+- Name: >-
+    さらなる高みへ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:27
 URLs:
@@ -587,6 +657,11 @@ URLs:
 - https://open.spotify.com/track/50vzjXBvI9LqWoH8rS7Ngs
 ---
 Track: Wise words
+Additional Names:
+- Name: >-
+    金言
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:42
 URLs:
@@ -595,6 +670,11 @@ URLs:
 - https://open.spotify.com/track/3G8frZE57AjViNcrFSgJVS
 ---
 Track: Piano that may not be played that well
+Additional Names:
+- Name: >-
+    あまりじょうずじゃないかもしれないピアノ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:42
 URLs:
@@ -606,6 +686,11 @@ Section: Chapter 4 hidden track
 Color: '#3165ff'
 ---
 Track: Hammer of Justice
+Additional Names:
+- Name: >-
+    正義の鉄槌
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:13
 URLs:
@@ -624,6 +709,11 @@ URLs:
 - https://open.spotify.com/track/4UKmADVuX37678FmIkWNec
 ---
 Track: The Second Sanctuary
+Additional Names:
+- Name: >-
+    第2の聖域
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:46
 URLs:
@@ -632,6 +722,11 @@ URLs:
 - https://open.spotify.com/track/4bmMBMIm6E5QkMcVxl98q9
 ---
 Track: Ripple
+Additional Names:
+- Name: >-
+    さざ波
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:31
 URLs:
@@ -648,6 +743,11 @@ URLs:
 - https://open.spotify.com/track/2j6z4O5sYkXzF73s2fYNMM
 ---
 Track: The Third Sanctuary
+Additional Names:
+- Name: >-
+    第3の聖域
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 4:07
 URLs:
@@ -664,6 +764,11 @@ URLs:
 - https://open.spotify.com/track/2BH3agU3rF9fUAyXHygvvi
 ---
 Track: Heavy Footsteps
+Additional Names:
+- Name: >-
+    迫る足音
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:38
 URLs:
@@ -672,6 +777,11 @@ URLs:
 - https://open.spotify.com/track/3P4gWy7Xs7fqmWIIx1wlyU
 ---
 Track: Crumbling Tower
+Additional Names:
+- Name: >-
+    崩れる塔
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:49
 URLs:
@@ -696,6 +806,11 @@ URLs:
 - https://open.spotify.com/track/6KJL2lAVwFQyuZx9UhJvPo
 ---
 Track: Need a hand!?
+Additional Names:
+- Name: >-
+    助っ人参上
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:46
 URLs:
@@ -704,6 +819,11 @@ URLs:
 - https://open.spotify.com/track/0TKD1A2DMx30e70scvLZBC
 ---
 Track: The place where it rained
+Additional Names:
+- Name: >-
+    雨が降った場所
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:52
 URLs:
@@ -712,6 +832,11 @@ URLs:
 - https://open.spotify.com/track/7dBppsBocHB0AhHbSe1G4L
 ---
 Track: The Ol’ Jitterbug
+Additional Names:
+- Name: >-
+    ダンシング・オールナイト
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:22
 URLs:
@@ -720,6 +845,11 @@ URLs:
 - https://open.spotify.com/track/13OOV33XXDkjmXcF5O4UMZ
 ---
 Track: Neverending Night
+Additional Names:
+- Name: >-
+    終わらない夜
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:39
 URLs:
@@ -728,6 +858,11 @@ URLs:
 - https://open.spotify.com/track/3VoY2M955hxgj9i6g3e5Yj
 ---
 Track: The LEGEND...?
+Additional Names:
+- Name: >-
+    伝説…？
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: track:the-legend-ch4
 Duration: 0:26
 URLs:
@@ -736,6 +871,11 @@ URLs:
 - https://open.spotify.com/track/4YKi7DleHSQLhO8dKws454
 ---
 Track: With Hope Crossed On Our Hearts
+Additional Names:
+- Name: >-
+    胸に希望を刻んで
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:39
 URLs:
@@ -747,6 +887,11 @@ Section: 'Chapter 4 hidden tracks'
 Color: '#3165ff'
 ---
 Track: Volume Adjustment
+Additional Names:
+- Name: >-
+    音量調整
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:36
 URLs:
@@ -754,6 +899,11 @@ URLs:
 - https://open.spotify.com/track/2HzSMVOrr9iIr0nUjIttuN
 ---
 Track: Catswing
+Additional Names:
+- Name: >-
+    キャットスイング
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:58
 URLs:
@@ -761,6 +911,11 @@ URLs:
 - https://open.spotify.com/track/3m5FpGqqw4Lu5jlPUx6YWr
 ---
 Track: AIRWAVES
+Additional Names:
+- Name: >-
+    エアウェーブ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: track:air-waves
 Duration: 2:00
 URLs:
@@ -768,6 +923,11 @@ URLs:
 - https://open.spotify.com/track/0M4R2a09Sru58lv4aW8nl0
 ---
 Track: Concert for you
+Additional Names:
+- Name: >-
+    キミのためのコンサート
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:02
 URLs:

--- a/album/deltarune-ch3-4-ost.yaml
+++ b/album/deltarune-ch3-4-ost.yaml
@@ -21,6 +21,11 @@ Groups:
 Section: 'Chapter 3: Late Night'
 ---
 Track: Flashback (Excerpt)
+Additional Names:
+- Name: >-
+    FLASHBACK
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:32
 URLs:
@@ -29,6 +34,11 @@ URLs:
 - https://open.spotify.com/track/5hsRssY21u2RnOzAaRPRPE
 ---
 Track: Feature Presentation
+Additional Names:
+- Name: >-
+    大変オマタセいたしました！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:42
 URLs:
@@ -37,6 +47,11 @@ URLs:
 - https://open.spotify.com/track/6tvpQrBDbIjbzgETc7FJAA
 ---
 Track: And Now For Today’s Sponsors…!
+Additional Names:
+- Name: >-
+    ご覧のスポンサーの提供でお送りします！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:31
 URLs:
@@ -45,6 +60,11 @@ URLs:
 - https://open.spotify.com/track/34ov2MLnX3jUhL5QeosFly
 ---
 Track: MIKE, the BOARD, please!
+Additional Names:
+- Name: >-
+    マイクく～ん！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:32
 URLs:
@@ -53,6 +73,11 @@ URLs:
 - https://open.spotify.com/track/2jGCOh2CyVs6fKWx6Mdqin
 ---
 Track: Sandy Board
+Additional Names:
+- Name: >-
+    SAND PARK
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:18
 URLs:
@@ -61,6 +86,11 @@ URLs:
 - https://open.spotify.com/track/1ibB9qEsHH6LdhZSCxUhtq
 ---
 Track: Adventure Board
+Additional Names:
+- Name: >-
+    ADVENTURE PARK
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:59
 URLs:
@@ -69,6 +99,11 @@ URLs:
 - https://open.spotify.com/track/77AbXWzEwS7xb2y0cQ1vKV
 ---
 Track: Query?
+Additional Names:
+- Name: >-
+    Question?
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:24
 URLs:
@@ -77,6 +112,11 @@ URLs:
 - https://open.spotify.com/track/0f3lbqBNjllwLhPpmPqoYH
 ---
 Track: Quiz!
+Additional Names:
+- Name: >-
+    問題です！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:16
 URLs:
@@ -85,6 +125,11 @@ URLs:
 - https://open.spotify.com/track/06MqXIRp3PBssVsdgQ2LmO
 ---
 Track: Dig! Dig! To The Center of the Earth!
+Additional Names:
+- Name: >-
+    ここ掘れ　ランラン！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:07
 URLs:
@@ -93,6 +138,11 @@ URLs:
 - https://open.spotify.com/track/7tXOPzioo1bTWpOe9XHcKz
 ---
 Track: Pushing Buddies
+Additional Names:
+- Name: >-
+    おしくらフレンズ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:19
 URLs:
@@ -101,6 +151,11 @@ URLs:
 - https://open.spotify.com/track/33tFlu3Zwzk0DuiqpqKvoc
 ---
 Track: Ruder Buster
+Additional Names:
+- Name: >-
+    スーパールードバスター
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:46
 URLs:
@@ -109,6 +164,11 @@ URLs:
 - https://open.spotify.com/track/1pzBe2vFkYc7RvieibXO8b
 ---
 Track: Physical Challenge
+Additional Names:
+- Name: >-
+    リアルチャレンジ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:47
 URLs:
@@ -117,6 +177,11 @@ URLs:
 - https://open.spotify.com/track/4zDUTFUluT3ptuXBUhqux5
 ---
 Track: Board Clear!
+Additional Names:
+- Name: >-
+    PARK CLEAR!
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:34
 URLs:
@@ -125,6 +190,11 @@ URLs:
 - https://open.spotify.com/track/4MOXjN5shJCZHjAtOoPTPN
 ---
 Track: Welcome to the Green Room
+Additional Names:
+- Name: >-
+    楽屋へ　ようこそ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:30
 URLs:
@@ -133,6 +203,11 @@ URLs:
 - https://open.spotify.com/track/4F9q9vdpzkA2OxuofEXxNf
 ---
 Track: Vapor Buster
+Additional Names:
+- Name: >-
+    ヴェイパーバスター
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:00
 URLs:
@@ -149,6 +224,11 @@ URLs:
 - https://open.spotify.com/track/59ZD83tA5CVrOT9fZmmTxS
 ---
 Track: Raft Ride
+Additional Names:
+- Name: >-
+    海の秘密
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:09
 URLs:
@@ -165,6 +245,11 @@ URLs:
 - https://open.spotify.com/track/126RQ9QDOI9vBdGxrO545m
 ---
 Track: Sound Check
+Additional Names:
+- Name: >-
+    サウンドチェック
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:25
 URLs:
@@ -173,6 +258,11 @@ URLs:
 - https://open.spotify.com/track/7mTVgwCZpAi2rxvsPtVAaj
 ---
 Track: Raise Up Your Bat
+Additional Names:
+- Name: >-
+    バットを振りかざせ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:13
 URLs:
@@ -189,6 +279,11 @@ URLs:
 - https://open.spotify.com/track/4rVYnz4PMR5k3LdGfbe7uW
 ---
 Track: Glowing Snow
+Additional Names:
+- Name: >-
+    雪嵐
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 2:22
 URLs:
@@ -197,6 +292,11 @@ URLs:
 - https://open.spotify.com/track/4hBKerIFw7vZ8Wj5RFf992
 ---
 Track: Big City Board
+Additional Names:
+- Name: >-
+    BIG CITY PARK
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 1:22
 URLs:
@@ -205,6 +305,11 @@ URLs:
 - https://open.spotify.com/track/5pRrR8C22MseJx8Z9jMNsW
 ---
 Track: Doom Board
+Additional Names:
+- Name: >-
+    EVIL PARK
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:52
 URLs:
@@ -213,6 +318,11 @@ URLs:
 - https://open.spotify.com/track/6Esifny7MfmbRssBmqSnyO
 ---
 Track: Metaphysical Challenge
+Additional Names:
+- Name: >-
+    リアルなチャレンジ
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:52
 URLs:
@@ -237,6 +347,11 @@ URLs:
 - https://open.spotify.com/track/3O9xF6nqYYtMjkuIutRYLP
 ---
 Track: Hall of Fame
+Additional Names:
+- Name: >-
+    殿堂入り！
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:30
 URLs:
@@ -261,6 +376,11 @@ URLs:
 - https://open.spotify.com/track/3TXV0txNTcLXCktESOcMuG
 ---
 Track: Crickets
+Additional Names:
+- Name: >-
+    虫の声
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:36
 URLs:
@@ -285,6 +405,11 @@ URLs:
 - https://open.spotify.com/track/2FuJAsTPVx9hIZOCdRbMPV
 ---
 Track: NORTHERNLIGHT
+Additional Names:
+- Name: >-
+    NORTH LIGHT
+  Annotation: >-
+    [Japanese release](https://tobyfoxjp.bandcamp.com/album/deltarune-chapters-3-4-ost)
 Main Release: DELTARUNE Soundtrack
 Duration: 0:23
 URLs:

--- a/album/deltarune-ch3-status-update.yaml
+++ b/album/deltarune-ch3-status-update.yaml
@@ -1,4 +1,9 @@
 Album: DELTARUNE Chapter 3 STATUS UPDATE
+Additional Names:
+- Name: >-
+    『DELTARUNE Chapter 3』開発進捗
+  Annotation: >-
+    [Japanese version](https://toby.fangamer.jp/newsletters/autumn23/)
 Directory: deltarune-ch3-status-update
 Directory Suffix: deltarune
 Has Track Numbers: false

--- a/album/deltarune-soundtrack.yaml
+++ b/album/deltarune-soundtrack.yaml
@@ -142,11 +142,6 @@ Referenced Tracks:
 ---
 Track: Fanfare (from Rose of Winter)
 Directory: fanfare-deltarune
-Additional Names:
-- Name: >-
-    Fanfare (from "Rose of Winter")
-  Annotation: >-
-    digital music platforms
 Duration: 0:15
 URLs:
 - https://tobyfox.bandcamp.com/track/fanfare-from-rose-of-winter

--- a/album/deltarune-status-update-sept-2022.yaml
+++ b/album/deltarune-status-update-sept-2022.yaml
@@ -1,4 +1,9 @@
 Album: DELTARUNE Status Update - Sept 2022
+Additional Names:
+- Name: >-
+    『DELTARUNE』開発進捗報告（2022年9月現在）
+  Annotation: >-
+    [Japanese version](https://deltarune.jp/update-092022/)
 Directory: deltarune-status-update-sept-2022
 Artists:
 - Toby Fox
@@ -19,6 +24,11 @@ Commentary: |-
     Why don't we show you what we've been working on!?
 ---
 Track: Hometown Day
+Additional Names:
+- Name: >-
+    ある日のホームタウン（仮）
+  Annotation: >-
+    [Japanese version](https://deltarune.jp/update-092022/)
 Main Release: Another day in hometown
 Duration: '2:19'
 URLs:
@@ -45,6 +55,11 @@ Commentary: |-
     ... and more?
 ---
 Track: My Funky Town
+Additional Names:
+- Name: >-
+    マイ　ファンキー　キャッスルタウン（仮）
+  Annotation: >-
+    [Japanese version](https://deltarune.jp/update-092022/)
 Duration: '1:24'
 URLs:
 - https://media.hsmusic.wiki/misc/deltarune-status-update-sept-2022/update2022-castle-funk.mp3
@@ -68,6 +83,11 @@ Commentary: |-
     More characters finally get their own rooms!
 ---
 Track: Green Room
+Additional Names:
+- Name: >-
+    グリーンルーム（仮）
+  Annotation: >-
+    [Japanese version](https://deltarune.jp/update-092022/)
 Duration: '0:45'
 URLs:
 - https://media.hsmusic.wiki/misc/deltarune-status-update-sept-2022/update2022-greenroom.mp3

--- a/album/pokemon-scarlet-violet-super-music-collection.yaml
+++ b/album/pokemon-scarlet-violet-super-music-collection.yaml
@@ -38,6 +38,8 @@ Start Counting From: 1
 Color: '#d5101e'
 ---
 Track: Welcome to Paldea
+Additional Names:
+- パルデア地方へようこそ！ (Japanese release)
 Duration: 2:13
 Artists:
 - Minako Adachi
@@ -48,6 +50,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Across the Skies of Paldea
+Additional Names:
+- パルデアの空を駆けて (Japanese release)
 Duration: 1:15
 Artists:
 - Go Ichinose
@@ -58,6 +62,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Home
+Additional Names:
+- 自宅 (Japanese release)
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 2:11
@@ -70,6 +76,8 @@ URLs:
 - https://www.youtube.com/watch?v=aWfJUCakY5g
 ---
 Track: Cabo Poco
+Additional Names:
+- コサジタウン (Japanese release)
 Duration: 1:56
 Artists:
 - Minako Adachi
@@ -80,6 +88,8 @@ Referenced Tracks:
 - track:home-pokemon-scarlet-violet
 ---
 Track: First Meeting
+Additional Names:
+- 出会い (Japanese release)
 Duration: 1:05
 Artists:
 - Hiromitsu Maeba
@@ -90,6 +100,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Becoming Stronger
+Additional Names:
+- 強さをめざして！ (Japanese release)
 Duration: 1:25
 Artists:
 - Hitomi Sato
@@ -98,6 +110,8 @@ URLs:
 - https://www.youtube.com/watch?v=dnriCo9MkCk
 ---
 Track: Battle! (Nemona)
+Additional Names:
+- 戦闘！ネモ (Japanese release)
 Duration: 2:12
 Artists:
 - Hitomi Sato
@@ -106,6 +120,8 @@ URLs:
 - https://www.youtube.com/watch?v=-BQBo66ir_Y
 ---
 Track: Obtained a Key Item!
+Additional Names:
+- 大切な道具を手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -116,6 +132,8 @@ Referenced Tracks:
 - Obtained a Pokémon (Pokémon Red / Pokémon Blue)
 ---
 Track: Poco Path
+Additional Names:
+- コサジの小道 (Japanese release)
 Duration: 2:19
 Artists:
 - Hitomi Sato
@@ -126,6 +144,8 @@ Referenced Tracks:
 - Cabo Poco
 ---
 Track: Battle! (Wild Pokémon)
+Additional Names:
+- 戦闘！野生ポケモン (Japanese release)
 Suffix Directory: true
 Duration: 2:50
 Artists:
@@ -137,6 +157,8 @@ URLs:
 - https://www.youtube.com/watch?v=S0bz0QVZ3j0
 ---
 Track: Victory! (Wild Pokémon)
+Additional Names:
+- 野生ポケモンに勝利！ (Japanese release)
 Suffix Directory: true
 Duration: 0:05
 Artists:
@@ -147,6 +169,8 @@ Referenced Tracks:
 - track:battle-wild-pokemon-pokemon-scarlet-violet
 ---
 Track: Obtained a Berry!
+Additional Names:
+- きのみを手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -157,6 +181,8 @@ Referenced Tracks:
 - Obtained a Berry! (Pokémon Ruby / Pokémon Sapphire)
 ---
 Track: Obtained an Item!
+Additional Names:
+- 道具を手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -167,6 +193,8 @@ URLs:
 - https://www.youtube.com/watch?v=-JQYrOnpyr4
 ---
 Track: By the Shore
+Additional Names:
+- 浜辺で (Japanese release)
 Duration: 0:31
 Artists:
 - Hiromitsu Maeba
@@ -178,6 +206,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Going through the Inlet Grotto
+Additional Names:
+- 入り江のほら穴を進む (Japanese release)
 Duration: 2:36
 Artists:
 - Hiromitsu Maeba
@@ -186,6 +216,8 @@ URLs:
 - https://www.youtube.com/watch?v=5PD1mgon5Ww
 ---
 Track: Battle in the Grotto
+Additional Names:
+- ほら穴での戦闘 (Japanese release)
 Duration: 2:36
 Artists:
 - Hiromitsu Maeba
@@ -196,6 +228,8 @@ Referenced Tracks:
 - Going through the Inlet Grotto
 ---
 Track: Escape from the Cave
+Additional Names:
+- 洞窟を脱出！ (Japanese release)
 Duration: 1:26
 Artists:
 - Hiromitsu Maeba
@@ -207,6 +241,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: A Test of Strength
+Additional Names:
+- 力試しだ！ (Japanese release)
 Duration: 1:21
 Artists:
 - Hiromitsu Maeba
@@ -215,6 +251,8 @@ URLs:
 - https://www.youtube.com/watch?v=uW9OajNcEfU
 ---
 Track: Battle! (Arven)
+Additional Names:
+- 戦闘！ペパー (Japanese release)
 Duration: 3:22
 Artists:
 - Go Ichinose
@@ -223,6 +261,8 @@ URLs:
 - https://www.youtube.com/watch?v=13jWvUj6w_c
 ---
 Track: South Province
+Additional Names:
+- 南エリア (Japanese release)
 Duration: 3:13
 Artists:
 - Minako Adachi
@@ -233,6 +273,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Battle! (South Province Wild Pokémon)
+Additional Names:
+- 戦闘！南の野生ポケモン (Japanese release)
 Duration: 2:47
 Artists:
 - Minako Adachi
@@ -243,6 +285,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: You Caught a Pokémon!
+Additional Names:
+- ポケモンを捕まえた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -253,6 +297,8 @@ Referenced Tracks:
 - Pokémon Caught (Pokémon Red / Pokémon Blue)
 ---
 Track: Pokémon Center
+Additional Names:
+- ポケモンセンター (Japanese release)
 Suffix Directory: true
 Duration: 2:43
 Artists:
@@ -264,6 +310,8 @@ Referenced Tracks:
 - Pokémon Center (Pokémon Red / Pokémon Blue)
 ---
 Track: Pokémon Healed
+Additional Names:
+- 回復 (Japanese release)
 Suffix Directory: true
 Duration: 0:06
 Artists:
@@ -275,6 +323,8 @@ Referenced Tracks:
 - Recovery (Pokémon Red / Pokémon Blue)
 ---
 Track: Happy Birthday!
+Additional Names:
+- お誕生日おめでとう！ (Japanese release)
 Duration: 0:11
 Artists:
 - Hitomi Sato
@@ -283,6 +333,8 @@ URLs:
 - https://www.youtube.com/watch?v=bhnK60Xi-AQ
 ---
 Track: Los Platos
+Additional Names:
+- プラトタウン (Japanese release)
 Duration: 2:54
 Artists:
 - Hitomi Sato
@@ -293,6 +345,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: A Stroll through the South Province
+Additional Names:
+- 南エリアを歩く (Japanese release)
 Duration: 2:54
 Artists:
 - Hitomi Sato
@@ -303,6 +357,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Mesagoza
+Additional Names:
+- テーブルシティ (Japanese release)
 Duration: 2:30
 Artists:
 - Minako Adachi
@@ -313,6 +369,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: A Tune at Mesagoza
+Additional Names:
+- テーブルシティで１曲どうぞ (Japanese release)
 Duration: 2:30
 Artists:
 - Minako Adachi
@@ -323,6 +381,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Team Star
+Additional Names:
+- スター団！ (Japanese release)
 Duration: 1:48
 Artists:
 - Teruo Taniguchi
@@ -331,6 +391,8 @@ URLs:
 - https://www.youtube.com/watch?v=U0lOYIkL5ro
 ---
 Track: Battle! (Team Star)
+Additional Names:
+- 戦闘！スター団 (Japanese release)
 Duration: 3:55
 Artists:
 - Teruo Taniguchi
@@ -341,6 +403,8 @@ Referenced Tracks:
 - Team Star
 ---
 Track: The Academy
+Additional Names:
+- アカデミー (Japanese release)
 Duration: 2:30
 Artists:
 - Minako Adachi (arranger)
@@ -355,6 +419,8 @@ Commentary: |-
     I also composed a majestic theme melody for the song "Academy". Surprisingly, this ended up used as a field theme for the whole game! Though, all songs using the melody were made by other amazing composers. (I love [[track:a-stroll-through-the-south-province|the soft piano version]] that plays at night.) Anyhow, that's all I did!
 ---
 Track: A Call from Cassiopeia
+Additional Names:
+- カシオペアからの電話 (Japanese release)
 Duration: 1:28
 Artists:
 - Hiromitsu Maeba
@@ -363,6 +429,8 @@ URLs:
 - https://www.youtube.com/watch?v=0LCPwH3iNpc
 ---
 Track: Professor Sada / Professor Turo
+Additional Names:
+- オーリム博士・フトゥー博士 (Japanese release)
 Duration: 1:27
 Artists:
 - Minako Adachi
@@ -371,6 +439,8 @@ URLs:
 - https://www.youtube.com/watch?v=ClHYHd6f-DI
 ---
 Track: Your Dorm Room
+Additional Names:
+- アカデミー・自分の部屋 (Japanese release)
 Duration: 2:30
 Artists:
 - Minako Adachi
@@ -381,6 +451,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: A Short Rest
+Additional Names:
+- ひとやすみ (Japanese release)
 Suffix Directory: true
 Duration: 0:06
 Artists:
@@ -392,6 +464,8 @@ Referenced Tracks:
 - Pokémon Healed (Pokémon Red / Pokémon Blue)
 ---
 Track: Starting the Treasure Hunt!
+Additional Names:
+- 宝探しスタート！ (Japanese release)
 Duration: 0:09
 Artists:
 - Hitomi Sato
@@ -400,6 +474,8 @@ URLs:
 - https://www.youtube.com/watch?v=Fats_yOZLAs
 ---
 Track: Trainers' Eyes Meet (Trainer)
+Additional Names:
+- 視線！トレーナー (Japanese release)
 Suffix Directory: true
 Duration: 0:17
 Artists:
@@ -411,6 +487,8 @@ Referenced Tracks:
 - track:battle-trainer-pokemon-scarlet-violet
 ---
 Track: Battle! (Trainer)
+Additional Names:
+- 戦闘！トレーナー (Japanese release)
 Suffix Directory: true
 Duration: 2:56
 Artists:
@@ -422,6 +500,8 @@ URLs:
 - https://www.youtube.com/watch?v=lxT27YJ1YNc
 ---
 Track: Victory! (Trainer)
+Additional Names:
+- トレーナーに勝利！ (Japanese release)
 Suffix Directory: true
 Duration: 0:31
 Artists:
@@ -433,6 +513,8 @@ Referenced Tracks:
 - track:victory-trainer-battle-pokemon-red-blue
 ---
 Track: Level Up!
+Additional Names:
+- レベルがあがった！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -443,6 +525,8 @@ Referenced Tracks:
 - track:obtained-an-item-pokemon-red-blue
 ---
 Track: Let's Make a Sandwich!
+Additional Names:
+- サンドウィッチを作ろう！ (Japanese release)
 Duration: 1:45
 Artists:
 - Hitomi Sato
@@ -451,6 +535,8 @@ URLs:
 - https://www.youtube.com/watch?v=WH_WniRbq0A
 ---
 Track: Time to Eat
+Additional Names:
+- いただきます (Japanese release)
 Duration: 1:45
 Artists:
 - Hitomi Sato
@@ -461,6 +547,8 @@ Referenced Tracks:
 - Let's Make a Sandwich!
 ---
 Track: A Super Delicious Sandwich
+Additional Names:
+- 食事・めっちゃおいしい！ (Japanese release)
 Duration: 0:05
 Artists:
 - Hitomi Sato
@@ -469,6 +557,8 @@ URLs:
 - https://www.youtube.com/watch?v=XpxZsS7j3eE
 ---
 Track: A Pretty Delicious Sandwich
+Additional Names:
+- 食事・なかなかおいしい！ (Japanese release)
 Duration: 0:04
 Artists:
 - Hitomi Sato
@@ -477,6 +567,8 @@ URLs:
 - https://www.youtube.com/watch?v=flva3Pq2Kuw
 ---
 Track: A Good Sandwich
+Additional Names:
+- 食事・ふつうにおいしい！ (Japanese release)
 Duration: 0:04
 Artists:
 - Hitomi Sato
@@ -485,6 +577,8 @@ URLs:
 - https://www.youtube.com/watch?v=bXw51g-FY20
 ---
 Track: A Not-So-Good Sandwich
+Additional Names:
+- 食事・おいしく……ないかも (Japanese release)
 Duration: 0:04
 Artists:
 - Hitomi Sato
@@ -493,6 +587,8 @@ URLs:
 - https://www.youtube.com/watch?v=AG-7yxzTmns
 ---
 Track: Obtained an Egg!
+Additional Names:
+- 食事・おいしく……ないかも (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -503,6 +599,8 @@ Referenced Tracks:
 - Received a Pokémon Egg! (Pokémon Gold / Pokémon Silver)
 ---
 Track: Evolution
+Additional Names:
+- 進化 (Japanese release)
 Suffix Directory: true
 Duration: 0:33
 Artists:
@@ -514,6 +612,8 @@ Referenced Tracks:
 - Evolution (Pokémon Red / Pokémon Blue)
 ---
 Track: Congratulations! Your Pokémon Evolved!
+Additional Names:
+- 進化おめでとう！ (Japanese release)
 Suffix Directory: true
 Duration: 0:05
 Artists:
@@ -528,6 +628,8 @@ Start Counting From: 1
 Color: '#bc4cb4'
 ---
 Track: Gym Reception
+Additional Names:
+- ジム受付 (Japanese release)
 Duration: 1:20
 Artists:
 - Minako Adachi
@@ -538,6 +640,8 @@ Referenced Tracks:
 - Gym Test
 ---
 Track: Gym Test
+Additional Names:
+- ジムテスト (Japanese release)
 Duration: 1:20
 Artists:
 - Minako Adachi
@@ -548,6 +652,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: Passed the Gym Test!
+Additional Names:
+- ジムテストに合格！ (Japanese release)
 Duration: 0:06
 Artists:
 - Hiromitsu Maeba
@@ -558,6 +664,8 @@ Referenced Tracks:
 - Battle & Victory! (Gym Leader)
 ---
 Track: Battle & Victory! (Gym Leader)
+Additional Names:
+- 戦闘！ジムリーダー～ジムリーダーに勝利！ (Japanese release)
 Duration: 4:29
 Artists:
 - Minako Adachi
@@ -569,6 +677,8 @@ Referenced Tracks:
 - Victory! (Gym Leader Battle) (Pokémon Red / Pokémon Blue)
 ---
 Track: Obtained a Badge!
+Additional Names:
+- バッジを手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:09
 Artists:
@@ -580,6 +690,8 @@ Referenced Tracks:
 - Obtained a Gym Badge (Pokémon Red / Pokémon Blue)
 ---
 Track: Obtained a TM!
+Additional Names:
+- 技マシンを手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -590,6 +702,8 @@ Referenced Tracks:
 - Received a TM! (Pokémon Gold / Pokémon Silver)
 ---
 Track: West Province
+Additional Names:
+- 西エリア (Japanese release)
 Duration: 2:16
 Artists:
 - Minako Adachi
@@ -598,6 +712,8 @@ URLs:
 - https://www.youtube.com/watch?v=xsbxhr7dsd8
 ---
 Track: Battle! (West Province Wild Pokémon)
+Additional Names:
+- 戦闘！西の野生ポケモン (Japanese release)
 Duration: 2:01
 Artists:
 - Minako Adachi
@@ -608,6 +724,8 @@ Referenced Tracks:
 - Asado Desert
 ---
 Track: Asado Desert
+Additional Names:
+- ロースト砂漠 (Japanese release)
 Duration: 2:01
 Artists:
 - Minako Adachi
@@ -618,6 +736,8 @@ Referenced Tracks:
 - West Province
 ---
 Track: Tera Raid Battle
+Additional Names:
+- テラレイドバトル！ (Japanese release)
 Duration: 4:06
 Artists:
 - Toby Fox
@@ -628,6 +748,8 @@ Referenced Tracks:
 - Battle! (Zero Lab)
 ---
 Track: Victory! (Tera Raid Battle)
+Additional Names:
+- テラレイドバトルで勝利！ (Japanese release)
 Duration: 0:42
 Artists:
 - Hiromitsu Maeba
@@ -638,6 +760,8 @@ Referenced Tracks:
 - Tera Raid Battle
 ---
 Track: A Stroll through the Asado Desert
+Additional Names:
+- ロースト砂漠を歩く (Japanese release)
 Duration: 2:00
 Artists:
 - Minako Adachi
@@ -648,6 +772,8 @@ Referenced Tracks:
 - Asado Desert
 ---
 Track: Cascarrafa
+Additional Names:
+- カラフシティ (Japanese release)
 Duration: 3:01
 Artists:
 - Hitomi Sato
@@ -656,6 +782,8 @@ URLs:
 - https://www.youtube.com/watch?v=QO3gSPTw3S4
 ---
 Track: Still at the Gym Test
+Additional Names:
+- まだまだジムテスト！ (Japanese release)
 Duration: 0:59
 Artists:
 - Hitomi Sato
@@ -666,6 +794,8 @@ Referenced Tracks:
 - Guide (Pokémon Red / Pokémon Blue)
 ---
 Track: Battle! (Titan)
+Additional Names:
+- 戦闘！ヌシ (Japanese release)
 Duration: 2:38
 Artists:
 - Go Ichinose
@@ -676,6 +806,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Second Battle against the Titan
+Additional Names:
+- 再びヌシに対峙 (Japanese release)
 Duration: 0:32
 Artists:
 - Go Ichinose
@@ -686,6 +818,8 @@ Referenced Tracks:
 - Battle! (Titan)
 ---
 Track: Victory! (Titan)
+Additional Names:
+- ヌシに勝利！ (Japanese release)
 Duration: 0:08
 Artists:
 - Go Ichinose
@@ -696,6 +830,8 @@ Referenced Tracks:
 - Battle! (Titan)
 ---
 Track: A Brief Moment
+Additional Names:
+- ちょっとひととき (Japanese release)
 Duration: 1:54
 Artists:
 - Hiromitsu Maeba
@@ -704,6 +840,8 @@ URLs:
 - https://www.youtube.com/watch?v=nBYrlquV5xw
 ---
 Track: A New Power for Your Ride
+Additional Names:
+- ライドの能力が上がった！ (Japanese release)
 Duration: 0:05
 Artists:
 - Hitomi Sato
@@ -714,6 +852,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: A Stroll through the West Province
+Additional Names:
+- 西エリアを歩く (Japanese release)
 Duration: 2:00
 Artists:
 - Minako Adachi
@@ -724,6 +864,8 @@ Referenced Tracks:
 - West Province
 ---
 Track: Medali
+Additional Names:
+- チャンプルタウン (Japanese release)
 Duration: 2:01
 Artists:
 - Minako Adachi
@@ -734,6 +876,8 @@ Referenced Tracks:
 - West Province
 ---
 Track: Time to Relax
+Additional Names:
+- ほのぼの時間 (Japanese release)
 Duration: 1:04
 Artists:
 - Minako Adachi
@@ -742,6 +886,8 @@ URLs:
 - https://www.youtube.com/watch?v=sbvdBu4z7L8
 ---
 Track: East Province
+Additional Names:
+- 東エリア (Japanese release)
 Duration: 2:59
 Artists:
 - Minako Adachi
@@ -750,6 +896,8 @@ URLs:
 - https://www.youtube.com/watch?v=rVeF3Gd_-pI
 ---
 Track: Battle! (East Province Wild Pokémon)
+Additional Names:
+- 戦闘！東の野生ポケモン (Japanese release)
 Duration: 2:41
 Artists:
 - Minako Adachi
@@ -760,6 +908,8 @@ Referenced Tracks:
 - East Province
 ---
 Track: Artazon
+Additional Names:
+- ボウルタウン (Japanese release)
 Duration: 2:41
 Artists:
 - Minako Adachi
@@ -770,6 +920,8 @@ Referenced Tracks:
 - East Province
 ---
 Track: Levincia
+Additional Names:
+- ハッコウシティ (Japanese release)
 Duration: 2:55
 Artists:
 - Hitomi Sato
@@ -778,6 +930,8 @@ URLs:
 - https://www.youtube.com/watch?v=8hZpjHzWOYY
 ---
 Track: The Iono Zone
+Additional Names:
+- ドンナモンジャTV！ (Japanese release)
 Duration: 0:07
 Artists:
 - Hitomi Sato
@@ -786,6 +940,8 @@ URLs:
 - https://www.youtube.com/watch?v=he-pD06tOeE
 ---
 Track: "'Ello, 'Ello, Hola! Ciao and Bonjour!"
+Additional Names:
+- おはこんハロチャオ！ (Japanese release)
 Duration: 1:19
 Artists:
 - Hiromitsu Maeba
@@ -794,6 +950,8 @@ URLs:
 - https://www.youtube.com/watch?v=fsZ5dC4BGQs
 ---
 Track: East Province (Area Three)
+Additional Names:
+- 東３番エリア (Japanese release)
 Duration: 2:41
 Artists:
 - Minako Adachi
@@ -804,6 +962,8 @@ Referenced Tracks:
 - East Province
 ---
 Track: A Stroll through the East Province
+Additional Names:
+- 東エリアを歩く (Japanese release)
 Duration: 2:41
 Artists:
 - Minako Adachi
@@ -814,6 +974,8 @@ Referenced Tracks:
 - East Province
 ---
 Track: Tagtree Thicket
+Additional Names:
+- しるしの木立ち (Japanese release)
 Duration: 2:41
 Artists:
 - Minako Adachi
@@ -824,6 +986,8 @@ Referenced Tracks:
 - East Province
 ---
 Track: The Name's Clive
+Additional Names:
+- 今のオレはネルケ (Japanese release)
 Duration: 0:38
 Artists:
 - Hiromitsu Maeba
@@ -832,6 +996,8 @@ URLs:
 - https://www.youtube.com/watch?v=ReF8gm-a_qs
 ---
 Track: Raiding the Base
+Additional Names:
+- いざカチこみ！ (Japanese release)
 Duration: 0:33
 Artists:
 - Teruo Taniguchi
@@ -842,6 +1008,8 @@ Referenced Tracks:
 - Team Star
 ---
 Track: Star Barrage
+Additional Names:
+- 団ラッシュ! (Japanese release)
 Duration: 4:46
 Artists:
 - Teruo Taniguchi
@@ -852,6 +1020,8 @@ Referenced Tracks:
 - Battle! (Team Star)
 ---
 Track: Star Barrage Finished
+Additional Names:
+- 団ラッシュFINISH！ (Japanese release)
 Duration: 0:07
 Artists:
 - Teruo Taniguchi
@@ -862,6 +1032,8 @@ Referenced Tracks:
 - Star Barrage
 ---
 Track: A Team Star Boss Appears!
+Additional Names:
+- スター団ボス登場！ (Japanese release)
 Duration: 0:52
 Artists:
 - Teruo Taniguchi
@@ -872,6 +1044,8 @@ Referenced Tracks:
 - Team Star
 ---
 Track: Battle! (Team Star Boss)
+Additional Names:
+- 戦闘！スター団ボス (Japanese release)
 Duration: 5:57
 Artists:
 - Teruo Taniguchi
@@ -882,6 +1056,8 @@ Referenced Tracks:
 - Battle! (Team Star)
 ---
 Track: Victory! (Team Star Boss)
+Additional Names:
+- スター団ボスに勝利！ (Japanese release)
 Duration: 0:52
 Artists:
 - Teruo Taniguchi
@@ -892,6 +1068,8 @@ Referenced Tracks:
 - Battle! (Team Star Boss)
 ---
 Track: Treasure of the Stars
+Additional Names:
+- 星々の宝物 (Japanese release)
 Duration: 3:13
 Artists:
 - Teruo Taniguchi
@@ -906,6 +1084,8 @@ Start Counting From: 1
 Color: '#d5101e'
 ---
 Track: North Province
+Additional Names:
+- 北エリア (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -914,6 +1094,8 @@ URLs:
 - https://www.youtube.com/watch?v=X3NdQgAlO_8
 ---
 Track: Battle! (North Province Wild Pokémon)
+Additional Names:
+- 戦闘！北の野生ポケモン (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -924,6 +1106,8 @@ Referenced Tracks:
 - North Province
 ---
 Track: Montenevera
+Additional Names:
+- フリッジタウン (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -934,6 +1118,8 @@ Referenced Tracks:
 - North Province
 ---
 Track: The Opening Act!
+Additional Names:
+- オープニングアクト！ (Japanese release)
 Duration: 4:03
 Artists:
 - Hiromitsu Maeba
@@ -944,6 +1130,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: MC of RIP
+Additional Names:
+- ソウルフルビート！ (Japanese release)
 Duration: 1:34
 Artists:
 - Hiromitsu Maeba
@@ -954,6 +1142,8 @@ Referenced Tracks:
 - The Opening Act!
 ---
 Track: A Stroll through the North Province
+Additional Names:
+- 北エリアを歩く (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -964,6 +1154,8 @@ Referenced Tracks:
 - North Province
 ---
 Track: Casseroya Lake
+Additional Names:
+- オージャの湖 (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -974,6 +1166,8 @@ Referenced Tracks:
 - North Province
 ---
 Track: Snow Slope Run
+Additional Names:
+- 雪山すべり (Japanese release)
 Duration: 2:10
 Artists:
 - Hitomi Sato
@@ -984,6 +1178,8 @@ Referenced Tracks:
 - North Province
 ---
 Track: North Province (Area Two)
+Additional Names:
+- 北２番エリア (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -994,6 +1190,8 @@ Referenced Tracks:
 - North Province
 ---
 Track: Alfornada
+Additional Names:
+- ベイクタウン (Japanese release)
 Duration: 2:52
 Artists:
 - Minako Adachi
@@ -1005,6 +1203,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Emotional Spectrum Practice
+Additional Names:
+- 喜怒驚楽エクササイズ！ (Japanese release)
 Duration: 1:01
 Artists:
 - Minako Adachi
@@ -1015,6 +1215,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: The Pokémon League Interview
+Additional Names:
+- ポケモンリーグ・面接テスト (Japanese release)
 Duration: 2:44
 Artists:
 - Hitomi Sato
@@ -1025,6 +1227,8 @@ Referenced Tracks:
 - The Final Road (Pokémon Red / Pokémon Blue)
 ---
 Track: Passed the Interview
+Additional Names:
+- 面接テストに合格！ (Japanese release)
 Duration: 0:07
 Artists:
 - Hitomi Sato
@@ -1033,6 +1237,8 @@ URLs:
 - https://www.youtube.com/watch?v=GcLEFnQlawY
 ---
 Track: The Pokémon League
+Additional Names:
+- ポケモンリーグ (Japanese release)
 Suffix Directory: true
 Duration: 2:21
 Artists:
@@ -1044,6 +1250,8 @@ URLs:
 - https://www.youtube.com/watch?v=yMrN4HDovTY
 ---
 Track: Battle! (Elite Four)
+Additional Names:
+- 戦闘！四天王 (Japanese release)
 Duration: 3:23
 Artists:
 - Minako Adachi
@@ -1052,6 +1260,8 @@ URLs:
 - https://www.youtube.com/watch?v=Nvuc3lYl7z0
 ---
 Track: Battle! (Top Champion)
+Additional Names:
+- 戦闘！トップチャンピオン (Japanese release)
 Duration: 3:18
 Artists:
 - Minako Adachi
@@ -1062,6 +1272,8 @@ Referenced Tracks:
 - Battle! (Champion) (Pokémon Gold / Pokémon Silver)
 ---
 Track: Victory! (Top Champion)
+Additional Names:
+- トップチャンピオンに勝利！ (Japanese release)
 Duration: 1:09
 Artists:
 - Minako Adachi
@@ -1072,6 +1284,8 @@ Referenced Tracks:
 - Battle! (Top Champion)
 ---
 Track: Together with Nemona
+Additional Names:
+- ネモと (Japanese release)
 Duration: 1:59
 Artists:
 - Hitomi Sato
@@ -1082,6 +1296,8 @@ Referenced Tracks:
 - Battle! (Nemona)
 ---
 Track: Battle! (Champion Nemona)
+Additional Names:
+- 戦闘！チャンピオンネモ (Japanese release)
 Duration: 3:07
 Artists:
 - Hitomi Sato
@@ -1092,6 +1308,8 @@ Referenced Tracks:
 - Battle! (Nemona)
 ---
 Track: My One and Only Rival
+Additional Names:
+- ただひとりのライバル (Japanese release)
 Duration: 1:07
 Artists:
 - Hitomi Sato
@@ -1106,6 +1324,8 @@ Start Counting From: 1
 Color: '#bc4cb4'
 ---
 Track: Battle! (Director Clavell)
+Additional Names:
+- 戦闘！クラベル校長 (Japanese release)
 Duration: 3:25
 Artists:
 - Hiromitsu Maeba
@@ -1117,6 +1337,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Clive's True Identity
+Additional Names:
+- ネルケの正体 (Japanese release)
 Duration: 1:06
 Artists:
 - Hiromitsu Maeba
@@ -1128,6 +1350,8 @@ Referenced Tracks:
 ## i love sotww
 ---
 Track: Battle! (Cassiopeia)
+Additional Names:
+- 戦闘！カシオペア (Japanese release)
 Duration: 5:33
 Artists:
 - Teruo Taniguchi
@@ -1138,6 +1362,8 @@ Referenced Tracks:
 - Battle! (Team Star)
 ---
 Track: Hasta la Vistar! ☆
+Additional Names:
+- お疲れさまでスター (Japanese release)
 Duration: 4:03
 Artists:
 - Hiromitsu Maeba
@@ -1148,6 +1374,8 @@ Referenced Tracks:
 - Battle! (Team Star)
 ---
 Track: Heart
+Additional Names:
+- 心 (Japanese release)
 Duration: 1:54
 Artists:
 - Hiromitsu Maeba
@@ -1158,6 +1386,8 @@ Referenced Tracks:
 - Hasta la Vistar! ☆
 ---
 Track: Arven's Treasure
+Additional Names:
+- ペパーの宝物 (Japanese release)
 Duration: 0:58
 Artists:
 - Hiromitsu Maeba
@@ -1168,6 +1398,8 @@ Referenced Tracks:
 - Battle! (Arven)
 ---
 Track: Finishing the Treasure Hunt
+Additional Names:
+- 宝探しクリア！ (Japanese release)
 Duration: 0:09
 Artists:
 - Hitomi Sato
@@ -1176,6 +1408,8 @@ URLs:
 - https://www.youtube.com/watch?v=_6tTQGoS1Bs
 ---
 Track: To the Great Crater of Paldea
+Additional Names:
+- パルデアの大穴へ！ (Japanese release)
 Duration: 0:50
 Artists:
 - Hiromitsu Maeba
@@ -1187,6 +1421,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Area Zero
+Additional Names:
+- エリアゼロ (Japanese release)
 Duration: 4:25
 Artists:
 - Go Ichinose (arranger)
@@ -1207,6 +1443,8 @@ Commentary: |-
     Also, not an actual reference, but the main arpeggio in this song happens to use the same scale as [[track:alphys]]. It's worth pointing out as the songs end up sounding slightly similar.
 ---
 Track: Battle! (Area Zero Pokémon)
+Additional Names:
+- 戦闘！エリアゼロのポケモン (Japanese release)
 Duration: 3:59
 Artists:
 - Go Ichinose
@@ -1217,6 +1455,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: The Gate Opens
+Additional Names:
+- ゲートが開いて (Japanese release)
 Duration: 0:47
 Artists:
 - Hiromitsu Maeba
@@ -1227,6 +1467,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Battle! (Area Zero Pokémon 2)
+Additional Names:
+- 戦闘！エリアゼロのポケモン2 (Japanese release)
 Duration: 3:59
 Artists:
 - Go Ichinose
@@ -1238,6 +1480,8 @@ Referenced Tracks:
 - Battle! (Area Zero Pokémon)
 ---
 Track: Activating Offensive Protocols
+Additional Names:
+- 戦闘プログラム起動 (Japanese release)
 Duration: 0:39
 Artists:
 - Hiromitsu Maeba
@@ -1248,6 +1492,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: Battle! (Zero Lab)
+Additional Names:
+- 戦闘！ゼロラボ (Japanese release)
 Duration: 5:57
 Artists:
 - Toby Fox
@@ -1264,6 +1510,8 @@ Commentary: |-
     Though there aren't any direct references, it's worth pointing out that this song has similarities to [[track:oppa-toby-style]].
 ---
 Track: Victory! (Zero Lab)
+Additional Names:
+- ゼロラボで勝利 (Japanese release)
 Duration: 1:07
 Artists:
 - Hiromitsu Maeba
@@ -1274,6 +1522,8 @@ Referenced Tracks:
 - Battle! (Zero Lab)
 ---
 Track: Reunion
+Additional Names:
+- 再会 (Japanese release)
 Duration: 1:22
 Artists:
 - Hiromitsu Maeba
@@ -1282,6 +1532,8 @@ URLs:
 - https://www.youtube.com/watch?v=5okVzsEgByw
 ---
 Track: Paradise Protection Protocol Initialized
+Additional Names:
+- 楽園防衛プログラム起動 (Japanese release)
 Duration: 2:05
 Artists:
 - Hiromitsu Maeba
@@ -1290,6 +1542,8 @@ URLs:
 - https://www.youtube.com/watch?v=UlsF8H7G2Pw
 ---
 Track: Battle Form
+Additional Names:
+- バトルフォルム (Japanese release)
 Duration: 0:21
 Artists:
 - Go Ichinose
@@ -1298,6 +1552,8 @@ URLs:
 - https://www.youtube.com/watch?v=Dw4rmTkXvzU
 ---
 Track: Batʇlə! (■■■)
+Additional Names:
+- 戦闘！■■■■ (Japanese release)
 Directory: battle-koraidon-miraidon
 Duration: 3:36
 Artists:
@@ -1309,6 +1565,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Earnest Feelings
+Additional Names:
+- 切なる思い (Japanese release)
 Duration: 1:51
 Artists:
 - Hiromitsu Maeba
@@ -1317,6 +1575,8 @@ URLs:
 - https://www.youtube.com/watch?v=J-af9dxY55E
 ---
 Track: I Bid You Adieu!
+Additional Names:
+- ボン・ボヤージュ! (Japanese release)
 Duration: 0:35
 Artists:
 - Hiromitsu Maeba
@@ -1325,6 +1585,8 @@ URLs:
 - https://www.youtube.com/watch?v=k9HLgpBUOhI
 ---
 Track: The Way Home
+Additional Names:
+- ザ・ホームウェイ (Japanese release)
 Duration: 2:22
 Artists:
 - Hiromitsu Maeba
@@ -1335,6 +1597,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: Get a Little More Fun Out of this Adventure!
+Additional Names:
+- より道して帰ろう (Japanese release)
 Duration: 1:02
 Artists:
 - Hiromitsu Maeba
@@ -1345,6 +1609,8 @@ Referenced Tracks:
 - South Province
 ---
 Track: The Academy Ace Tournament
+Additional Names:
+- 学校最強大会！ (Japanese release)
 Duration: 4:53
 Artists:
 - Toby Fox
@@ -1355,6 +1621,8 @@ Referenced Tracks:
 - The Academy
 ---
 Track: Mystery Gift
+Additional Names:
+- ふしぎなおくりもの (Japanese release)
 Suffix Directory: true
 Duration: 0:39
 Artists:
@@ -1366,6 +1634,8 @@ Referenced Tracks:
 - Mystery Gift (Pokémon Platinum)
 ---
 Track: The Battle Stadium
+Additional Names:
+- バトルスタジアム！ (Japanese release)
 Duration: 0:52
 Artists:
 - Hitomi Sato
@@ -1374,6 +1644,8 @@ URLs:
 - https://www.youtube.com/watch?v=FiHP2ChYboY
 ---
 Track: Battle! (Calamity Pokémon)
+Additional Names:
+- 戦闘！災厄ポケモン (Japanese release)
 Duration: 3:39
 Artists:
 - Go Ichinose
@@ -1382,6 +1654,8 @@ URLs:
 - https://www.youtube.com/watch?v=RNqrin6f-yE
 ---
 Track: Pokédex Evaluation... It's Perfect!
+Additional Names:
+- 図鑑評価・完璧！ (Japanese release)
 Suffix Directory: true
 Duration: 0:06
 Artists:
@@ -1393,6 +1667,8 @@ Referenced Tracks:
 - Pokédex Evaluation... Complete! (Pokémon Gold / Pokémon Silver)
 ---
 Track: Title Screen
+Additional Names:
+- タイトル (Japanese release)
 Suffix Directory: true
 Duration: 1:36
 Artists:
@@ -1409,6 +1685,8 @@ Start Counting From: 1
 Color: '#01b5ac'
 ---
 Track: 'The Hidden Treasure of Area Zero: The Teal Mask'
+Additional Names:
+- ゼロの秘宝「碧の仮面」 (Japanese release)
 Duration: 0:20
 Artists:
 - Minako Adachi
@@ -1417,6 +1695,8 @@ URLs:
 - https://www.youtube.com/watch?v=MP07XNOl4oQ
 ---
 Track: Carmine & Kieran
+Additional Names:
+- こ・う・りゅ・う (Japanese release)
 Duration: 1:00
 Artists:
 - Minako Adachi
@@ -1425,6 +1705,8 @@ URLs:
 - https://www.youtube.com/watch?v=_i1F00d_7GQ
 ---
 Track: Battle! (Carmine)
+Additional Names:
+- 戦闘！ゼイユ (Japanese release)
 Duration: 2:08
 Artists:
 - Minako Adachi
@@ -1435,6 +1717,8 @@ Referenced Tracks:
 - Carmine & Kieran
 ---
 Track: Mossui Town
+Additional Names:
+- スイリョクタウン (Japanese release)
 Duration: 3:29
 Artists:
 - Minako Adachi
@@ -1445,6 +1729,8 @@ Referenced Tracks:
 - The Land of Kitakami
 ---
 Track: Battle! (Kieran)
+Additional Names:
+- 戦闘！スグリ (Japanese release)
 Duration: 2:04
 Artists:
 - Minako Adachi
@@ -1455,6 +1741,8 @@ Referenced Tracks:
 - Battle! (Carmine)
 ---
 Track: The Land of Kitakami
+Additional Names:
+- キタカミの里 (Japanese release)
 Duration: 3:29
 Artists:
 - Minako Adachi
@@ -1463,6 +1751,8 @@ URLs:
 - https://www.youtube.com/watch?v=GAsrehyERj0
 ---
 Track: Battle! (Kitakami Pokémon)
+Additional Names:
+- 戦闘！キタカミのポケモン (Japanese release)
 Duration: 3:32
 Artists:
 - Minako Adachi
@@ -1473,6 +1763,8 @@ Referenced Tracks:
 - The Land of Kitakami
 ---
 Track: Photo (Pokémon March)
+Additional Names:
+- 撮影・マーチ (Japanese release)
 Duration: 0:52
 Artists:
 - Teruo Taniguchi
@@ -1483,6 +1775,8 @@ Referenced Tracks:
 - 'Pokégear Radio: Pokémon March (Pokémon Gold / Pokémon Silver)'
 ---
 Track: Photo (Battle)
+Additional Names:
+- 撮影・勝負 (Japanese release)
 Duration: 1:43
 Artists:
 - Teruo Taniguchi
@@ -1493,6 +1787,8 @@ Referenced Tracks:
 - Battle! (Wild Pokémon—Johto Version) (Pokémon Gold / Pokémon Silver)
 ---
 Track: Photo (Pokémon Lullaby)
+Additional Names:
+- 撮影・こもりうた (Japanese release)
 Duration: 1:11
 Artists:
 - Teruo Taniguchi
@@ -1503,6 +1799,8 @@ Referenced Tracks:
 - 'Pokégear Radio: Pokémon Lullaby (Pokémon Gold / Pokémon Silver)'
 ---
 Track: Perrin's Theme
+Additional Names:
+- サザレのテーマ (Japanese release)
 Duration: 2:18
 Artists:
 - Hitomi Sato
@@ -1511,6 +1809,8 @@ URLs:
 - https://www.youtube.com/watch?v=hGDwEpdr33M
 ---
 Track: Historic Signboard
+Additional Names:
+- 看板の歴史 (Japanese release)
 Duration: 1:12
 Artists:
 - Minako Adachi
@@ -1519,6 +1819,8 @@ URLs:
 - https://www.youtube.com/watch?v=bXEfQoOybJI
 ---
 Track: Together with Kieran
+Additional Names:
+- スグリと (Japanese release)
 Duration: 2:19
 Artists:
 - Hitomi Sato
@@ -1530,6 +1832,8 @@ Referenced Tracks:
 - Historic Signboard
 ---
 Track: The Festival of Masks
+Additional Names:
+- オモテ祭り (Japanese release)
 Duration: 1:33
 Artists:
 - Minako Adachi
@@ -1540,6 +1844,8 @@ Referenced Tracks:
 - Historic Signboard
 ---
 Track: Ogre Oustin'
+Additional Names:
+- 鬼退治フェス！ (Japanese release)
 Duration: 2:24
 Artists:
 - Hiromitsu Maeba
@@ -1548,6 +1854,8 @@ URLs:
 - https://www.youtube.com/watch?v=10r0MiS5zJI
 ---
 Track: Ogre Oustin' Completed
+Additional Names:
+- 鬼退治フェス クリア！ (Japanese release)
 Duration: 0:40
 Artists:
 - Hiromitsu Maeba
@@ -1558,6 +1866,8 @@ Referenced Tracks:
 - Ogre Oustin'
 ---
 Track: The Mysterious Child Who Dropped Their Mask
+Additional Names:
+- お面を落とした不思議な子 (Japanese release)
 Duration: 0:39
 Artists:
 - Hiromitsu Maeba
@@ -1566,6 +1876,8 @@ URLs:
 - https://www.youtube.com/watch?v=dCGuL9drQIY
 ---
 Track: The True History
+Additional Names:
+- 本当の歴史 (Japanese release)
 Duration: 1:49
 Artists:
 - Hiromitsu Maeba
@@ -1576,6 +1888,8 @@ Referenced Tracks:
 - Historic Signboard
 ---
 Track: Crystal Pool
+Additional Names:
+- てらす池 (Japanese release)
 Duration: 4:55
 Artists:
 - Go Ichinose
@@ -1586,6 +1900,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: Twisted
+Additional Names:
+- 歪み (Japanese release)
 Suffix Directory: true
 Always Reference By Directory: true
 Duration: 1:15
@@ -1598,6 +1914,8 @@ Referenced Tracks:
 - Historic Signboard
 ---
 Track: The Loyal Three Return
+Additional Names:
+- よみがえるともっこ (Japanese release)
 Duration: 0:42
 Artists:
 - Minako Adachi
@@ -1606,6 +1924,8 @@ URLs:
 - https://www.youtube.com/watch?v=t4VjKjWiidY
 ---
 Track: The Loyal Three Cause Trouble
+Additional Names:
+- ともっこ騒動 (Japanese release)
 Duration: 1:03
 Artists:
 - Hitomi Sato
@@ -1616,6 +1936,8 @@ Referenced Tracks:
 - The Loyal Three Return
 ---
 Track: Battle! (Loyal Three)
+Additional Names:
+- 戦闘！ともっこ (Japanese release)
 Duration: 2:43
 Artists:
 - Minako Adachi
@@ -1626,6 +1948,8 @@ Referenced Tracks:
 - The Loyal Three Return
 ---
 Track: Decisive Battle! (Kieran)
+Additional Names:
+- 決戦！スグリ (Japanese release)
 Duration: 2:53
 Artists:
 - Minako Adachi
@@ -1636,6 +1960,8 @@ Referenced Tracks:
 - Battle! (Kieran)
 ---
 Track: Battle! (Ogerpon)
+Additional Names:
+- 戦闘！オーガポン (Japanese release)
 Duration: 2:44
 Artists:
 - Minako Adachi
@@ -1644,6 +1970,8 @@ URLs:
 - https://www.youtube.com/watch?v=vra1NsKxvrg
 ---
 Track: Caught Ogerpon!
+Additional Names:
+- オーガポンを捕まえた！ (Japanese release)
 Duration: 0:36
 Artists:
 - Minako Adachi
@@ -1654,6 +1982,8 @@ Referenced Tracks:
 - Battle! (Ogerpon)
 ---
 Track: A Moment of Honesty
+Additional Names:
+- 今は素直に (Japanese release)
 Duration: 2:21
 Artists:
 - Hiromitsu Maeba
@@ -1662,6 +1992,8 @@ URLs:
 - https://www.youtube.com/watch?v=eJhm8SSGaiA
 ---
 Track: I Need to Become Stronger
+Additional Names:
+- 強くならないと (Japanese release)
 Duration: 0:53
 Artists:
 - Hiromitsu Maeba
@@ -1672,6 +2004,8 @@ Referenced Tracks:
 - The Land of Kitakami
 ---
 Track: 'The Hidden Treasure of Area Zero: The Indigo Disk'
+Additional Names:
+- ゼロの秘宝「藍の円盤」 (Japanese release)
 Duration: 0:19
 Artists:
 - Minako Adachi
@@ -1680,6 +2014,8 @@ URLs:
 - https://www.youtube.com/watch?v=whWnPCNlvw4
 ---
 Track: Blueberry Academy
+Additional Names:
+- ブルーベリー学園 (Japanese release)
 Duration: 2:48
 Artists:
 - Minako Adachi
@@ -1688,6 +2024,8 @@ URLs:
 - https://www.youtube.com/watch?v=2hc-dc_37UQ
 ---
 Track: To the Terarium
+Additional Names:
+- ドームへ (Japanese release)
 Duration: 1:05
 Artists:
 - Go Ichinose
@@ -1696,6 +2034,8 @@ URLs:
 - https://www.youtube.com/watch?v=NyFoZzdFMI4
 ---
 Track: Welcome to the Terarium!
+Additional Names:
+- ここがテラリウムドーム！ (Japanese release)
 Duration: 2:18
 Artists:
 - Go Ichinose
@@ -1707,6 +2047,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: Terarium (Savanna Biome)
+Additional Names:
+- ドーム・サバンナエリア (Japanese release)
 Duration: 4:42
 Artists:
 - Go Ichinose
@@ -1720,6 +2062,8 @@ Referenced Tracks:
 - Route 4 (Spring)
 ---
 Track: Battle! (Terarium Pokémon)
+Additional Names:
+- 戦闘！ドームのポケモン (Japanese release)
 Duration: 2:27
 Artists:
 - Go Ichinose
@@ -1730,6 +2074,8 @@ Referenced Tracks:
 - Battle! (Wild Pokémon) (Pokémon Black / Pokémon White)
 ---
 Track: Terarium (Coastal Biome)
+Additional Names:
+- ドーム・コーストエリア (Japanese release)
 Duration: 4:42
 Artists:
 - Go Ichinose
@@ -1743,6 +2089,8 @@ Referenced Tracks:
 - Route 4 (Spring)
 ---
 Track: Trainers' Eyes Meet (Academy Trainer)
+Additional Names:
+- 視線！学園のトレーナー (Japanese release)
 Duration: 0:11
 Artists:
 - Haruka Soeda
@@ -1753,6 +2101,8 @@ Referenced Tracks:
 - Battle! (Academy Trainer)
 ---
 Track: Battle! (Academy Trainer)
+Additional Names:
+- 戦闘！学園のトレーナー (Japanese release)
 Duration: 3:34
 Artists:
 - Haruka Soeda
@@ -1768,6 +2118,8 @@ Start Counting From: 1
 Color: '#1494b7'
 ---
 Track: Terarium (Central Plaza)
+Additional Names:
+- ドーム・センタースクエア (Japanese release)
 Duration: 4:42
 Artists:
 - Go Ichinose
@@ -1781,6 +2133,8 @@ Referenced Tracks:
 - Route 4 (Spring)
 ---
 Track: Unsettling Atmosphere
+Additional Names:
+- 不穏な空気 (Japanese release)
 Duration: 1:14
 Artists:
 - Hitomi Sato
@@ -1791,6 +2145,8 @@ Referenced Tracks:
 - A Regular Day at BB Academy
 ---
 Track: A Regular Day at BB Academy
+Additional Names:
+- 学園の日常 (Japanese release)
 Duration: 2:09
 Artists:
 - Hitomi Sato
@@ -1801,6 +2157,8 @@ Referenced Tracks:
 - Blueberry Academy
 ---
 Track: Your BB Dorm Room
+Additional Names:
+- 学園・自分の部屋 (Japanese release)
 Duration: 2:48
 Artists:
 - Minako Adachi
@@ -1811,6 +2169,8 @@ Referenced Tracks:
 - Blueberry Academy
 ---
 Track: Item Printer
+Additional Names:
+- どうぐプリンター (Japanese release)
 Duration: 0:04
 Artists:
 - Haruka Soeda
@@ -1819,6 +2179,8 @@ URLs:
 - https://www.youtube.com/watch?v=oNIy5A3bKQA
 ---
 Track: Terarium (Canyon Biome)
+Additional Names:
+- ドーム・キャニオンエリア (Japanese release)
 Duration: 4:42
 Artists:
 - Go Ichinose
@@ -1832,6 +2194,8 @@ Referenced Tracks:
 - Route 4 (Spring)
 ---
 Track: Battle! (Terarium Tera Pokémon)
+Additional Names:
+- 戦闘！ドームのテラスタルポケモン (Japanese release)
 Duration: 2:23
 Artists:
 - Go Ichinose
@@ -1844,6 +2208,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: The Flying Time Trial
+Additional Names:
+- そらとぶタイムアタック！ (Japanese release)
 Duration: 1:17
 Artists:
 - Hitomi Sato
@@ -1852,6 +2218,8 @@ URLs:
 - https://www.youtube.com/watch?v=xK0QLcynZug
 ---
 Track: Elite Trial Completed
+Additional Names:
+- 四天王チャレンジ クリア！ (Japanese release)
 Duration: 0:40
 Artists:
 - Hitomi Sato
@@ -1863,6 +2231,8 @@ Referenced Tracks:
 - Blueberry Academy
 ---
 Track: Terarium (Polar Biome)
+Additional Names:
+- ドーム・ポーラエリア (Japanese release)
 Duration: 4:42
 Artists:
 - Go Ichinose
@@ -1875,6 +2245,8 @@ Referenced Tracks:
 - Route 4 (Spring)
 ---
 Track: Battle! (BB League Elite Four)
+Additional Names:
+- 戦闘！ブルベリーグ四天王 (Japanese release)
 Duration: 2:54
 Artists:
 - Minako Adachi
@@ -1883,6 +2255,8 @@ URLs:
 - https://www.youtube.com/watch?v=cJ36mhkjkiE
 ---
 Track: Victory! (BB League Elite Four)
+Additional Names:
+- ブルベリーグ四天王に勝利！ (Japanese release)
 Duration: 0:36
 Artists:
 - Minako Adachi
@@ -1893,6 +2267,8 @@ Referenced Tracks:
 - Battle! (BB League Elite Four)
 ---
 Track: True Feelings
+Additional Names:
+- 本心 (Japanese release)
 Duration: 2:13
 Artists:
 - Hitomi Sato
@@ -1901,6 +2277,8 @@ URLs:
 - https://www.youtube.com/watch?v=zBJqdrnufL0
 ---
 Track: The Battle Begins
+Additional Names:
+- 勝負が始まる (Japanese release)
 Duration: 0:38
 Artists:
 - Minako Adachi
@@ -1912,6 +2290,8 @@ Referenced Tracks:
 - Battle! (Champion Kieran)
 ---
 Track: Battle! (Champion Kieran)
+Additional Names:
+- 戦闘！チャンピオンスグリ (Japanese release)
 Duration: 3:30
 Artists:
 - Minako Adachi
@@ -1922,6 +2302,8 @@ Referenced Tracks:
 - Decisive Battle! (Kieran)
 ---
 Track: Kieran Defeated
+Additional Names:
+- 敗北のスグリ (Japanese release)
 Duration: 0:47
 Artists:
 - Minako Adachi
@@ -1932,6 +2314,8 @@ Referenced Tracks:
 - Battle! (Kieran)
 ---
 Track: Briar's Theme
+Additional Names:
+- ブライアのテーマ (Japanese release)
 Duration: 2:16
 Artists:
 - Hitomi Sato
@@ -1940,6 +2324,8 @@ URLs:
 - https://www.youtube.com/watch?v=aq9u0NN5R3Q
 ---
 Track: Area Zero Underdepths
+Additional Names:
+- ゼロの大空洞 (Japanese release)
 Duration: 4:37
 Artists:
 - Hitomi Sato
@@ -1950,6 +2336,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: Terapagos Reawakened
+Additional Names:
+- 蘇ったテラパゴス (Japanese release)
 Duration: 1:06
 Artists:
 - Hiromitsu Maeba
@@ -1961,6 +2349,8 @@ Referenced Tracks:
 - Battle! (Terapagos)
 ---
 Track: Battle! (Terapagos)
+Additional Names:
+- 戦闘！テラパゴス (Japanese release)
 Duration: 2:46
 Artists:
 - Go Ichinose (composer & arranger)
@@ -1973,6 +2363,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: What the Hidden Treasure Needs
+Additional Names:
+- 秘宝の条件 (Japanese release)
 Duration: 1:23
 Artists:
 - Hiromitsu Maeba
@@ -1983,6 +2375,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: Terapagos Goes Berserk
+Additional Names:
+- テラパゴスの暴走 (Japanese release)
 Duration: 1:01
 Artists:
 - Hiromitsu Maeba
@@ -1994,6 +2388,8 @@ Referenced Tracks:
 - Battle! (Terapagos)
 ---
 Track: Battle! (Terapagos, the Hidden Treasure of Area Zero)
+Additional Names:
+- 戦闘！ゼロの秘宝 テラパゴス (Japanese release)
 Duration: 5:27
 Artists:
 - Go Ichinose
@@ -2006,6 +2402,8 @@ Referenced Tracks:
 - Tera Raid Battle
 ---
 Track: Caught Terapagos!
+Additional Names:
+- テラパゴスを捕まえた！ (Japanese release)
 Duration: 0:58
 Artists:
 - Hiromitsu Maeba
@@ -2016,6 +2414,8 @@ Referenced Tracks:
 - Area Zero
 ---
 Track: Starting Over from Zero
+Additional Names:
+- もう一度ゼロから (Japanese release)
 Duration: 1:15
 Artists:
 - Hiromitsu Maeba
@@ -2024,6 +2424,8 @@ URLs:
 - https://www.youtube.com/watch?v=07Df0C8CqB0
 ---
 Track: Studying Together with Team Star
+Additional Names:
+- 勉強会だよ！スター団 (Japanese release)
 Duration: 2:18
 Artists:
 - Haruka Soeda
@@ -2035,6 +2437,8 @@ Referenced Tracks:
 - Battle! (Team Star Boss)
 ---
 Track: Relic Song
+Additional Names:
+- いにしえのうた (Japanese release)
 Suffix Directory: true
 Duration: 2:01
 Artists:
@@ -2047,6 +2451,8 @@ Referenced Tracks:
 - Relic Song (Pokémon Black / Pokémon White)
 ---
 Track: 'The Hidden Treasure of Area Zero: Epilogue'
+Additional Names:
+- ゼロの秘宝番外編 (Japanese release)
 Duration: 0:11
 Artists:
 - Hiromitsu Maeba
@@ -2057,6 +2463,8 @@ Referenced Tracks:
 - Mochi Mayhem
 ---
 Track: The Curse of the Village...?
+Additional Names:
+- 村の呪い……？ (Japanese release)
 Duration: 0:42
 Artists:
 - Go Ichinose
@@ -2065,6 +2473,8 @@ URLs:
 - https://www.youtube.com/watch?v=th5_OPA0kQE
 ---
 Track: Mochi Mayhem
+Additional Names:
+- キビキビパニック！ (Japanese release)
 Duration: 1:15
 Artists:
 - Go Ichinose (composer & arranger)
@@ -2075,6 +2485,8 @@ URLs:
 - https://www.youtube.com/watch?v=M7LwxT2q7AE
 ---
 Track: A Drone? A Pokémon? It's Binding Mochi!
+Additional Names:
+- ドローン？ポケモン？くさりもち！ (Japanese release)
 Duration: 0:40
 Artists:
 - Minako Adachi
@@ -2083,6 +2495,8 @@ URLs:
 - https://www.youtube.com/watch?v=3tWNrpAVw2M
 ---
 Track: Battle! (Pecharunt)
+Additional Names:
+- 戦闘！モモワロウ (Japanese release)
 Duration: 3:09
 Artists:
 - Hiromitsu Maeba
@@ -2093,6 +2507,8 @@ Referenced Tracks:
 - Mochi Mayhem
 ---
 Track: Title Screen
+Additional Names:
+- タイトル (Japanese release)
 Directory: title-screen-2
 Suffix Directory: true
 Duration: 2:08

--- a/album/pokemon-sword-shield-super-music-collection.yaml
+++ b/album/pokemon-sword-shield-super-music-collection.yaml
@@ -30,6 +30,8 @@ Start Counting From: 1
 Color: '#00a2e7'
 ---
 Track: Title Screen
+Additional Names:
+- タイトル (Japanese release)
 Suffix Directory: true
 Duration: 1:25
 Artists:
@@ -42,6 +44,8 @@ Referenced Tracks:
 - Title Screen (Pokémon Red / Pokémon Blue)
 ---
 Track: Exhibition Match
+Additional Names:
+- エキシビションマッチ (Japanese release)
 Duration: 1:54
 Artists:
 - Minako Adachi
@@ -50,6 +54,8 @@ URLs:
 - https://www.youtube.com/watch?v=FxotlznPMFg
 ---
 Track: Postwick
+Additional Names:
+- ハロンタウン (Japanese release)
 Duration: 3:25
 Artists:
 - Go Ichinose
@@ -58,6 +64,8 @@ URLs:
 - https://www.youtube.com/watch?v=_UjfJAw51vY
 ---
 Track: Hop's Theme
+Additional Names:
+- ホップのテーマ (Japanese release)
 Duration: 2:36
 Artists:
 - Go Ichinose
@@ -66,6 +74,8 @@ URLs:
 - https://www.youtube.com/watch?v=TkOcfawy8vU
 ---
 Track: Route 1
+Additional Names:
+- １番道路 (Japanese release)
 Suffix Directory: true
 Duration: 1:17
 Artists:
@@ -75,6 +85,8 @@ URLs:
 - https://www.youtube.com/watch?v=F_oKi-e3Dv0
 ---
 Track: Wedgehurst
+Additional Names:
+- ブラッシータウン (Japanese release)
 Duration: 2:57
 Artists:
 - Go Ichinose
@@ -83,6 +95,8 @@ URLs:
 - https://www.youtube.com/watch?v=F_oKi-e3Dv0
 ---
 Track: Let's Have a Champion Time!
+Additional Names:
+- チャンピオン タイム！ (Japanese release)
 Duration: 1:27
 Artists:
 - Go Ichinose
@@ -91,6 +105,8 @@ URLs:
 - https://www.youtube.com/watch?v=tUzpeApK0k0
 ---
 Track: Time for a Breather
+Additional Names:
+- ひとやすみ (Japanese release)
 Duration: 0:06
 Artists:
 - Minako Adachi
@@ -101,6 +117,8 @@ Referenced Tracks:
 - Pokémon Healed (Pokémon Red / Pokémon Blue)
 ---
 Track: Battle! (Hop)
+Additional Names:
+- 戦闘！ホップ (Japanese release)
 Duration: 3:18
 Artists:
 - Go Ichinose
@@ -111,6 +129,8 @@ Referenced Tracks:
 - Hop's Theme
 ---
 Track: Slumbering Weald
+Additional Names:
+- まどろみの森 (Japanese release)
 Duration: 4:04
 Artists:
 - Go Ichinose
@@ -119,6 +139,8 @@ URLs:
 - https://www.youtube.com/watch?v=4puWpbtrn1U
 ---
 Track: In the Fog
+Additional Names:
+- 霧の中で (Japanese release)
 Duration: 1:45
 Artists:
 - Go Ichinose
@@ -127,6 +149,8 @@ URLs:
 - https://www.youtube.com/watch?v=FidGR2tps-o
 ---
 Track: Obtained an Item!
+Additional Names:
+- どうぐを手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -137,6 +161,8 @@ Referenced Tracks:
 - Level Up! (Pokémon Red / Pokémon Blue)
 ---
 Track: Pokémon Research Lab
+Additional Names:
+- ポケモン研究所 (Japanese release)
 Duration: 1:59
 Artists:
 - Minako Adachi
@@ -145,6 +171,8 @@ URLs:
 - https://www.youtube.com/watch?v=AkQcpMxhyh0
 ---
 Track: Sonia's Theme
+Additional Names:
+- ソニアのテーマ (Japanese release)
 Duration: 2:08
 Artists:
 - Minako Adachi
@@ -153,6 +181,8 @@ URLs:
 - https://www.youtube.com/watch?v=sRHXOydAFxs
 ---
 Track: Obtained a Key Item!
+Additional Names:
+- たいせつなどうぐを手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:04
 Artists:
@@ -163,6 +193,8 @@ Referenced Tracks:
 - Obtained a Pokémon (Pokémon Red / Pokémon Blue)
 ---
 Track: Pokémon Center
+Additional Names:
+- ポケモンセンター (Japanese release)
 Suffix Directory: true
 Duration: 2:17
 Artists:
@@ -174,6 +206,8 @@ Referenced Tracks:
 - Pokémon Center (Pokémon Red / Pokémon Blue)
 ---
 Track: Pokémon Healed
+Additional Names:
+- 回復 (Japanese release)
 Suffix Directory: true
 Duration: 0:05
 Artists:
@@ -185,6 +219,8 @@ Referenced Tracks:
 - Pokémon Healed (Pokémon Red / Pokémon Blue)
 ---
 Track: Battle! (Wild Pokémon)
+Additional Names:
+- 戦闘！野生ポケモン (Japanese release)
 Suffix Directory: true
 Duration: 2:22
 Artists:
@@ -194,6 +230,8 @@ URLs:
 - https://www.youtube.com/watch?v=lV30h2U-k-4
 ---
 Track: Victory! (Wild Pokémon)
+Additional Names:
+- 野生ポケモンに勝利！ (Japanese release)
 Suffix Directory: true
 Duration: 0:31
 Artists:
@@ -205,6 +243,8 @@ Referenced Tracks:
 - Victory! (Wild Pokémon) (Pokémon Red / Pokémon Blue)
 ---
 Track: Guide
+Additional Names:
+- 道案内 (Japanese release)
 Suffix Directory: true
 Duration: 1:02
 Artists:
@@ -216,6 +256,8 @@ Referenced Tracks:
 - Guide (Pokémon Red / Pokémon Blue)
 ---
 Track: At the Train Station
+Additional Names:
+- 駅 (Japanese release)
 Duration: 2:52
 Artists:
 - Go Ichinose
@@ -226,6 +268,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: Wild Area (South)
+Additional Names:
+- ワイルドエリア・南 (Japanese release)
 Duration: 3:58
 Artists:
 - Go Ichinose
@@ -234,6 +278,8 @@ URLs:
 - https://www.youtube.com/watch?v=cH2c9XM5zeY
 ---
 Track: Battle! (Max Raid Battle)
+Additional Names:
+- マックスレイドバトル！ (Japanese release)
 Duration: 2:22
 Artists:
 - Go Ichinose
@@ -242,6 +288,8 @@ URLs:
 - https://www.youtube.com/watch?v=n2ym36JHmjA
 ---
 Track: Victory! (Dynamax Pokémon)
+Additional Names:
+- ダイマックスポケモンに勝利！ (Japanese release)
 Duration: 0:37
 Artists:
 - Go Ichinose
@@ -250,6 +298,8 @@ URLs:
 - https://www.youtube.com/watch?v=d0lEIjeb-WI
 ---
 Track: Let's Make Curry!
+Additional Names:
+- カレーをつくろう！ (Japanese release)
 Duration: 1:56
 Artists:
 - Go Ichinose
@@ -258,6 +308,8 @@ URLs:
 - https://www.youtube.com/watch?v=towrVDZT7Kk
 ---
 Track: Curry (Koffing Class)
+Additional Names:
+- カレー・ドガース級 (Japanese release)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -268,6 +320,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Curry (Wobbuffet Class)
+Additional Names:
+- カレー・ソーナンス級 (Japanese release)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -278,6 +332,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Curry (Milcery Class)
+Additional Names:
+- カレー・マホミル級 (Japanese release)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -288,6 +344,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Curry (Copperajah Class)
+Additional Names:
+- カレー・ダイオウドウ級 (Japanese release)
 Duration: 0:07
 Artists:
 - Go Ichinose
@@ -298,6 +356,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Curry (Charizard Class)
+Additional Names:
+- カレー・リザードン級 (Japanese release)
 Duration: 0:08
 Artists:
 - Go Ichinose
@@ -308,6 +368,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Curry Dex—Keep Going!
+Additional Names:
+- カレー図鑑・がんばろう！ (Japanese release)
 Duration: 0:05
 Artists:
 - Go Ichinose
@@ -318,6 +380,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Curry Dex—Complete!
+Additional Names:
+- カレー図鑑・完成！ (Japanese release)
 Duration: 0:07
 Artists:
 - Go Ichinose
@@ -328,6 +392,8 @@ Referenced Tracks:
 - Let's Make Curry!
 ---
 Track: Motostoke
+Additional Names:
+- エンジンシティ (Japanese release)
 Duration: 3:13
 Artists:
 - Go Ichinose
@@ -336,6 +402,8 @@ URLs:
 - https://www.youtube.com/watch?v=Aj0PmmA0PSk
 ---
 Track: Boutique
+Additional Names:
+- ブティック (Japanese release)
 Suffix Directory: true
 Duration: 2:09
 Artists:
@@ -345,6 +413,8 @@ URLs:
 - https://www.youtube.com/watch?v=jwue8IVikMc
 ---
 Track: At the Stadium
+Additional Names:
+- スタジアム (Japanese release)
 Duration: 1:46
 Artists:
 - Minako Adachi
@@ -355,6 +425,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: Budew Drop Inn
+Additional Names:
+- ホテル スボミーイン (Japanese release)
 Duration: 2:26
 Artists:
 - Go Ichinose
@@ -363,6 +435,8 @@ URLs:
 - https://www.youtube.com/watch?v=n-2AXr46JsM
 ---
 Track: An Old Legend
+Additional Names:
+- 歴史の伝説 (Japanese release)
 Duration: 3:34
 Artists:
 - Go Ichinose
@@ -371,6 +445,8 @@ URLs:
 - https://www.youtube.com/watch?v=HXWF-tJaxz0
 ---
 Track: Team Yell Appears!
+Additional Names:
+- エール団登場！ (Japanese release)
 Duration: 2:49
 Artists:
 - Minako Adachi
@@ -379,6 +455,8 @@ URLs:
 - https://www.youtube.com/watch?v=-BDOBGLaVSs
 ---
 Track: Marnie's Theme
+Additional Names:
+- マリィのテーマ (Japanese release)
 Duration: 2:35
 Artists:
 - Minako Adachi
@@ -387,6 +465,8 @@ URLs:
 - https://www.youtube.com/watch?v=lpgK0k0TkSs
 ---
 Track: Gym Challenge Opening Ceremony
+Additional Names:
+- ジムチャレンジ開会式 (Japanese release)
 Duration: 1:04
 Artists:
 - Minako Adachi
@@ -397,6 +477,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: Chairman Rose
+Additional Names:
+- ローズ委員長 (Japanese release)
 Duration: 1:50
 Artists:
 - Go Ichinose
@@ -409,6 +491,8 @@ Start Counting From: 1
 Color: '#dd005d'
 ---
 Track: Route 3
+Additional Names:
+- ３番道路 (Japanese release)
 Suffix Directory: true
 Duration: 2:57
 Artists:
@@ -418,6 +502,8 @@ URLs:
 - https://www.youtube.com/watch?v=6oYY6ZfJ_KE
 ---
 Track: Trainers' Eyes Meet (Trainer)
+Additional Names:
+- 視線！トレーナー (Japanese release)
 Suffix Directory: true
 Duration: 0:18
 Artists:
@@ -429,6 +515,8 @@ Referenced Tracks:
 - track:battle-trainer-pokemon-sword-shield
 ---
 Track: Battle! (Trainer)
+Additional Names:
+- 戦闘！トレーナー (Japanese release)
 Suffix Directory: true
 Duration: 3:08
 Artists:
@@ -440,6 +528,8 @@ Referenced Tracks:
 - Title Screen (Pokémon Red / Pokémon Blue)
 ---
 Track: Victory! (Trainer)
+Additional Names:
+- トレーナーに勝利！ (Japanese release)
 Suffix Directory: true
 Duration: 0:33
 Artists:
@@ -451,6 +541,8 @@ Referenced Tracks:
 - Victory! (Trainer Battle) (Pokémon Red / Pokémon Blue)
 ---
 Track: Trainers' Eyes Meet (Lass)
+Additional Names:
+- 視線！ミニスカート (Japanese release)
 Suffix Directory: true
 Duration: 0:18
 Artists:
@@ -462,6 +554,8 @@ Referenced Tracks:
 - A Trainer Appears (Girl Version) (Pokémon Red / Pokémon Blue)
 ---
 Track: Evolution
+Additional Names:
+- 進化 (Japanese release)
 Suffix Directory: true
 Duration: 0:59
 Artists:
@@ -475,6 +569,8 @@ Sampled Tracks:
 - Evolution (Pokémon Red / Pokémon Blue)
 ---
 Track: Evolution (Galar)
+Additional Names:
+- 進化（ガラル） (Japanese release)
 Duration: 0:59
 Artists:
 - Minako Adachi
@@ -487,6 +583,8 @@ Sampled Tracks:
 - Evolution (Pokémon Red / Pokémon Blue)
 ---
 Track: Congratulations! Your Pokémon Evolved!
+Additional Names:
+- 進化おめでとう！ (Japanese release)
 Duration: 0:05
 Artists:
 - Minako Adachi
@@ -496,6 +594,8 @@ Referenced Tracks:
 - 'Fanfare: Evolution (Pokémon Red / Pokémon Blue)'
 ---
 Track: Galar Mine
+Additional Names:
+- ガラル鉱山 (Japanese release)
 Duration: 2:27
 Artists:
 - Go Ichinose
@@ -504,6 +604,8 @@ URLs:
 - https://www.youtube.com/watch?v=Nu4bZ6RaNMY
 ---
 Track: Trainers' Eyes Meet (Worker)
+Additional Names:
+- 視線！さぎょういん (Japanese release)
 Duration: 0:27
 Artists:
 - Go Ichinose
@@ -512,6 +614,8 @@ URLs:
 - https://www.youtube.com/watch?v=4Dy_QA4qrg4
 ---
 Track: Bede's Theme
+Additional Names:
+- ビートのテーマ (Japanese release)
 Duration: 1:41
 Artists:
 - Go Ichinose
@@ -520,6 +624,8 @@ URLs:
 - https://www.youtube.com/watch?v=w_3uePaatFo
 ---
 Track: Battle! (Bede)
+Additional Names:
+- 戦闘！ビート (Japanese release)
 Duration: 3:01
 Artists:
 - Go Ichinose
@@ -530,6 +636,8 @@ Referenced Tracks:
 - Bede's Theme
 ---
 Track: Trainers' Eyes Meet (Pokémon Breeder)
+Additional Names:
+- 視線！ポケモンブリーダー (Japanese release)
 Duration: 1:04
 Artists:
 - Go Ichinose
@@ -538,6 +646,8 @@ URLs:
 - https://www.youtube.com/watch?v=wVR-HijcJwA
 ---
 Track: Turffield
+Additional Names:
+- ターフタウン (Japanese release)
 Duration: 2:56
 Artists:
 - Go Ichinose
@@ -546,6 +656,8 @@ URLs:
 - https://www.youtube.com/watch?v=fvF_FCIj2KA
 ---
 Track: Gym Mission!
+Additional Names:
+- ジムミッション！ (Japanese release)
 Duration: 1:40
 Artists:
 - Minako Adachi
@@ -556,6 +668,8 @@ Referenced Tracks:
 - Pokémon Gym (Pokémon Red / Pokémon Blue)
 ---
 Track: Trainers' Eyes Meet (Gym Trainer)
+Additional Names:
+- 視線！ジムトレーナー (Japanese release)
 Duration: 0:19
 Artists:
 - Go Ichinose
@@ -566,6 +680,8 @@ Referenced Tracks:
 - track:battle-trainer-pokemon-sword-shield
 ---
 Track: Victory! (Gym Trainer)
+Additional Names:
+- ジムトレーナーに勝利！ (Japanese release)
 Duration: 0:37
 Artists:
 - Minako Adachi
@@ -576,6 +692,8 @@ Referenced Tracks:
 - Victory! (Trainer Battle) (Pokémon Red / Pokémon Blue)
 ---
 Track: Gym Mission Cleared!
+Additional Names:
+- ジムミッション クリア！！ (Japanese release)
 Duration: 0:04
 Artists:
 - Minako Adachi
@@ -586,6 +704,8 @@ Referenced Tracks:
 - Gym Mission!
 ---
 Track: Battle! (Gym Leader)
+Additional Names:
+- 戦闘！ジムリーダー (Japanese release)
 Suffix Directory: true
 Duration: 5:14
 Artists:
@@ -595,6 +715,8 @@ URLs:
 - https://www.youtube.com/watch?v=JJJZ5s1ddoI
 ---
 Track: Victory! (Gym Leader)
+Additional Names:
+- ジムリーダーに勝利！ (Japanese release)
 Suffix Directory: true
 Duration: 0:45
 Artists:
@@ -606,6 +728,8 @@ Referenced Tracks:
 - Victory! (Gym Leader Battle) (Pokémon Red / Pokémon Blue)
 ---
 Track: Obtained a Gym Badge!
+Additional Names:
+- ジムバッジを手に入れた！ (Japanese release)
 Suffix Directory: true
 Duration: 0:10
 Artists:
@@ -617,6 +741,8 @@ Referenced Tracks:
 - Obtained a Gym Badge (Pokémon Red / Pokémon Blue)
 ---
 Track: Hulbury
+Additional Names:
+- バウタウン (Japanese release)
 Duration: 2:31
 Artists:
 - Go Ichinose
@@ -625,6 +751,8 @@ URLs:
 - https://www.youtube.com/watch?v=NRUxNUlaVN4
 ---
 Track: Poké Jobs
+Additional Names:
+- ポケジョブ (Japanese release)
 Duration: 4:01
 Artists:
 - Go Ichinose (arranger)
@@ -635,6 +763,8 @@ URLs:
 - https://www.youtube.com/watch?v=GTdhAHjGfP4
 ---
 Track: Battle! (Marnie)
+Additional Names:
+- 戦闘！マリィ (Japanese release)
 Duration: 2:43
 Artists:
 - Minako Adachi
@@ -646,6 +776,8 @@ Referenced Tracks:
 - Battle! (Team Yell)
 ---
 Track: Wild Area (North)
+Additional Names:
+- ワイルドエリア・北 (Japanese release)
 Duration: 3:52
 Artists:
 - Minako Adachi
@@ -656,6 +788,8 @@ Referenced Tracks:
 - Wild Area (South)
 ---
 Track: Rotom Rally
+Additional Names:
+- ロトムラリー (Japanese release)
 Duration: 2:27
 Artists:
 - Go Ichinose
@@ -664,6 +798,8 @@ URLs:
 - https://www.youtube.com/watch?v=YwqBri2xEUQ
 ---
 Track: Reach Goal in Rotom Rally!
+Additional Names:
+- ロトムラリーでゴール！ (Japanese release)
 Duration: 0:04
 Artists:
 - Go Ichinose
@@ -673,6 +809,8 @@ Referenced Tracks:
 - track:title-screen-pokemon-sword-shield
 ---
 Track: Hammerlocke
+Additional Names:
+- ナックルシティ (Japanese release)
 Duration: 1:55
 Artists:
 - Minako Adachi
@@ -681,6 +819,8 @@ URLs:
 - https://www.youtube.com/watch?v=v1WtWJYwcdY
 ---
 Track: Hair Salon
+Additional Names:
+- ヘアサロン (Japanese release)
 Suffix Directory: true
 Duration: 1:54
 Artists:
@@ -690,6 +830,8 @@ URLs:
 - https://www.youtube.com/watch?v=p7K2yebT0aQ
 ---
 Track: Route 6
+Additional Names:
+- ６番道路 (Japanese release)
 Suffix Directory: true
 Duration: 2:48
 Artists:
@@ -701,6 +843,8 @@ Referenced Tracks:
 - Wild Area (North)
 ---
 Track: Trainers' Eyes Meet (Artist)
+Additional Names:
+- 視線！げいじゅつか (Japanese release)
 Suffix Directory: true
 Duration: 0:31
 Artists:
@@ -710,6 +854,8 @@ URLs:
 - https://www.youtube.com/watch?v=8YyJjeizRVk
 ---
 Track: Stow-on-Side
+Additional Names:
+- ラテラルタウン (Japanese release)
 Duration: 2:42
 Artists:
 - Minako Adachi
@@ -718,6 +864,8 @@ URLs:
 - https://www.youtube.com/watch?v=d0FE9PYLWW8
 ---
 Track: The Ancient Mural Crumbles
+Additional Names:
+- 崩れる遺跡 (Japanese release)
 Duration: 0:28
 Artists:
 - Go Ichinose
@@ -728,6 +876,8 @@ Referenced Tracks:
 - The Truth Behind the Mural
 ---
 Track: The Truth Behind the Mural
+Additional Names:
+- 遺跡の真実 (Japanese release)
 Duration: 4:52
 Artists:
 - Go Ichinose
@@ -736,6 +886,8 @@ URLs:
 - https://www.youtube.com/watch?v=emiLhRPsgIM
 ---
 Track: Glimwood Tangle
+Additional Names:
+- ルミナスメイズの森 (Japanese release)
 Duration: 3:13
 Artists:
 - Minako Adachi
@@ -744,6 +896,8 @@ URLs:
 - https://www.youtube.com/watch?v=csGNQoR-n_s
 ---
 Track: Ballonlea
+Additional Names:
+- アラベスクタウン (Japanese release)
 Duration: 3:55
 Artists:
 - Minako Adachi
@@ -752,6 +906,8 @@ URLs:
 - https://www.youtube.com/watch?v=_qNxTGgbGfM
 ---
 Track: Circhester
+Additional Names:
+- キルクスタウン (Japanese release)
 Duration: 3:07
 Artists:
 - Minako Adachi
@@ -764,6 +920,8 @@ Start Counting From: 1
 Color: '#fff001'
 ---
 Track: Spikemuth
+Additional Names:
+- スパイクタウン (Japanese release)
 Duration: 2:06
 Artists:
 - Minako Adachi
@@ -772,6 +930,8 @@ URLs:
 - https://www.youtube.com/watch?v=5yVnAemSAKM
 ---
 Track: Battle! (Team Yell)
+Additional Names:
+- 戦闘！エール団 (Japanese release)
 Duration: 2:39
 Artists:
 - Minako Adachi
@@ -782,6 +942,8 @@ Referenced Tracks:
 - Team Yell Appears!
 ---
 Track: 'Battle! (Gym Leader: Piers)'
+Additional Names:
+- 戦闘！ジムリーダーネズ (Japanese release)
 Duration: 3:11
 Artists:
 - Minako Adachi
@@ -792,6 +954,8 @@ Referenced Tracks:
 - Battle! (Team Yell)
 ---
 Track: Route 10
+Additional Names:
+- １０番道路 (Japanese release)
 Duration: 1:38
 Artists:
 - Go Ichinose
@@ -800,6 +964,8 @@ URLs:
 - https://www.youtube.com/watch?v=dwoRVf6PVIc
 ---
 Track: Wyndon
+Additional Names:
+- シュートシティ (Japanese release)
 Duration: 4:01
 Artists:
 - Go Ichinose
@@ -808,6 +974,8 @@ URLs:
 - https://www.youtube.com/watch?v=Q3lqHojx1Nk
 ---
 Track: Wyndon Stadium
+Additional Names:
+- シュートスタジアム (Japanese release)
 Duration: 2:11
 Artists:
 - Minako Adachi
@@ -818,6 +986,8 @@ Referenced Tracks:
 - Gym Challenge Opening Ceremony
 ---
 Track: Decisive Battle! (Marnie)
+Additional Names:
+- 決戦！マリィ (Japanese release)
 Duration: 3:24
 Artists:
 - Minako Adachi
@@ -828,6 +998,8 @@ Referenced Tracks:
 - Battle! (Marnie)
 ---
 Track: Decisive Battle! (Hop)
+Additional Names:
+- 決戦！ホップ (Japanese release)
 Duration: 3:15
 Artists:
 - Go Ichinose
@@ -838,6 +1010,8 @@ Referenced Tracks:
 - Battle! (Hop)
 ---
 Track: Rose Tower
+Additional Names:
+- ローズタワー (Japanese release)
 Duration: 2:25
 Artists:
 - Minako Adachi
@@ -848,6 +1022,8 @@ Referenced Tracks:
 - Chairman Rose
 ---
 Track: Reaching the Top
+Additional Names:
+- てっぺん到着 (Japanese release)
 Duration: 2:24
 Artists:
 - Minako Adachi
@@ -858,6 +1034,8 @@ Referenced Tracks:
 - Rose Tower
 ---
 Track: Battle! (Oleana)
+Additional Names:
+- 戦闘！オリーヴ (Japanese release)
 Duration: 2:27
 Artists:
 - Minako Adachi
@@ -869,6 +1047,8 @@ Referenced Tracks:
 - Chairman Rose
 ---
 Track: The Finals Begin
+Additional Names:
+- ファイナルトーナメント開催！ (Japanese release)
 Duration: 0:29
 Artists:
 - Minako Adachi
@@ -877,6 +1057,8 @@ URLs:
 - https://www.youtube.com/watch?v=9fj3jKL8N34
 ---
 Track: Battle! (Finals)
+Additional Names:
+- 戦闘！ファイナルトーナメント！ (Japanese release)
 Duration: 4:33
 Artists:
 - Minako Adachi
@@ -887,6 +1069,8 @@ Referenced Tracks:
 - track:battle-gym-leader-pokemon-sword-shield
 ---
 Track: Victory! (Champion Cup)
+Additional Names:
+- チャンピオンカップで勝利！ (Japanese release)
 Duration: 0:36
 Artists:
 - Minako Adachi
@@ -897,6 +1081,8 @@ Referenced Tracks:
 - Battle! (Finals)
 ---
 Track: The Darkest Day
+Additional Names:
+- ブラックナイト (Japanese release)
 Duration: 0:32
 Artists:
 - Minako Adachi
@@ -905,6 +1091,8 @@ URLs:
 - https://www.youtube.com/watch?v=sCpVnlx8ySA
 ---
 Track: Deep in the Forest
+Additional Names:
+- 森の奥で (Japanese release)
 Duration: 2:04
 Artists:
 - Go Ichinose
@@ -915,6 +1103,8 @@ Referenced Tracks:
 - In the Fog
 ---
 Track: A Bizarre Situation
+Additional Names:
+- 異常事態 (Japanese release)
 Duration: 1:59
 Artists:
 - Minako Adachi
@@ -923,6 +1113,8 @@ URLs:
 - https://www.youtube.com/watch?v=62An3smV0NU
 ---
 Track: Battle! (Rose)
+Additional Names:
+- 戦闘！ローズ (Japanese release)
 Duration: 3:01
 Artists:
 - Minako Adachi
@@ -931,6 +1123,8 @@ URLs:
 - https://www.youtube.com/watch?v=S9H2Vbtl9OM
 ---
 Track: Leon and Eternatus
+Additional Names:
+- ダンデとムゲンダイナ (Japanese release)
 Duration: 0:29
 Artists:
 - Minako Adachi
@@ -939,6 +1133,8 @@ URLs:
 - https://www.youtube.com/watch?v=SFaMOms5OSg
 ---
 Track: Battle! (Eternatus)
+Additional Names:
+- 戦闘！ムゲンダイナ (Japanese release)
 Duration: 3:34
 Artists:
 - Go Ichinose
@@ -947,6 +1143,8 @@ URLs:
 - https://www.youtube.com/watch?v=6ocbwkxaFuI
 ---
 Track: Eternal Power
+Additional Names:
+- 無限大の力 (Japanese release)
 Duration: 2:42
 Artists:
 - Go Ichinose
@@ -957,6 +1155,8 @@ Referenced Tracks:
 - Battle! (Eternatus)
 ---
 Track: Decisive Battle! (Eternatus)
+Additional Names:
+- 決戦！ムゲンダイナ (Japanese release)
 Duration: 4:29
 Artists:
 - Go Ichinose
@@ -968,6 +1168,8 @@ Referenced Tracks:
 - In the Fog
 ---
 Track: You Caught Eternatus!
+Additional Names:
+- ムゲンダイナを捕まえた！ (Japanese release)
 Duration: 0:28
 Artists:
 - Go Ichinose
@@ -979,6 +1181,8 @@ Referenced Tracks:
 - Decisive Battle! (Eternatus)
 ---
 Track: Decisive Battle! (Champion Leon)
+Additional Names:
+- 決戦！チャンピオンダンデ (Japanese release)
 Duration: 5:07
 Artists:
 - Go Ichinose
@@ -990,6 +1194,8 @@ Referenced Tracks:
 - Decisive Battle! (Eternatus)
 ---
 Track: Victory! (Champion Leon)
+Additional Names:
+- チャンピオンダンデに勝利！ (Japanese release)
 Duration: 0:36
 Artists:
 - Go Ichinose
@@ -1000,6 +1206,8 @@ Referenced Tracks:
 - Decisive Battle! (Champion Leon)
 ---
 Track: For a Bright Future
+Additional Names:
+- 明るい未来をつくるために (Japanese release)
 Duration: 1:16
 Artists:
 - Go Ichinose
@@ -1012,6 +1220,8 @@ Referenced Tracks:
 ## lists Adachi as composer next to Masuda so probably referencing something else too, probably from this game
 ---
 Track: Battle Tower
+Additional Names:
+- バトルタワー (Japanese release)
 Suffix Directory: true
 Duration: 1:48
 Artists:
@@ -1023,6 +1233,8 @@ Referenced Tracks:
 - Battle Tower (Johto) (Pokémon Crystal)
 ---
 Track: Battle! (Battle Tower)
+Additional Names:
+- 戦闘！バトルタワー (Japanese release)
 Duration: 5:16
 Artists:
 - Toby Fox
@@ -1056,6 +1268,8 @@ Commentary: |- ##https://www.pokemon.com/us/pokemon-news/a-special-letter-and-so
     It doesn't seem to be an intentional reference, but people pointed out this song has a similar melody to [[track:a-baby-legend]].
 ---
 Track: Battle! (Zacian/Zamazenta)
+Additional Names:
+- 戦闘！ザシアン・ザマゼンタ (Japanese release)
 Duration: 4:19
 Artists:
 - Go Ichinose
@@ -1070,6 +1284,8 @@ Start Counting From: 1
 Color: '#38ad69'
 ---
 Track: Isle of Armor
+Additional Names:
+- ヨロイ島 (Japanese release)
 Duration: 2:41
 Artists:
 - Minako Adachi
@@ -1078,6 +1294,8 @@ URLs:
 - https://www.youtube.com/watch?v=92xKA9VmxLE
 ---
 Track: Krazy for Klara
+Additional Names:
+- クララにクラクラァ (Japanese release)
 Duration: 1:36
 Artists:
 - Hitomi Sato
@@ -1086,6 +1304,8 @@ URLs:
 - https://www.youtube.com/watch?v=1ZqZhDmpD04
 ---
 Track: Battle! (Klara)
+Additional Names:
+- 戦闘！クララ (Japanese release)
 Duration: 2:03
 Artists:
 - Minako Adachi
@@ -1096,6 +1316,8 @@ Referenced Tracks:
 - Krazy for Klara
 ---
 Track: The Amazing Avery
+Additional Names:
+- スーパー☆セイボリー (Japanese release)
 Duration: 1:26
 Artists:
 - Hitomi Sato
@@ -1104,6 +1326,8 @@ URLs:
 - https://www.youtube.com/watch?v=8RJAMvT1I8s
 ---
 Track: Battle! (Avery)
+Additional Names:
+- 戦闘！セイボリー (Japanese release)
 Duration: 1:42
 Artists:
 - Minako Adachi
@@ -1114,6 +1338,8 @@ Referenced Tracks:
 - The Amazing Avery
 ---
 Track: Master Dojo
+Additional Names:
+- マスター道場 (Japanese release)
 Duration: 1:53
 Artists:
 - Minako Adachi
@@ -1122,6 +1348,8 @@ URLs:
 - https://www.youtube.com/watch?v=7I_YCZUKkPI
 ---
 Track: Mustard's Theme
+Additional Names:
+- マスタードのテーマ (Japanese release)
 Duration: 2:07
 Artists:
 - Hitomi Sato
@@ -1130,6 +1358,8 @@ URLs:
 - https://www.youtube.com/watch?v=4Xni9LM9J-0
 ---
 Track: Battle! (Mustard)
+Additional Names:
+- 戦闘！マスタード (Japanese release)
 Duration: 2:20
 Artists:
 - Minako Adachi
@@ -1140,6 +1370,8 @@ Referenced Tracks:
 - Mustard's Theme
 ---
 Track: Obtained an Item...?
+Additional Names:
+- 道具を手に入れ…… (Japanese release)
 Directory: obtained-an-item-but
 Duration: 0:04
 Artists:
@@ -1151,6 +1383,8 @@ Sampled Tracks:
 - track:obtained-an-item-pokemon-sword-shield
 ---
 Track: Secret Armor
+Additional Names:
+- 秘伝のヨロイ (Japanese release)
 Duration: 0:41
 Artists:
 - Minako Adachi
@@ -1161,6 +1395,8 @@ Referenced Tracks:
 - Battle! (Mustard)
 ---
 Track: Tower of Waters
+Additional Names:
+- みずの塔 (Japanese release)
 Duration: 3:07
 Artists:
 - Minako Adachi
@@ -1169,6 +1405,8 @@ URLs:
 - https://www.youtube.com/watch?v=bPm5Zki1joM
 ---
 Track: Tower of Darkness
+Additional Names:
+- あくの塔 (Japanese release)
 Duration: 3:07
 Artists:
 - Minako Adachi
@@ -1179,6 +1417,8 @@ Referenced Tracks:
 - Tower of Waters
 ---
 Track: Battle! (Serious Mustard)
+Additional Names:
+- 戦闘！本気のマスタード (Japanese release)
 Duration: 2:50
 Artists:
 - Minako Adachi
@@ -1190,6 +1430,8 @@ Referenced Tracks:
 - Tower of Waters
 ---
 Track: Victory! (Mustard)
+Additional Names:
+- マスタードに勝利！ (Japanese release)
 Duration: 0:57
 Artists:
 - Minako Adachi
@@ -1200,6 +1442,8 @@ Referenced Tracks:
 - Battle! (Serious Mustard)
 ---
 Track: Victory with Kubfu
+Additional Names:
+- ダクマと勝利 (Japanese release)
 Duration: 0:26
 Artists:
 - Minako Adachi
@@ -1210,6 +1454,8 @@ Referenced Tracks:
 - Mustard's Theme
 ---
 Track: Crown Tundra
+Additional Names:
+- カンムリ雪原 (Japanese release)
 Duration: 4:32
 Artists:
 - Minako Adachi
@@ -1218,6 +1464,8 @@ URLs:
 - https://www.youtube.com/watch?v=ESOTrCO-bF4
 ---
 Track: Peony's Theme
+Additional Names:
+- ピオニーのテーマ (Japanese release)
 Duration: 1:53
 Artists:
 - Hitomi Sato
@@ -1226,6 +1474,8 @@ URLs:
 - https://www.youtube.com/watch?v=gdRCcp63qkM
 ---
 Track: Battle! (Peony)
+Additional Names:
+- 戦闘！ピオニー (Japanese release)
 Duration: 2:54
 Artists:
 - Hitomi Sato
@@ -1234,6 +1484,8 @@ URLs:
 - https://www.youtube.com/watch?v=6Np45H24SGI
 ---
 Track: Max Lair
+Additional Names:
+- マックスダイ巣穴 (Japanese release)
 Duration: 1:29
 Artists:
 - Hitomi Sato
@@ -1242,6 +1494,8 @@ URLs:
 - https://www.youtube.com/watch?v=owYdSVoMXqU
 ---
 Track: Dynamax Adventure
+Additional Names:
+- ダイマックスアドベンチャー (Japanese release)
 Duration: 3:00
 Artists:
 - Hitomi Sato
@@ -1252,6 +1506,8 @@ Referenced Tracks:
 - Battle! (Max Raid Battle)
 ---
 Track: Battle! (Dynamax Adventure)
+Additional Names:
+- 戦闘！ダイマックスアドベンチャー (Japanese release)
 Duration: 3:05
 Artists:
 - Go Ichinose
@@ -1262,6 +1518,8 @@ Referenced Tracks:
 - Battle! (Max Raid Battle)
 ---
 Track: Freezington
+Additional Names:
+- フリーズ村 (Japanese release)
 Duration: 3:00
 Artists:
 - Minako Adachi
@@ -1270,6 +1528,8 @@ URLs:
 - https://www.youtube.com/watch?v=v7Rg7dyb6zY
 ---
 Track: Legends of Legendary Pokémon
+Additional Names:
+- 伝説！伝説の伝説！！ (Japanese release)
 Duration: 0:09
 Artists:
 - Hitomi Sato
@@ -1278,6 +1538,8 @@ URLs:
 - https://www.youtube.com/watch?v=F4FMyZ0Td5Y
 ---
 Track: The King of Bountiful Harvests
+Additional Names:
+- 豊穣の王 (Japanese release)
 Duration: 1:36
 Artists:
 - Hitomi Sato
@@ -1288,6 +1550,8 @@ Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
 ---
 Track: Battle! (Calyrex)
+Additional Names:
+- 戦闘！バドレックス (Japanese release)
 Duration: 3:21
 Artists:
 - Junichi Masuda
@@ -1298,6 +1562,8 @@ Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
 ---
 Track: Dance of Bountiful Harvests
+Additional Names:
+- 豊穣の踊り (Japanese release)
 Duration: 0:09
 Artists:
 - Minako Adachi
@@ -1306,6 +1572,8 @@ URLs:
 - https://www.youtube.com/watch?v=eHcoVQwAb48
 ---
 Track: Battle! (Glastrier/Spectrier)
+Additional Names:
+- 戦闘！ブリザポス・レイスポス (Japanese release)
 Duration: 2:12
 Artists:
 - Junichi Masuda
@@ -1316,6 +1584,8 @@ Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
 ---
 Track: Crown Shrine
+Additional Names:
+- カンムリ神殿 (Japanese release)
 Duration: 1:56
 Artists:
 - Minako Adachi
@@ -1326,6 +1596,8 @@ Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
 ---
 Track: As One
+Additional Names:
+- じんばいったい (Japanese release)
 Duration: 1:13
 Artists:
 - Minako Adachi
@@ -1337,6 +1609,8 @@ Referenced Tracks:
 - Battle! (The King of Bountiful Harvests)
 ---
 Track: Battle! (The King of Bountiful Harvests)
+Additional Names:
+- 戦闘！豊穣の王 (Japanese release)
 Duration: 2:37
 Artists:
 - Junichi Masuda
@@ -1345,6 +1619,8 @@ URLs:
 - https://www.youtube.com/watch?v=27GaAUbE8LA
 ---
 Track: You Found a Clue!
+Additional Names:
+- 手がかりを見つけた！ (Japanese release)
 Duration: 0:04
 Artists:
 - Keita Okamoto
@@ -1353,6 +1629,8 @@ URLs:
 - https://www.youtube.com/watch?v=F_cQmGvvOD8
 ---
 Track: Battle! (The Giant of Legend)
+Additional Names:
+- 戦闘！伝説の巨人 (Japanese release)
 Duration: 2:30
 Artists:
 - Hitomi Sato
@@ -1363,6 +1641,8 @@ Referenced Tracks:
 - Battle! (Regirock/Regice/Registeel) (Pokémon Ruby / Pokémon Sapphire)
 ---
 Track: Gathering at the Tree
+Additional Names:
+- 大樹に集う (Japanese release)
 Duration: 1:06
 Artists:
 - Minako Adachi
@@ -1373,6 +1653,8 @@ Referenced Tracks:
 - Battle! (The Bird Pokémon of Legend)
 ---
 Track: Battle! (The Bird Pokémon of Legend)
+Additional Names:
+- 戦闘！伝説のとりポケモン (Japanese release)
 Duration: 4:19
 Artists:
 - Go Ichinose
@@ -1381,6 +1663,8 @@ URLs:
 - https://www.youtube.com/watch?v=1qRZMVbrPLM
 ---
 Track: Staff Credits
+Additional Names:
+- スタッフロール (Japanese release)
 Suffix Directory: true
 Duration: 3:30
 Artists:

--- a/album/undertale-collectors-edition-soundtrack.yaml
+++ b/album/undertale-collectors-edition-soundtrack.yaml
@@ -29,6 +29,11 @@ Section: Disc 1
 ---
 Track: Once Upon a Time
 Main Release: Once Upon a Time
+Additional Names:
+- Name: >-
+    むかしむかし…
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:29
 URLs:
 - https://tobyfox.bandcamp.com/track/once-upon-a-time-2
@@ -37,6 +42,11 @@ URLs:
 ---
 Track: Start Menu
 Main Release: Start Menu
+Additional Names:
+- Name: >-
+    スタートメニュー
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/start-menu
@@ -45,6 +55,11 @@ URLs:
 ---
 Track: Your Best Friend
 Main Release: Your Best Friend
+Additional Names:
+- Name: >-
+    キミの親友
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:23
 URLs:
 - https://tobyfox.bandcamp.com/track/your-best-friend-2
@@ -53,6 +68,11 @@ URLs:
 ---
 Track: Fallen Down
 Main Release: track:fallen-down-undertale
+Additional Names:
+- Name: >-
+    おちてきた子
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/fallen-down-2
@@ -61,6 +81,11 @@ URLs:
 ---
 Track: Ruins
 Main Release: track:ruins-undertale
+Additional Names:
+- Name: >-
+    いせき
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:32
 URLs:
 - https://tobyfox.bandcamp.com/track/ruins-2
@@ -69,6 +94,11 @@ URLs:
 ---
 Track: Uwa!! So Temperate♫
 Main Release: Uwa!! So Temperate♫
+Additional Names:
+- Name: >-
+    おだやかだワン！♫
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-temperate
@@ -77,6 +107,11 @@ URLs:
 ---
 Track: Anticipation
 Main Release: Anticipation
+Additional Names:
+- Name: >-
+    緊迫のとき
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:22
 URLs:
 - https://tobyfox.bandcamp.com/track/anticipation-2
@@ -85,6 +120,11 @@ URLs:
 ---
 Track: Unnecessary Tension
 Main Release: Unnecessary Tension
+Additional Names:
+- Name: >-
+    重要任務…？
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:17
 URLs:
 - https://tobyfox.bandcamp.com/track/unnecessary-tension-2
@@ -93,6 +133,11 @@ URLs:
 ---
 Track: Enemy Approaching
 Main Release: Enemy Approaching
+Additional Names:
+- Name: >-
+    ENEMY APPROACHING!
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/enemy-approaching-2
@@ -101,6 +146,11 @@ URLs:
 ---
 Track: Ghost Fight
 Main Release: Ghost Fight
+Additional Names:
+- Name: >-
+    ゴースト・ファイト
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/ghost-fight-2
@@ -109,6 +159,11 @@ URLs:
 ---
 Track: Determination
 Main Release: Determination
+Additional Names:
+- Name: >-
+    ケツイ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/determination-2
@@ -117,6 +172,11 @@ URLs:
 ---
 Track: Home
 Main Release: track:home-undertale
+Additional Names:
+- Name: >-
+    ホーム
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-2
@@ -125,6 +185,11 @@ URLs:
 ---
 Track: Home (Music Box)
 Main Release: Home (Music Box)
+Additional Names:
+- Name: >-
+    ホーム（オルゴール）
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-music-box-2
@@ -133,6 +198,11 @@ URLs:
 ---
 Track: Heartache
 Main Release: Heartache
+Additional Names:
+- Name: >-
+    心の痛み
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:48
 URLs:
 - https://tobyfox.bandcamp.com/track/heartache-2
@@ -141,6 +211,11 @@ URLs:
 ---
 Track: sans.
 Main Release: sans.
+Additional Names:
+- Name: >-
+    サンズ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:51
 URLs:
 - https://tobyfox.bandcamp.com/track/sans
@@ -149,6 +224,11 @@ URLs:
 ---
 Track: Nyeh Heh Heh!
 Main Release: Nyeh Heh Heh!
+Additional Names:
+- Name: >-
+    ニャハハ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/nyeh-heh-heh-2
@@ -157,6 +237,11 @@ URLs:
 ---
 Track: Snowy
 Main Release: Snowy
+Additional Names:
+- Name: >-
+    雪景色
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:44
 URLs:
 - https://tobyfox.bandcamp.com/track/snowy
@@ -165,6 +250,11 @@ URLs:
 ---
 Track: Uwa!! So Holiday♫
 Main Release: Uwa!! So Holiday♫
+Additional Names:
+- Name: >-
+    ホリデーシーズンだワン！♫
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:30
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-holiday
@@ -173,6 +263,11 @@ URLs:
 ---
 Track: Dogbass
 Main Release: Dogbass
+Additional Names:
+- Name: >-
+    ドッグベース
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:07
 URLs:
 - https://tobyfox.bandcamp.com/track/dogbass
@@ -181,6 +276,11 @@ URLs:
 ---
 Track: Mysterious Place
 Main Release: Mysterious Place
+Additional Names:
+- Name: >-
+    謎めいた場所
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/mysterious-place
@@ -189,6 +289,11 @@ URLs:
 ---
 Track: Dogsong
 Main Release: Dogsong
+Additional Names:
+- Name: >-
+    ドッグソング
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:37
 URLs:
 - https://tobyfox.bandcamp.com/track/dogsong
@@ -197,6 +302,11 @@ URLs:
 ---
 Track: Snowdin Town
 Main Release: Snowdin Town
+Additional Names:
+- Name: >-
+    スノーフルのまち
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:16
 URLs:
 - https://tobyfox.bandcamp.com/track/snowdin-town
@@ -205,6 +315,11 @@ URLs:
 ---
 Track: Shop
 Main Release: track:shop-undertale
+Additional Names:
+- Name: >-
+    いらっしゃいませ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/shop
@@ -221,6 +336,11 @@ URLs:
 ---
 Track: Dating Start!
 Main Release: Dating Start!
+Additional Names:
+- Name: >-
+    DATE START!
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:57
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-start
@@ -229,6 +349,11 @@ URLs:
 ---
 Track: Dating Tense!
 Main Release: Dating Tense!
+Additional Names:
+- Name: >-
+    DATE DANGER!
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-tense
@@ -237,6 +362,11 @@ URLs:
 ---
 Track: Dating Fight!
 Main Release: Dating Fight!
+Additional Names:
+- Name: >-
+    DATE FIGHT!
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:36
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-fight
@@ -245,6 +375,11 @@ URLs:
 ---
 Track: Premonition
 Main Release: track:premonition-undertale
+Additional Names:
+- Name: >-
+    もしかして…
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/premonition
@@ -253,6 +388,11 @@ URLs:
 ---
 Track: Danger Mystery
 Main Release: Danger Mystery
+Additional Names:
+- Name: >-
+    キケンのナゾ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/danger-mystery
@@ -261,6 +401,11 @@ URLs:
 ---
 Track: Undyne
 Main Release: Undyne
+Additional Names:
+- Name: >-
+    アンダイン
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/undyne
@@ -269,6 +414,11 @@ URLs:
 ---
 Track: Waterfall
 Main Release: Waterfall
+Additional Names:
+- Name: >-
+    ウォーターフェル
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:07
 URLs:
 - https://tobyfox.bandcamp.com/track/waterfall
@@ -277,6 +427,11 @@ URLs:
 ---
 Track: Run!
 Main Release: Run!
+Additional Names:
+- Name: >-
+    逃げろ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:27
 URLs:
 - https://tobyfox.bandcamp.com/track/run
@@ -285,6 +440,11 @@ URLs:
 ---
 Track: Quiet Water
 Main Release: Quiet Water
+Additional Names:
+- Name: >-
+    やすらぎの水辺
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/quiet-water
@@ -293,6 +453,11 @@ URLs:
 ---
 Track: Memory
 Main Release: track:memory-undertale
+Additional Names:
+- Name: >-
+    思い出
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:15
 URLs:
 - https://tobyfox.bandcamp.com/track/memory
@@ -301,6 +466,11 @@ URLs:
 ---
 Track: Bird That Carries You Over A Disproportionately Small Gap
 Main Release: Bird That Carries You Over A Disproportionately Small Gap
+Additional Names:
+- Name: >-
+    びっくりするほど近い距離を飛んで渡らせてくれる鳥
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/bird-that-carries-you-over-a-disproportionately-small-gap
@@ -309,6 +479,11 @@ URLs:
 ---
 Track: Dummy!
 Main Release: Dummy!
+Additional Names:
+- Name: >-
+    怒りのマネキン！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dummy
@@ -317,6 +492,11 @@ URLs:
 ---
 Track: Pathetic House
 Main Release: Pathetic House
+Additional Names:
+- Name: >-
+    みすぼらしい家
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:39
 URLs:
 - https://tobyfox.bandcamp.com/track/pathetic-house
@@ -325,6 +505,11 @@ URLs:
 ---
 Track: Spooktune
 Main Release: track:spooktune-undertale
+Additional Names:
+- Name: >-
+    ブルブルチューン
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:24
 URLs:
 - https://tobyfox.bandcamp.com/track/spooktune
@@ -333,6 +518,11 @@ URLs:
 ---
 Track: Spookwave
 Main Release: Spookwave
+Additional Names:
+- Name: >-
+    ブルブルウェーブ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/spookwave
@@ -341,6 +531,11 @@ URLs:
 ---
 Track: Ghouliday
 Main Release: Ghouliday
+Additional Names:
+- Name: >-
+    グロすマスソング
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:13
 URLs:
 - https://tobyfox.bandcamp.com/track/ghouliday
@@ -349,6 +544,11 @@ URLs:
 ---
 Track: Chill
 Main Release: track:chill-undertale
+Additional Names:
+- Name: >-
+    まったり
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/chill
@@ -357,6 +557,11 @@ URLs:
 ---
 Track: Thundersnail
 Main Release: Thundersnail
+Additional Names:
+- Name: >-
+    サンダースネイル
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:42
 URLs:
 - https://tobyfox.bandcamp.com/track/thundersnail
@@ -365,6 +570,11 @@ URLs:
 ---
 Track: Temmie Village
 Main Release: Temmie Village
+Additional Names:
+- Name: >-
+    手ミーむら！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/temmie-village
@@ -373,6 +583,11 @@ URLs:
 ---
 Track: Tem Shop
 Main Release: Tem Shop
+Additional Names:
+- Name: >-
+    手ミーみせ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/tem-shop
@@ -381,6 +596,11 @@ URLs:
 ---
 Track: NGAHHH!!
 Main Release: NGAHHH!!
+Additional Names:
+- Name: >-
+    ぬあああああ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:23
 URLs:
 - https://tobyfox.bandcamp.com/track/ngahhh
@@ -389,6 +609,11 @@ URLs:
 ---
 Track: Spear of Justice
 Main Release: Spear of Justice
+Additional Names:
+- Name: >-
+    正義の槍
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:55
 URLs:
 - https://tobyfox.bandcamp.com/track/spear-of-justice
@@ -397,6 +622,11 @@ URLs:
 ---
 Track: Ooo
 Main Release: Ooo
+Additional Names:
+- Name: >-
+    Woo
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/ooo
@@ -405,6 +635,11 @@ URLs:
 ---
 Track: Alphys
 Main Release: Alphys
+Additional Names:
+- Name: >-
+    アルフィー
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:26
 URLs:
 - https://tobyfox.bandcamp.com/track/alphys
@@ -413,6 +648,11 @@ URLs:
 ---
 Track: It's Showtime!
 Main Release: It's Showtime!
+Additional Names:
+- Name: >-
+    イッツ・ショータイム！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/its-showtime
@@ -421,6 +661,11 @@ URLs:
 ---
 Track: Metal Crusher
 Main Release: Metal Crusher
+Additional Names:
+- Name: >-
+    メタル・クラッシャー
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/metal-crusher
@@ -437,6 +682,11 @@ URLs:
 ---
 Track: Uwa!! So HEATS!!♫
 Main Release: Uwa!! So HEATS!!♫
+Additional Names:
+- Name: >-
+    あついワン！♫
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:34
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-heats
@@ -445,6 +695,11 @@ URLs:
 ---
 Track: Stronger Monsters
 Main Release: Stronger Monsters
+Additional Names:
+- Name: >-
+    強敵たち
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/stronger-monsters
@@ -453,6 +708,11 @@ URLs:
 ---
 Track: Hotel
 Main Release: track:hotel-undertale
+Additional Names:
+- Name: >-
+    ホテル
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:28
 URLs:
 - https://tobyfox.bandcamp.com/track/hotel
@@ -461,6 +721,11 @@ URLs:
 ---
 Track: Can You Really Call This A Hotel, I Didn't Receive A Mint On My Pillow Or Anything
 Main Release: Can You Really Call This A Hotel, I Didn't Receive A Mint On My Pillow Or Anything
+Additional Names:
+- Name: >-
+    枕の上にミントチョコレートも置いていない宿泊施設をホテルと呼んでよいものだろうか
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:01
 URLs:
 - https://tobyfox.bandcamp.com/track/can-you-really-call-this-a-hotel-i-didnt-receive-a-mint-on-my-pillow-or-anything
@@ -469,6 +734,11 @@ URLs:
 ---
 Track: Confession
 Main Release: track:confession-undertale
+Additional Names:
+- Name: >-
+    告白
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:43
 URLs:
 - https://tobyfox.bandcamp.com/track/confession
@@ -477,6 +747,11 @@ URLs:
 ---
 Track: Live Report
 Main Release: Live Report
+Additional Names:
+- Name: >-
+    現場から中継です
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/live-report
@@ -485,6 +760,11 @@ URLs:
 ---
 Track: Death Report
 Main Release: Death Report
+Additional Names:
+- Name: >-
+    絶対絶命レポート
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:47
 URLs:
 - https://tobyfox.bandcamp.com/track/death-report
@@ -493,6 +773,11 @@ URLs:
 ---
 Track: Spider Dance
 Main Release: Spider Dance
+Additional Names:
+- Name: >-
+    スパイダーダンス
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:46
 URLs:
 - https://tobyfox.bandcamp.com/track/spider-dance
@@ -501,6 +786,11 @@ URLs:
 ---
 Track: Wrong Enemy !?
 Main Release: Wrong Enemy !?
+Additional Names:
+- Name: >-
+    おかしな敵
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:59
 URLs:
 - https://tobyfox.bandcamp.com/track/wrong-enemy
@@ -509,6 +799,11 @@ URLs:
 ---
 Track: Oh! One True Love
 Main Release: Oh! One True Love
+Additional Names:
+- Name: >-
+    ああ！運命の人よ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:24
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-one-true-love
@@ -517,6 +812,11 @@ URLs:
 ---
 Track: Oh! Dungeon
 Main Release: Oh! Dungeon
+Additional Names:
+- Name: >-
+    ああ！とらわれの恋人よ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:33
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-dungeon
@@ -525,6 +825,11 @@ URLs:
 ---
 Track: It's Raining Somewhere Else
 Main Release: It's Raining Somewhere Else
+Additional Names:
+- Name: >-
+    今日もどこかで雨が降る
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:50
 URLs:
 - https://tobyfox.bandcamp.com/track/its-raining-somewhere-else
@@ -533,6 +838,11 @@ URLs:
 ---
 Track: CORE Approach
 Main Release: CORE Approach
+Additional Names:
+- Name: >-
+    コアへの接近
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:12
 URLs:
 - https://tobyfox.bandcamp.com/track/core-approach
@@ -541,6 +851,11 @@ URLs:
 ---
 Track: CORE
 Main Release: CORE
+Additional Names:
+- Name: >-
+    コア
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:46
 URLs:
 - https://tobyfox.bandcamp.com/track/core
@@ -549,6 +864,11 @@ URLs:
 ---
 Track: Last Episode!
 Main Release: Last Episode!
+Additional Names:
+- Name: >-
+    最終回！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:08
 URLs:
 - https://tobyfox.bandcamp.com/track/last-episode
@@ -557,6 +877,11 @@ URLs:
 ---
 Track: Oh My...
 Main Release: Oh My...
+Additional Names:
+- Name: >-
+    なんとッ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-my
@@ -565,6 +890,11 @@ URLs:
 ---
 Track: Death by Glamour
 Main Release: Death by Glamour
+Additional Names:
+- Name: >-
+    華麗なる死闘
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:15
 URLs:
 - https://tobyfox.bandcamp.com/track/death-by-glamour
@@ -573,6 +903,11 @@ URLs:
 ---
 Track: For the Fans
 Main Release: For the Fans
+Additional Names:
+- Name: >-
+    愛するファンのみんなへ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:47
 URLs:
 - https://tobyfox.bandcamp.com/track/for-the-fans
@@ -581,6 +916,11 @@ URLs:
 ---
 Track: Long Elevator
 Main Release: Long Elevator
+Additional Names:
+- Name: >-
+    長～いエレベーター
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:20
 URLs:
 - https://tobyfox.bandcamp.com/track/long-elevator
@@ -592,6 +932,11 @@ Start Counting From: 1
 ---
 Track: Undertale
 Main Release: Undertale
+Additional Names:
+- Name: >-
+    UNDERTALE
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 6:22
 URLs:
 - https://tobyfox.bandcamp.com/track/undertale
@@ -600,6 +945,11 @@ URLs:
 ---
 Track: Song That Might Play When You Fight Sans
 Main Release: Song That Might Play When You Fight Sans
+Additional Names:
+- Name: >-
+    サンズとのバトルで流れるかもしれない曲
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/song-that-might-play-when-you-fight-sans
@@ -608,6 +958,11 @@ URLs:
 ---
 Track: The Choice
 Main Release: The Choice
+Additional Names:
+- Name: >-
+    決断のとき
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:13
 URLs:
 - https://tobyfox.bandcamp.com/track/the-choice
@@ -616,6 +971,11 @@ URLs:
 ---
 Track: Small Shock
 Main Release: Small Shock
+Additional Names:
+- Name: >-
+    小さな衝撃
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/small-shock
@@ -624,6 +984,11 @@ URLs:
 ---
 Track: Barrier
 Main Release: track:barrier-undertale
+Additional Names:
+- Name: >-
+    バリア
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/barrier
@@ -640,6 +1005,11 @@ URLs:
 ---
 Track: ASGORE
 Main Release: ASGORE
+Additional Names:
+- Name: >-
+    アズゴア
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:36
 URLs:
 - https://tobyfox.bandcamp.com/track/asgore
@@ -648,6 +1018,11 @@ URLs:
 ---
 Track: You Idiot
 Main Release: You Idiot
+Additional Names:
+- Name: >-
+    バカだね
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:35
 URLs:
 - https://www.youtube.com/watch?v=oJFur9DFkoQ
@@ -655,6 +1030,11 @@ URLs:
 ---
 Track: Your Best Nightmare
 Main Release: Your Best Nightmare
+Additional Names:
+- Name: >-
+    最高の悪夢
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 4:00
 URLs:
 - https://www.youtube.com/watch?v=SObWQRaltug
@@ -662,6 +1042,11 @@ URLs:
 ---
 Track: Finale
 Main Release: track:finale-undertale
+Additional Names:
+- Name: >-
+    フィナーレ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:52
 URLs:
 - https://www.youtube.com/watch?v=5qajT8lS2ok
@@ -669,6 +1054,11 @@ URLs:
 ---
 Track: An Ending
 Main Release: An Ending
+Additional Names:
+- Name: >-
+    ひとつのエンディング
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 3:29
 URLs:
 - https://www.youtube.com/watch?v=gLgUesz8444
@@ -676,6 +1066,11 @@ URLs:
 ---
 Track: She's Playing Piano
 Main Release: She's Playing Piano
+Additional Names:
+- Name: >-
+    彼女がピアノを弾いている
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=41S_VS4dvY8
@@ -683,6 +1078,11 @@ URLs:
 ---
 Track: Here We Are
 Main Release: Here We Are
+Additional Names:
+- Name: >-
+    真実
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:06
 URLs:
 - https://www.youtube.com/watch?v=LS86CPaShI4
@@ -690,6 +1090,11 @@ URLs:
 ---
 Track: Amalgam
 Main Release: Amalgam
+Additional Names:
+- Name: >-
+    アマルガム
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:20
 URLs:
 - https://www.youtube.com/watch?v=0T8AROoIh44
@@ -697,6 +1102,11 @@ URLs:
 ---
 Track: Fallen Down (Reprise)
 Main Release: Fallen Down (Reprise)
+Additional Names:
+- Name: >-
+    おちてきた子（リプライズ）
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:31
 URLs:
 - https://www.youtube.com/watch?v=AvDrW4JTjME
@@ -704,6 +1114,11 @@ URLs:
 ---
 Track: Don't Give Up
 Main Release: Don't Give Up
+Additional Names:
+- Name: >-
+    あきらめないで
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:02
 URLs:
 - https://www.youtube.com/watch?v=YQlbR-XW0CQ
@@ -711,6 +1126,11 @@ URLs:
 ---
 Track: Hopes and Dreams
 Main Release: Hopes and Dreams
+Additional Names:
+- Name: >-
+    夢と希望
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 3:01
 URLs:
 - https://www.youtube.com/watch?v=HA3Ks8NLS-Y
@@ -718,6 +1138,11 @@ URLs:
 ---
 Track: Burn in Despair!
 Main Release: Burn in Despair!
+Additional Names:
+- Name: >-
+    燃え尽きろ！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:21
 URLs:
 - https://www.youtube.com/watch?v=VauL5iv687I
@@ -732,6 +1157,11 @@ URLs:
 ---
 Track: His Theme
 Main Release: His Theme
+Additional Names:
+- Name: >-
+    彼のテーマ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:05
 URLs:
 - https://www.youtube.com/watch?v=8tf-gVaHdag
@@ -739,6 +1169,11 @@ URLs:
 ---
 Track: Final Power
 Main Release: Final Power
+Additional Names:
+- Name: >-
+    最後の力
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=9WAKw79WqSQ
@@ -746,6 +1181,11 @@ URLs:
 ---
 Track: Reunited
 Main Release: track:reunited-undertale
+Additional Names:
+- Name: >-
+    再会
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 4:44
 URLs:
 - https://www.youtube.com/watch?v=8K0npQ--ACw
@@ -753,6 +1193,11 @@ URLs:
 ---
 Track: Menu (Full)
 Main Release: Menu (Full)
+Additional Names:
+- Name: >-
+    スタートメニュー（Full Ver.）
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:32
 URLs:
 - https://www.youtube.com/watch?v=q2IYscs_8uY
@@ -760,6 +1205,11 @@ URLs:
 ---
 Track: Respite
 Main Release: track:respite-undertale
+Additional Names:
+- Name: >-
+    自由
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 1:54
 URLs:
 - https://www.youtube.com/watch?v=USVk9tGQXbo
@@ -767,6 +1217,11 @@ URLs:
 ---
 Track: Bring It In, Guys!
 Main Release: Bring It In, Guys!
+Additional Names:
+- Name: >-
+    全員、集合！
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 4:12
 URLs:
 - https://www.youtube.com/watch?v=uxmzr8pNGDU
@@ -774,6 +1229,11 @@ URLs:
 ---
 Track: Last Goodbye
 Main Release: Last Goodbye
+Additional Names:
+- Name: >-
+    これでホントにサヨナラ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:15
 URLs:
 - https://www.youtube.com/watch?v=EpBQ5m3Ag3Q
@@ -781,6 +1241,11 @@ URLs:
 ---
 Track: But the Earth Refused to Die
 Main Release: But the Earth Refused to Die
+Additional Names:
+- Name: >-
+    BUT THE EARTH REFUSED TO DIE
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:34
 URLs:
 - https://www.youtube.com/watch?v=O6pph2RMoPU
@@ -788,6 +1253,11 @@ URLs:
 ---
 Track: Battle Against a True Hero
 Main Release: Battle Against a True Hero
+Additional Names:
+- Name: >-
+    本物のヒーローとの戦い
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 2:37
 URLs:
 - https://www.youtube.com/watch?v=DcERQHg3iy8
@@ -795,6 +1265,11 @@ URLs:
 ---
 Track: Power of -NEO-
 Main Release: Power of "NEO"
+Additional Names:
+- Name: >-
+    "NEO"の力
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=bWUIWTkBiqE
@@ -809,6 +1284,11 @@ URLs:
 ---
 Track: Good Night
 Main Release: Good Night
+Additional Names:
+- Name: >-
+    おやすみなさい
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=a9-7h0NmMn8
@@ -817,8 +1297,13 @@ URLs:
 Track: Mysterious Shrine
 Suffix Directory: false
 Additional Names:
-- Name: Dog Shrine
+- Name: >-
+    Dog Shrine
   Annotation: Japanese "Annoying Dog Shrine" bonus vinyl
+- Name: >-
+    ナゾの神社
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Date First Released: January 11, 2018
 # date cite: Japanese UNDERTALE collector's edition soundtrack, fangamer
 # https://web.archive.org/web/20171109000020/http://www.fangamer.jp:80/products/undertale-ps4-vita/
@@ -831,8 +1316,13 @@ Referenced Tracks:
 Track: Absolutely Overfamiliar Shrine
 Suffix Directory: false
 Additional Names:
-- Name: Absolutely Overfamiliar Shrine (Dog Shrine 2)
+- Name: >-
+    Absolutely Overfamiliar Shrine (Dog Shrine 2)
   Annotation: Japanese "Annoying Dog Shrine" bonus vinyl
+- Name: >-
+    どう見てもうざい神社
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Duration: 0:18
 URLs:
 - https://www.youtube.com/watch?v=SlEwOWhF8yg
@@ -841,6 +1331,11 @@ Referenced Tracks:
 ---
 Track: Dating Start! (FM Version)
 Main Release: Dating Start! (FM Version)
+Additional Names:
+- Name: >-
+    DATE START!（FM Ver.）
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Artists:
 - coda
 Duration: 2:47
@@ -849,6 +1344,11 @@ URLs:
 ---
 Track: Bereavement
 Main Release: Bereavement
+Additional Names:
+- Name: >-
+    別れ
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Artists:
 - flashygoodness
 Duration: 5:56
@@ -856,6 +1356,11 @@ URLs:
 - https://www.youtube.com/watch?v=OesB3WPzd2k
 ---
 Track: Bonetrousle (Trailer Version)
+Additional Names:
+- Name: >-
+    Bonetrousle (Trailer Ver.)
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Suffix Directory: false
 Duration: 0:50
 URLs:
@@ -864,6 +1369,11 @@ Referenced Tracks:
 - Bonetrousle
 ---
 Track: Before the Story
+Additional Names:
+- Name: >-
+    はじまりの前
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Suffix Directory: false
 Duration: 1:28
 Referenced Tracks:
@@ -873,6 +1383,11 @@ URLs:
 ---
 Track: Dog Dating
 Main Release: Dog Dating
+Additional Names:
+- Name: >-
+    DOG DATE
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/products/undertale-game)
 Artists:
 - coda
 Duration: 0:22

--- a/album/undertale-deltarune-fan-encore-cd.yaml
+++ b/album/undertale-deltarune-fan-encore-cd.yaml
@@ -28,7 +28,7 @@ Additional Names:
 - Name: >-
     DOGTARUNE(トレーラー)
   Annotation: >-
-    Original title
+    original title
 Duration: 0:16
 #URLs:
 #- 
@@ -46,7 +46,7 @@ Additional Names:
 - Name: >-
     BEGINNING(トレーラー)
   Annotation: >-
-    Original title
+    original title
 Main Release: track:beginning-deltarune
 Duration: 0:59
 Commentary: |-
@@ -66,7 +66,7 @@ Additional Names:
 - Name: >-
     ルードバスター
   Annotation: >-
-    Original title
+    original title
 Main Release: Rude Buster
 Directory: rude-buster-fan-encore-cd
 Duration: 2:44
@@ -88,7 +88,7 @@ Additional Names:
 - Name: >-
     SEコレクション
   Annotation: >-
-    Original title
+    original title
 Main Release: track:se-collection
 Duration: 2:25
 Commentary: |-
@@ -105,7 +105,7 @@ Additional Names:
 - Name: >-
     夢と希望
   Annotation: >-
-    Original title
+    original title
 Main Release: Hopes and Dreams
 Duration: 6:03
 ---
@@ -114,7 +114,7 @@ Additional Names:
 - Name: >-
     本物のヒーローとの戦い
   Annotation: >-
-    Original title
+    original title
 Main Release: Battle Against a True Hero
 Duration: '5:12'
 ---
@@ -123,7 +123,7 @@ Additional Names:
 - Name: >-
     いせき
   Annotation: >-
-    Original title
+    original title
 Main Release: track:ruins-undertale
 Duration: 1:34
 ---
@@ -134,7 +134,7 @@ Additional Names:
 - Name: >-
     いせき
   Annotation: >-
-    Original title
+    original title
 Directory: ruins-music-engine-fan-encore
 Always Reference By Directory: true
 Artists:
@@ -155,7 +155,7 @@ Additional Names:
 - Name: >-
     緊迫のとき / ENEMY APPROACHING!
   Annotation: >-
-    Original title
+    original title
 Directory: anticipation-enemy-approaching-music-engine-fan-encore
 Always Reference By Directory: true
 Artists:
@@ -177,7 +177,7 @@ Additional Names:
 - Name: >-
     コア / 華麗なる死闘
   Annotation: >-
-    Original title
+    original title
 Directory: core-death-by-glamour-music-engine-fan-encore-cd
 Always Reference By Directory: true
 Artists:
@@ -199,7 +199,7 @@ Additional Names:
 - Name: >-
     愛するファンのみんなへ
   Annotation: >-
-    Original title
+    original title
 Directory: for-the-fans-music-engine-fan-encore-cd
 Always Reference By Directory: true
 Artists:

--- a/album/undertale-deltarune-fan-encore-cd.yaml
+++ b/album/undertale-deltarune-fan-encore-cd.yaml
@@ -24,6 +24,11 @@ Groups:
 Section: DELTARUNE Trial Tracks
 ---
 Track: DOGTARUNE (Trailer)
+Additional Names:
+- Name: >-
+    DOGTARUNE(トレーラー)
+  Annotation: >-
+    Original title
 Duration: 0:16
 #URLs:
 #- 
@@ -37,6 +42,11 @@ Commentary: |-
     この曲を作ったときは、なんも考えてなかったです。
 ---
 Track: Beginning
+Additional Names:
+- Name: >-
+    BEGINNING(トレーラー)
+  Annotation: >-
+    Original title
 Main Release: track:beginning-deltarune
 Duration: 0:59
 Commentary: |-
@@ -52,6 +62,11 @@ Commentary: |-
     旅の始まりには うってつけ
 ---
 Track: Rude Buster
+Additional Names:
+- Name: >-
+    ルードバスター
+  Annotation: >-
+    Original title
 Main Release: Rude Buster
 Directory: rude-buster-fan-encore-cd
 Duration: 2:44
@@ -69,6 +84,11 @@ Commentary: |-
 Section: UNDERTALE Encore
 ---
 Track: SE Collection
+Additional Names:
+- Name: >-
+    SEコレクション
+  Annotation: >-
+    Original title
 Main Release: track:se-collection
 Duration: 2:25
 Commentary: |-
@@ -81,20 +101,40 @@ Main Release: track:megalovania-undertale
 Duration: 5:14
 ---
 Track: Hopes and Dreams
+Additional Names:
+- Name: >-
+    夢と希望
+  Annotation: >-
+    Original title
 Main Release: Hopes and Dreams
 Duration: 6:03
 ---
 Track: Battle Against a True Hero
+Additional Names:
+- Name: >-
+    本物のヒーローとの戦い
+  Annotation: >-
+    Original title
 Main Release: Battle Against a True Hero
 Duration: '5:12'
 ---
 Track: Ruins
+Additional Names:
+- Name: >-
+    いせき
+  Annotation: >-
+    Original title
 Main Release: track:ruins-undertale
 Duration: 1:34
 ---
 Section: MUSIC Engine Orchestra
 ---
 Track: Ruins
+Additional Names:
+- Name: >-
+    いせき
+  Annotation: >-
+    Original title
 Directory: ruins-music-engine-fan-encore
 Always Reference By Directory: true
 Artists:
@@ -111,6 +151,11 @@ Commentary: |-
     (from "MUSIC Engine UNDERTALE CD Vol.2: Toriel")
 ---
 Track: Anticipation / Enemy Approaching
+Additional Names:
+- Name: >-
+    緊迫のとき / ENEMY APPROACHING!
+  Annotation: >-
+    Original title
 Directory: anticipation-enemy-approaching-music-engine-fan-encore
 Always Reference By Directory: true
 Artists:
@@ -128,6 +173,11 @@ Commentary: |-
     (from "MUSIC Engine UNDERTALE CD Vol.2: Toriel")
 ---
 Track: CORE / Death by Glamour
+Additional Names:
+- Name: >-
+    コア / 華麗なる死闘
+  Annotation: >-
+    Original title
 Directory: core-death-by-glamour-music-engine-fan-encore-cd
 Always Reference By Directory: true
 Artists:
@@ -145,6 +195,11 @@ Commentary: |-
     (from "MUSIC Engine UNDERTALE CD Vol.3: Alphys & Mettaton")
 ---
 Track: For the Fans
+Additional Names:
+- Name: >-
+    愛するファンのみんなへ
+  Annotation: >-
+    Original title
 Directory: for-the-fans-music-engine-fan-encore-cd
 Always Reference By Directory: true
 Artists:

--- a/album/undertale-fan-selection-cd.yaml
+++ b/album/undertale-fan-selection-cd.yaml
@@ -25,7 +25,7 @@ Additional Names:
 - Name: >-
     みゅうみゅう イントロ (トレーラー)
   Annotation: >-
-    Original title
+    original title
 Duration: 0:17
 URLs:
 - https://www.youtube.com/watch?v=HUd7hex_6h8
@@ -38,7 +38,7 @@ Additional Names:
 - Name: >-
     サンズとのバトルで流れるかもしれない曲
   Annotation: >-
-    Original title
+    original title
 Duration: 2:02
 URLs:
 - https://www.youtube.com/watch?v=sbUq8L4_Ypk
@@ -63,7 +63,7 @@ Additional Names:
 - Name: >-
     アズゴア
   Annotation: >-
-    Original title
+    original title
 Duration: 5:14
 URLs:
 - https://www.youtube.com/watch?v=ut4KQeMMPMo
@@ -78,7 +78,7 @@ Additional Names:
 - Name: >-
     UNDERTALE
   Annotation: >-
-    Original title
+    original title
 Duration: 6:25
 URLs:
 - https://www.youtube.com/watch?v=mf6hifdXFgk
@@ -89,7 +89,7 @@ Additional Names:
 - Name: >-
     スパイダーダンス
   Annotation: >-
-    Original title
+    original title
 Duration: 3:30
 URLs:
 - https://www.youtube.com/watch?v=sG3vQ1AiYLQ
@@ -104,7 +104,7 @@ Additional Names:
 - Name: >-
     夢と希望
   Annotation: >-
-    Original title
+    original title
 Duration: 6:04
 URLs:
 - https://www.youtube.com/watch?v=OSgr0ro9A1w
@@ -119,7 +119,7 @@ Additional Names:
 - Name: >-
     華麗なる死闘
   Annotation: >-
-    Original title
+    original title
 Duration: 4:31
 URLs:
 - https://www.youtube.com/watch?v=48RhaY_DrYA
@@ -144,7 +144,7 @@ Additional Names:
 - Name: >-
     本物のヒーローとの戦い
   Annotation: >-
-    Original title
+    original title
 Duration: 5:13
 URLs:
 - https://www.youtube.com/watch?v=UNrWDwvgNNo
@@ -170,7 +170,7 @@ Additional Names:
 - Name: >-
     ウォーターフェル
   Annotation: >-
-    Original title
+    original title
 Directory: waterfall-music-engine-fan-selection
 Always Reference By Directory: true
 Duration: 4:17
@@ -194,7 +194,7 @@ Additional Names:
 - Name: >-
     ぬあああああ!
   Annotation: >-
-    Original title
+    original title
 Directory: ngahhh-music-engine-fan-selection
 Always Reference By Directory: true
 Duration: 2:01
@@ -217,7 +217,7 @@ Additional Names:
 - Name: >-
     UNDERTALE
   Annotation: >-
-    Original title
+    original title
 Directory: undertale-music-engine-fan-selection
 Always Reference By Directory: true
 Duration: 6:25
@@ -242,7 +242,7 @@ Additional Names:
 - Name: >-
     SEコレクション
   Annotation: >-
-    Original title
+    original title
 Suffix Directory: false
 Duration: 2:23
 URLs:

--- a/album/undertale-fan-selection-cd.yaml
+++ b/album/undertale-fan-selection-cd.yaml
@@ -21,6 +21,11 @@ Art Tags:
 Section: Nintendo Switch Trailer Music
 ---
 Track: Mew Mew Intro (Trailer)
+Additional Names:
+- Name: >-
+    みゅうみゅう イントロ (トレーラー)
+  Annotation: >-
+    Original title
 Duration: 0:17
 URLs:
 - https://www.youtube.com/watch?v=HUd7hex_6h8
@@ -29,6 +34,11 @@ Section: Top 10 songs chosen by fans (double loop)
 ---
 Track: Song That Might Play When You Fight Sans
 Main Release: Song That Might Play When You Fight Sans
+Additional Names:
+- Name: >-
+    サンズとのバトルで流れるかもしれない曲
+  Annotation: >-
+    Original title
 Duration: 2:02
 URLs:
 - https://www.youtube.com/watch?v=sbUq8L4_Ypk
@@ -49,6 +59,11 @@ Commentary: |-
 ---
 Track: ASGORE
 Main Release: ASGORE
+Additional Names:
+- Name: >-
+    アズゴア
+  Annotation: >-
+    Original title
 Duration: 5:14
 URLs:
 - https://www.youtube.com/watch?v=ut4KQeMMPMo
@@ -59,12 +74,22 @@ Commentary: |-
 ---
 Track: Undertale
 Main Release: Undertale
+Additional Names:
+- Name: >-
+    UNDERTALE
+  Annotation: >-
+    Original title
 Duration: 6:25
 URLs:
 - https://www.youtube.com/watch?v=mf6hifdXFgk
 ---
 Track: Spider Dance
 Main Release: Spider Dance
+Additional Names:
+- Name: >-
+    スパイダーダンス
+  Annotation: >-
+    Original title
 Duration: 3:30
 URLs:
 - https://www.youtube.com/watch?v=sG3vQ1AiYLQ
@@ -75,6 +100,11 @@ Commentary: |-
 ---
 Track: Hopes and Dreams
 Main Release: Hopes and Dreams
+Additional Names:
+- Name: >-
+    夢と希望
+  Annotation: >-
+    Original title
 Duration: 6:04
 URLs:
 - https://www.youtube.com/watch?v=OSgr0ro9A1w
@@ -85,6 +115,11 @@ Commentary: |-
 ---
 Track: Death by Glamour
 Main Release: Death by Glamour
+Additional Names:
+- Name: >-
+    華麗なる死闘
+  Annotation: >-
+    Original title
 Duration: 4:31
 URLs:
 - https://www.youtube.com/watch?v=48RhaY_DrYA
@@ -105,6 +140,11 @@ Commentary: |-
 ---
 Track: Battle Against a True Hero
 Main Release: Battle Against a True Hero
+Additional Names:
+- Name: >-
+    本物のヒーローとの戦い
+  Annotation: >-
+    Original title
 Duration: 5:13
 URLs:
 - https://www.youtube.com/watch?v=UNrWDwvgNNo
@@ -126,6 +166,11 @@ Commentary: |-
 Section: Live Arrangements
 ---
 Track: Waterfall ##re-release of MUSIC Engine arrangement album vol.1
+Additional Names:
+- Name: >-
+    ウォーターフェル
+  Annotation: >-
+    Original title
 Directory: waterfall-music-engine-fan-selection
 Always Reference By Directory: true
 Duration: 4:17
@@ -145,6 +190,11 @@ Commentary: |-
     (From "MUSIC Engine UNDERTALE ARRANGE Vol.1: Undyne")
 ---
 Track: NGAHHH!! ##re-release of MUSIC Engine arrangement album vol.1
+Additional Names:
+- Name: >-
+    ぬあああああ!
+  Annotation: >-
+    Original title
 Directory: ngahhh-music-engine-fan-selection
 Always Reference By Directory: true
 Duration: 2:01
@@ -163,6 +213,11 @@ Commentary: |-
     (From "MUSIC Engine UNDERTALE ARRANGE Vol.1: Undyne")
 ---
 Track: Undertale
+Additional Names:
+- Name: >-
+    UNDERTALE
+  Annotation: >-
+    Original title
 Directory: undertale-music-engine-fan-selection
 Always Reference By Directory: true
 Duration: 6:25
@@ -183,6 +238,11 @@ Commentary: |-
 Section: SE Collection
 ---
 Track: SE Collection
+Additional Names:
+- Name: >-
+    SEコレクション
+  Annotation: >-
+    Original title
 Suffix Directory: false
 Duration: 2:23
 URLs:

--- a/album/undertale-soundtrack-cd.yaml
+++ b/album/undertale-soundtrack-cd.yaml
@@ -1,4 +1,9 @@
 Album: UNDERTALE Soundtrack (CD)
+Additional Names:
+- Name: >-
+    「UNDERTALE」サウンドトラック（日本語版）
+  Annotation: >-
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Directory Suffix: undertale-cd
 Suffix Track Directories: true
 Artists:
@@ -38,6 +43,11 @@ Section: Disc 1
 ---
 Track: Once Upon a Time
 Main Release: Once Upon a Time
+Additional Names:
+- Name: >-
+    むかしむかし…
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=AFZby8KSCuA)
 Duration: 1:29
 URLs:
 - https://tobyfox.bandcamp.com/track/once-upon-a-time-2
@@ -46,6 +56,11 @@ URLs:
 ---
 Track: Start Menu
 Main Release: Start Menu
+Additional Names:
+- Name: >-
+    スタートメニュー
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DopVsY89fBs)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/start-menu
@@ -54,6 +69,11 @@ URLs:
 ---
 Track: Your Best Friend
 Main Release: Your Best Friend
+Additional Names:
+- Name: >-
+    キミの親友
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=gv4ai0G5ZUg)
 Duration: 0:23
 URLs:
 - https://tobyfox.bandcamp.com/track/your-best-friend-2
@@ -62,6 +82,11 @@ URLs:
 ---
 Track: Fallen Down
 Main Release: track:fallen-down-undertale
+Additional Names:
+- Name: >-
+    おちてきた子
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qG5ZjezxIck)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/fallen-down-2
@@ -70,6 +95,11 @@ URLs:
 ---
 Track: Ruins
 Main Release: track:ruins-undertale
+Additional Names:
+- Name: >-
+    いせき
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=i0H9zYeplWE)
 Duration: 1:32
 URLs:
 - https://tobyfox.bandcamp.com/track/ruins-2
@@ -78,6 +108,11 @@ URLs:
 ---
 Track: Uwa!! So Temperate♫
 Main Release: Uwa!! So Temperate♫
+Additional Names:
+- Name: >-
+    おだやかだワン！♫
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Ex99CEiW9yk)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-temperate
@@ -86,6 +121,11 @@ URLs:
 ---
 Track: Anticipation
 Main Release: Anticipation
+Additional Names:
+- Name: >-
+    緊迫のとき
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=MKBZmviipPk)
 Duration: 0:22
 URLs:
 - https://tobyfox.bandcamp.com/track/anticipation-2
@@ -94,6 +134,11 @@ URLs:
 ---
 Track: Unnecessary Tension
 Main Release: Unnecessary Tension
+Additional Names:
+- Name: >-
+    重要任務…？
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=CxYSALlHTeQ)
 Duration: 0:17
 URLs:
 - https://tobyfox.bandcamp.com/track/unnecessary-tension-2
@@ -102,6 +147,11 @@ URLs:
 ---
 Track: Enemy Approaching
 Main Release: Enemy Approaching
+Additional Names:
+- Name: >-
+    ENEMY APPROACHING!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=nrUNu6TdFWQ)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/enemy-approaching-2
@@ -110,6 +160,11 @@ URLs:
 ---
 Track: Ghost Fight
 Main Release: Ghost Fight
+Additional Names:
+- Name: >-
+    ゴースト・ファイト
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=FeuwA9XBV0g)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/ghost-fight-2
@@ -118,6 +173,11 @@ URLs:
 ---
 Track: Determination
 Main Release: Determination
+Additional Names:
+- Name: >-
+    ケツイ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=xSCwRBDaHw8)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/determination-2
@@ -126,6 +186,10 @@ URLs:
 ---
 Track: Home
 Main Release: track:home-undertale
+- Name: >-
+    ホーム
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=0UkRqMFMZic)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-2
@@ -134,6 +198,11 @@ URLs:
 ---
 Track: Home (Music Box)
 Main Release: Home (Music Box)
+Additional Names:
+- Name: >-
+    ホーム（オルゴール）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=vC1GAZ62NPg)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-music-box-2
@@ -142,6 +211,11 @@ URLs:
 ---
 Track: Heartache
 Main Release: Heartache
+Additional Names:
+- Name: >-
+    心の痛み
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=IZvESNW3HjU)
 Duration: 1:48
 URLs:
 - https://tobyfox.bandcamp.com/track/heartache-2
@@ -150,6 +224,11 @@ URLs:
 ---
 Track: sans.
 Main Release: sans.
+Additional Names:
+- Name: >-
+    サンズ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=F3dO5JNEgIk)
 Duration: 0:51
 URLs:
 - https://tobyfox.bandcamp.com/track/sans
@@ -158,6 +237,11 @@ URLs:
 ---
 Track: Nyeh Heh Heh!
 Main Release: Nyeh Heh Heh!
+Additional Names:
+- Name: >-
+    ニャハハ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=GQWuIxIts5A)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/nyeh-heh-heh-2
@@ -166,6 +250,11 @@ URLs:
 ---
 Track: Snowy
 Main Release: Snowy
+Additional Names:
+- Name: >-
+    雪景色
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=HVrnz2x8etk)
 Duration: 1:44
 URLs:
 - https://tobyfox.bandcamp.com/track/snowy
@@ -174,6 +263,11 @@ URLs:
 ---
 Track: Uwa!! So Holiday♫
 Main Release: Uwa!! So Holiday♫
+Additional Names:
+- Name: >-
+    ホリデーシーズンだワン！♫
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=aXczmxc-N8g)
 Duration: 0:30
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-holiday
@@ -182,6 +276,11 @@ URLs:
 ---
 Track: Dogbass
 Main Release: Dogbass
+Additional Names:
+- Name: >-
+    ドッグベース
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Mh44JW2mq8U)
 Duration: 0:07
 URLs:
 - https://tobyfox.bandcamp.com/track/dogbass
@@ -190,6 +289,11 @@ URLs:
 ---
 Track: Mysterious Place
 Main Release: Mysterious Place
+Additional Names:
+- Name: >-
+    謎めいた場所
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=a8fLyOS4OXU)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/mysterious-place
@@ -198,6 +302,11 @@ URLs:
 ---
 Track: Dogsong
 Main Release: Dogsong
+Additional Names:
+- Name: >-
+    ドッグソング
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=tfO1zcVb4dY)
 Duration: 0:37
 URLs:
 - https://tobyfox.bandcamp.com/track/dogsong
@@ -206,6 +315,11 @@ URLs:
 ---
 Track: Snowdin Town
 Main Release: Snowdin Town
+Additional Names:
+- Name: >-
+    スノーフルのまち
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=nTHMhRgJgP0)
 Duration: 1:16
 URLs:
 - https://tobyfox.bandcamp.com/track/snowdin-town
@@ -214,6 +328,11 @@ URLs:
 ---
 Track: Shop
 Main Release: track:shop-undertale
+Additional Names:
+- Name: >-
+    いらっしゃいませ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Txf-qkLVJx8)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/shop
@@ -230,6 +349,11 @@ URLs:
 ---
 Track: Dating Start!
 Main Release: Dating Start!
+Additional Names:
+- Name: >-
+    DATE START!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=puwOdeKHAKY)
 Duration: 1:57
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-start
@@ -238,6 +362,11 @@ URLs:
 ---
 Track: Dating Tense!
 Main Release: Dating Tense!
+Additional Names:
+- Name: >-
+    DATE DANGER!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=1u-RXnYHkCE)
 Duration: 0:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-tense
@@ -246,6 +375,11 @@ URLs:
 ---
 Track: Dating Fight!
 Main Release: Dating Fight!
+Additional Names:
+- Name: >-
+    DATE FIGHT!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=QJmGkzWCI34)
 Duration: 0:36
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-fight
@@ -254,6 +388,11 @@ URLs:
 ---
 Track: Premonition
 Main Release: track:premonition-undertale
+Additional Names:
+- Name: >-
+    もしかして…
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=SyFjHBA8Sqo)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/premonition
@@ -262,6 +401,11 @@ URLs:
 ---
 Track: Danger Mystery
 Main Release: Danger Mystery
+Additional Names:
+- Name: >-
+    キケンのナゾ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=l35q6TPP63c)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/danger-mystery
@@ -270,6 +414,11 @@ URLs:
 ---
 Track: Undyne
 Main Release: Undyne
+Additional Names:
+- Name: >-
+    アンダイン
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=M_NW2CVgJCk)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/undyne
@@ -278,6 +427,11 @@ URLs:
 ---
 Track: Waterfall
 Main Release: Waterfall
+Additional Names:
+- Name: >-
+    ウォーターフェル
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DVUh7caufKU)
 Duration: 2:07
 URLs:
 - https://tobyfox.bandcamp.com/track/waterfall
@@ -286,6 +440,11 @@ URLs:
 ---
 Track: Run!
 Main Release: Run!
+Additional Names:
+- Name: >-
+    逃げろ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=92JtOM-wz4I)
 Duration: 0:27
 URLs:
 - https://tobyfox.bandcamp.com/track/run
@@ -294,6 +453,11 @@ URLs:
 ---
 Track: Quiet Water
 Main Release: Quiet Water
+Additional Names:
+- Name: >-
+    やすらぎの水辺
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=PBEGCIeJ4HQ)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/quiet-water
@@ -302,6 +466,11 @@ URLs:
 ---
 Track: Memory
 Main Release: track:memory-undertale
+Additional Names:
+- Name: >-
+    思い出
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=r3uFD8AKmr8)
 Duration: 1:15
 URLs:
 - https://tobyfox.bandcamp.com/track/memory
@@ -310,6 +479,11 @@ URLs:
 ---
 Track: Bird That Carries You Over A Disproportionately Small Gap
 Main Release: Bird That Carries You Over A Disproportionately Small Gap
+Additional Names:
+- Name: >-
+    びっくりするほど近い距離を飛んで渡らせてくれる鳥
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=__XEopj2hxg)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/bird-that-carries-you-over-a-disproportionately-small-gap
@@ -318,6 +492,11 @@ URLs:
 ---
 Track: Dummy!
 Main Release: Dummy!
+Additional Names:
+- Name: >-
+    怒りのマネキン！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=FbtgN-lqRHA)
 Duration: 2:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dummy
@@ -326,6 +505,11 @@ URLs:
 ---
 Track: Pathetic House
 Main Release: Pathetic House
+Additional Names:
+- Name: >-
+    みすぼらしい家
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=D15E0GCJJrc)
 Duration: 0:39
 URLs:
 - https://tobyfox.bandcamp.com/track/pathetic-house
@@ -334,6 +518,11 @@ URLs:
 ---
 Track: Spooktune
 Main Release: track:spooktune-undertale
+Additional Names:
+- Name: >-
+    ブルブルチューン
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=xNSOwI595QY)
 Duration: 0:24
 URLs:
 - https://tobyfox.bandcamp.com/track/spooktune
@@ -342,6 +531,11 @@ URLs:
 ---
 Track: Spookwave
 Main Release: Spookwave
+Additional Names:
+- Name: >-
+    ブルブルウェーブ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=927DZIW5Zbg)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/spookwave
@@ -350,6 +544,11 @@ URLs:
 ---
 Track: Ghouliday
 Main Release: Ghouliday
+Additional Names:
+- Name: >-
+    グロすマスソング
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=I5bWvTkjBj8)
 Duration: 0:13
 URLs:
 - https://tobyfox.bandcamp.com/track/ghouliday
@@ -358,6 +557,11 @@ URLs:
 ---
 Track: Chill
 Main Release: track:chill-undertale
+Additional Names:
+- Name: >-
+    まったり
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=IBo1GuVxEe0)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/chill
@@ -366,6 +570,11 @@ URLs:
 ---
 Track: Thundersnail
 Main Release: Thundersnail
+Additional Names:
+- Name: >-
+    サンダースネイル
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=KuQnII1Wd6I)
 Duration: 0:42
 URLs:
 - https://tobyfox.bandcamp.com/track/thundersnail
@@ -374,6 +583,11 @@ URLs:
 ---
 Track: Temmie Village
 Main Release: Temmie Village
+Additional Names:
+- Name: >-
+    手ミーむら！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=BmMu_GO5UBE)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/temmie-village
@@ -382,6 +596,11 @@ URLs:
 ---
 Track: Tem Shop
 Main Release: Tem Shop
+Additional Names:
+- Name: >-
+    手ミーみせ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=k7UMwQvXSoo)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/tem-shop
@@ -390,6 +609,11 @@ URLs:
 ---
 Track: NGAHHH!!
 Main Release: NGAHHH!!
+Additional Names:
+- Name: >-
+    ぬあああああ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=4BSINiU1xEA)
 Duration: 1:23
 URLs:
 - https://tobyfox.bandcamp.com/track/ngahhh
@@ -398,6 +622,11 @@ URLs:
 ---
 Track: Spear of Justice
 Main Release: Spear of Justice
+Additional Names:
+- Name: >-
+    正義の槍
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=XGzYhJcm-Jw)
 Duration: 1:55
 URLs:
 - https://tobyfox.bandcamp.com/track/spear-of-justice
@@ -406,6 +635,11 @@ URLs:
 ---
 Track: Ooo
 Main Release: Ooo
+Additional Names:
+- Name: >-
+    Woo
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=7UwlGSgQhTs)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/ooo
@@ -414,6 +648,11 @@ URLs:
 ---
 Track: Alphys
 Main Release: Alphys
+Additional Names:
+- Name: >-
+    アルフィー
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=WDujywIOBdA)
 Duration: 1:26
 URLs:
 - https://tobyfox.bandcamp.com/track/alphys
@@ -422,6 +661,11 @@ URLs:
 ---
 Track: It's Showtime!
 Main Release: It's Showtime!
+Additional Names:
+- Name: >-
+    イッツ・ショータイム！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=0OKu3CvY3ZY)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/its-showtime
@@ -430,6 +674,11 @@ URLs:
 ---
 Track: Metal Crusher
 Main Release: Metal Crusher
+Additional Names:
+- Name: >-
+    メタル・クラッシャー
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=J6brXCuKTHo)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/metal-crusher
@@ -446,6 +695,11 @@ URLs:
 ---
 Track: Uwa!! So HEATS!!♫
 Main Release: Uwa!! So HEATS!!♫
+Additional Names:
+- Name: >-
+    あついワン！♫
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=R1TPMim12yU)
 Duration: 0:34
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-heats
@@ -454,6 +708,11 @@ URLs:
 ---
 Track: Stronger Monsters
 Main Release: Stronger Monsters
+Additional Names:
+- Name: >-
+    強敵たち
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=uQU3KBJu1aI)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/stronger-monsters
@@ -462,6 +721,11 @@ URLs:
 ---
 Track: Hotel
 Main Release: track:hotel-undertale
+Additional Names:
+- Name: >-
+    ホテル
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=naLXDko8eUA)
 Duration: 1:28
 URLs:
 - https://tobyfox.bandcamp.com/track/hotel
@@ -470,6 +734,11 @@ URLs:
 ---
 Track: Can You Really Call This A Hotel, I Didn't Receive A Mint On My Pillow Or Anything
 Main Release: Can You Really Call This A Hotel, I Didn't Receive A Mint On My Pillow Or Anything
+Additional Names:
+- Name: >-
+    枕の上にミントチョコレートも置いていない宿泊施設をホテルと呼んでよいものだろうか
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=zWXD1ZJE-HY)
 Duration: 1:01
 URLs:
 - https://tobyfox.bandcamp.com/track/can-you-really-call-this-a-hotel-i-didnt-receive-a-mint-on-my-pillow-or-anything
@@ -478,6 +747,11 @@ URLs:
 ---
 Track: Confession
 Main Release: track:confession-undertale
+Additional Names:
+- Name: >-
+    告白
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=c8xdkxeKKg4)
 Duration: 0:43
 URLs:
 - https://tobyfox.bandcamp.com/track/confession
@@ -486,6 +760,11 @@ URLs:
 ---
 Track: Live Report
 Main Release: Live Report
+Additional Names:
+- Name: >-
+    現場から中継です
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=m-BeSffEiIA)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/live-report
@@ -494,6 +773,11 @@ URLs:
 ---
 Track: Death Report
 Main Release: Death Report
+Additional Names:
+- Name: >-
+    絶対絶命レポート
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=BENfoomNhUM)
 Duration: 0:47
 URLs:
 - https://tobyfox.bandcamp.com/track/death-report
@@ -502,6 +786,11 @@ URLs:
 ---
 Track: Spider Dance
 Main Release: Spider Dance
+Additional Names:
+- Name: >-
+    スパイダーダンス
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=OA46s3gww_o)
 Duration: 1:46
 URLs:
 - https://tobyfox.bandcamp.com/track/spider-dance
@@ -510,6 +799,11 @@ URLs:
 ---
 Track: Wrong Enemy !?
 Main Release: Wrong Enemy !?
+Additional Names:
+- Name: >-
+    おかしな敵
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=fb6kGsixpYg)
 Duration: 0:59
 URLs:
 - https://tobyfox.bandcamp.com/track/wrong-enemy
@@ -518,6 +812,11 @@ URLs:
 ---
 Track: Oh! One True Love
 Main Release: Oh! One True Love
+Additional Names:
+- Name: >-
+    ああ！運命の人よ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=GOCuKG1o2cM)
 Duration: 1:24
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-one-true-love
@@ -526,6 +825,11 @@ URLs:
 ---
 Track: Oh! Dungeon
 Main Release: Oh! Dungeon
+Additional Names:
+- Name: >-
+    ああ！とらわれの恋人よ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=TPyPCv28fC0)
 Duration: 0:33
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-dungeon
@@ -534,6 +838,11 @@ URLs:
 ---
 Track: It's Raining Somewhere Else
 Main Release: It's Raining Somewhere Else
+Additional Names:
+- Name: >-
+    今日もどこかで雨が降る
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=KtC-pl9P3kE)
 Duration: 2:50
 URLs:
 - https://tobyfox.bandcamp.com/track/its-raining-somewhere-else
@@ -542,6 +851,11 @@ URLs:
 ---
 Track: CORE Approach
 Main Release: CORE Approach
+Additional Names:
+- Name: >-
+    コアへの接近
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=ZkXjF0IIeug)
 Duration: 0:12
 URLs:
 - https://tobyfox.bandcamp.com/track/core-approach
@@ -553,6 +867,11 @@ Start Counting From: 1
 ---
 Track: CORE
 Main Release: CORE
+Additional Names:
+- Name: >-
+    コア
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=SEOYyM9n9mw)
 Duration: 2:46
 URLs:
 - https://tobyfox.bandcamp.com/track/core
@@ -561,6 +880,11 @@ URLs:
 ---
 Track: Last Episode!
 Main Release: Last Episode!
+Additional Names:
+- Name: >-
+    最終回！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=poDx-ww7H2A)
 Duration: 0:08
 URLs:
 - https://tobyfox.bandcamp.com/track/last-episode
@@ -569,6 +893,11 @@ URLs:
 ---
 Track: Oh My...
 Main Release: Oh My...
+Additional Names:
+- Name: >-
+    なんとッ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=FqRdEUsl27I)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-my
@@ -577,6 +906,11 @@ URLs:
 ---
 Track: Death by Glamour
 Main Release: Death by Glamour
+Additional Names:
+- Name: >-
+    華麗なる死闘
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qeDIZCc6Cyo)
 Duration: 2:15
 URLs:
 - https://tobyfox.bandcamp.com/track/death-by-glamour
@@ -585,6 +919,11 @@ URLs:
 ---
 Track: For the Fans
 Main Release: For the Fans
+Additional Names:
+- Name: >-
+    愛するファンのみんなへ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=_AayQ9tBfxA)
 Duration: 1:47
 URLs:
 - https://tobyfox.bandcamp.com/track/for-the-fans
@@ -593,6 +932,11 @@ URLs:
 ---
 Track: Long Elevator
 Main Release: Long Elevator
+Additional Names:
+- Name: >-
+    長～いエレベーター
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=KPsTN7GcEjI)
 Duration: 0:20
 URLs:
 - https://tobyfox.bandcamp.com/track/long-elevator
@@ -601,6 +945,11 @@ URLs:
 ---
 Track: Undertale
 Main Release: Undertale
+Additional Names:
+- Name: >-
+    UNDERTALE
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=1HIKNbnV8nw)
 Duration: 6:22
 URLs:
 - https://tobyfox.bandcamp.com/track/undertale
@@ -609,6 +958,11 @@ URLs:
 ---
 Track: Song That Might Play When You Fight Sans
 Main Release: Song That Might Play When You Fight Sans
+Additional Names:
+- Name: >-
+    サンズとのバトルで流れるかもしれない曲
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=hZaECtu1igk)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/song-that-might-play-when-you-fight-sans
@@ -617,6 +971,11 @@ URLs:
 ---
 Track: The Choice
 Main Release: The Choice
+Additional Names:
+- Name: >-
+    決断のとき
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=RWl8o-znLck)
 Duration: 2:13
 URLs:
 - https://tobyfox.bandcamp.com/track/the-choice
@@ -625,6 +984,11 @@ URLs:
 ---
 Track: Small Shock
 Main Release: Small Shock
+Additional Names:
+- Name: >-
+    小さな衝撃
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=BZg1BuY1QiY)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/small-shock
@@ -633,6 +997,11 @@ URLs:
 ---
 Track: Barrier
 Main Release: track:barrier-undertale
+Additional Names:
+- Name: >-
+    バリア
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=XPVq0qXuPLs)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/barrier
@@ -649,6 +1018,11 @@ URLs:
 ---
 Track: ASGORE
 Main Release: ASGORE
+Additional Names:
+- Name: >-
+    アズゴア
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=42kI2lT0x6U)
 Duration: 2:36
 URLs:
 - https://tobyfox.bandcamp.com/track/asgore
@@ -657,6 +1031,11 @@ URLs:
 ---
 Track: You Idiot
 Main Release: You Idiot
+Additional Names:
+- Name: >-
+    バカだね
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=TRcQImpnW5Q)
 Duration: 0:35
 URLs:
 - https://www.youtube.com/watch?v=oJFur9DFkoQ
@@ -664,6 +1043,11 @@ URLs:
 ---
 Track: Your Best Nightmare
 Main Release: Your Best Nightmare
+Additional Names:
+- Name: >-
+    最高の悪夢
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DxxLzJDARbo)
 Duration: 4:00
 URLs:
 - https://www.youtube.com/watch?v=SObWQRaltug
@@ -671,6 +1055,11 @@ URLs:
 ---
 Track: Finale
 Main Release: track:finale-undertale
+Additional Names:
+- Name: >-
+    フィナーレ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=hiioWOkHTp0)
 Duration: 1:52
 URLs:
 - https://www.youtube.com/watch?v=5qajT8lS2ok
@@ -678,6 +1067,11 @@ URLs:
 ---
 Track: An Ending
 Main Release: An Ending
+Additional Names:
+- Name: >-
+    ひとつのエンディング
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=9g6V67JzAHY)
 Duration: 3:29
 URLs:
 - https://www.youtube.com/watch?v=gLgUesz8444
@@ -685,6 +1079,11 @@ URLs:
 ---
 Track: She's Playing Piano
 Main Release: She's Playing Piano
+Additional Names:
+- Name: >-
+    彼女がピアノを弾いている
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=rLKvVTJdYy0)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=41S_VS4dvY8
@@ -692,6 +1091,11 @@ URLs:
 ---
 Track: Here We Are
 Main Release: Here We Are
+Additional Names:
+- Name: >-
+    真実
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=52olsp3GUqY)
 Duration: 2:06
 URLs:
 - https://www.youtube.com/watch?v=LS86CPaShI4
@@ -699,6 +1103,11 @@ URLs:
 ---
 Track: Amalgam
 Main Release: Amalgam
+Additional Names:
+- Name: >-
+    アマルガム
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DYRHwiyJsBA)
 Duration: 1:20
 URLs:
 - https://www.youtube.com/watch?v=0T8AROoIh44
@@ -706,6 +1115,11 @@ URLs:
 ---
 Track: Fallen Down (Reprise)
 Main Release: Fallen Down (Reprise)
+Additional Names:
+- Name: >-
+    おちてきた子（リプライズ）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qG5ZjezxIck)
 Duration: 2:31
 URLs:
 - https://www.youtube.com/watch?v=AvDrW4JTjME
@@ -713,6 +1127,11 @@ URLs:
 ---
 Track: Don't Give Up
 Main Release: Don't Give Up
+Additional Names:
+- Name: >-
+    あきらめないで
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=rpYoFaphxqQ)
 Duration: 2:02
 URLs:
 - https://www.youtube.com/watch?v=YQlbR-XW0CQ
@@ -720,6 +1139,11 @@ URLs:
 ---
 Track: Hopes and Dreams
 Main Release: Hopes and Dreams
+Additional Names:
+- Name: >-
+    夢と希望
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=wbO3p7_Mf30)
 Duration: 3:01
 URLs:
 - https://www.youtube.com/watch?v=HA3Ks8NLS-Y
@@ -727,6 +1151,11 @@ URLs:
 ---
 Track: Burn in Despair!
 Main Release: Burn in Despair!
+Additional Names:
+- Name: >-
+    燃え尽きろ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=kdM6Kl8ooGc)
 Duration: 0:21
 URLs:
 - https://www.youtube.com/watch?v=VauL5iv687I
@@ -741,6 +1170,11 @@ URLs:
 ---
 Track: His Theme
 Main Release: His Theme
+Additional Names:
+- Name: >-
+    彼のテーマ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=pMXxxFeZAPg)
 Duration: 2:05
 URLs:
 - https://www.youtube.com/watch?v=8tf-gVaHdag
@@ -748,6 +1182,11 @@ URLs:
 ---
 Track: Final Power
 Main Release: Final Power
+Additional Names:
+- Name: >-
+    最後の力
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Df0gorkBD-M)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=9WAKw79WqSQ
@@ -755,6 +1194,11 @@ URLs:
 ---
 Track: Reunited
 Main Release: track:reunited-undertale
+Additional Names:
+- Name: >-
+    再会
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=VUaeXgFlFFY)
 Duration: 4:44
 URLs:
 - https://www.youtube.com/watch?v=8K0npQ--ACw
@@ -762,6 +1206,11 @@ URLs:
 ---
 Track: Menu (Full)
 Main Release: Menu (Full)
+Additional Names:
+- Name: >-
+    スタートメニュー（Full Ver.）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=u2dqBeqbxFg)
 Duration: 0:32
 URLs:
 - https://www.youtube.com/watch?v=q2IYscs_8uY
@@ -769,6 +1218,11 @@ URLs:
 ---
 Track: Respite
 Main Release: track:respite-undertale
+Additional Names:
+- Name: >-
+    自由
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=ZDC9LWRcY1g)
 Duration: 1:54
 URLs:
 - https://www.youtube.com/watch?v=USVk9tGQXbo
@@ -776,6 +1230,11 @@ URLs:
 ---
 Track: Bring It In, Guys!
 Main Release: Bring It In, Guys!
+Additional Names:
+- Name: >-
+    全員、集合！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qOQz2gfWGaw)
 Duration: 4:12
 URLs:
 - https://www.youtube.com/watch?v=uxmzr8pNGDU
@@ -783,6 +1242,11 @@ URLs:
 ---
 Track: Last Goodbye
 Main Release: Last Goodbye
+Additional Names:
+- Name: >-
+    これでホントにサヨナラ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=oiaO05_ImsA)
 Duration: 2:15
 URLs:
 - https://www.youtube.com/watch?v=EpBQ5m3Ag3Q
@@ -790,6 +1254,11 @@ URLs:
 ---
 Track: But the Earth Refused to Die
 Main Release: But the Earth Refused to Die
+Additional Names:
+- Name: >-
+    BUT THE EARTH REFUSED TO DIE
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=WBPw2OOfzRM)
 Duration: 0:34
 URLs:
 - https://www.youtube.com/watch?v=O6pph2RMoPU
@@ -797,6 +1266,11 @@ URLs:
 ---
 Track: Battle Against a True Hero
 Main Release: Battle Against a True Hero
+Additional Names:
+- Name: >-
+    本物のヒーローとの戦い
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Bzw9yLkLVJg)
 Duration: 2:37
 URLs:
 - https://www.youtube.com/watch?v=DcERQHg3iy8
@@ -804,6 +1278,11 @@ URLs:
 ---
 Track: Power of -NEO-
 Main Release: Power of "NEO"
+Additional Names:
+- Name: >-
+    "NEO"の力
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=gXLA6GKdmEg)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=bWUIWTkBiqE
@@ -818,12 +1297,22 @@ URLs:
 ---
 Track: Good Night
 Main Release: Good Night
+Additional Names:
+- Name: >-
+    おやすみなさい
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=a9-7h0NmMn8
 - https://open.spotify.com/track/6Z3K31BKi5YL9Tj0zD3yvq
 ---
 Track: Dating Start! (FM Version)
+Additional Names:
+- Name: >-
+    DATE START!（FM Ver.）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
 Suffix Directory: false
 Artists:
 - artist:coda
@@ -836,6 +1325,11 @@ Referenced Tracks:
 - Maya Fey - Turnabout Sisters 2001
 ---
 Track: Bereavement
+Additional Names:
+- Name: >-
+    別れ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
 Suffix Directory: false
 Artists:
 - flashygoodness
@@ -848,6 +1342,11 @@ Referenced Tracks:
 Section: Hidden Track
 ---
 Track: Dog Dating
+Additional Names:
+- Name: >-
+    DOG DATE
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
 Suffix Directory: false
 Artists:
 - artist:coda

--- a/album/undertale-soundtrack-cd.yaml
+++ b/album/undertale-soundtrack-cd.yaml
@@ -186,6 +186,7 @@ URLs:
 ---
 Track: Home
 Main Release: track:home-undertale
+Additional Names:
 - Name: >-
     ホーム
   Annotation: >-

--- a/album/undertale-soundtrack-cd.yaml
+++ b/album/undertale-soundtrack-cd.yaml
@@ -47,7 +47,7 @@ Additional Names:
 - Name: >-
     むかしむかし…
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=AFZby8KSCuA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:29
 URLs:
 - https://tobyfox.bandcamp.com/track/once-upon-a-time-2
@@ -60,7 +60,7 @@ Additional Names:
 - Name: >-
     スタートメニュー
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=DopVsY89fBs)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/start-menu
@@ -73,7 +73,7 @@ Additional Names:
 - Name: >-
     キミの親友
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=gv4ai0G5ZUg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:23
 URLs:
 - https://tobyfox.bandcamp.com/track/your-best-friend-2
@@ -86,7 +86,7 @@ Additional Names:
 - Name: >-
     おちてきた子
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=qG5ZjezxIck)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/fallen-down-2
@@ -99,7 +99,7 @@ Additional Names:
 - Name: >-
     いせき
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=i0H9zYeplWE)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:32
 URLs:
 - https://tobyfox.bandcamp.com/track/ruins-2
@@ -112,7 +112,7 @@ Additional Names:
 - Name: >-
     おだやかだワン！♫
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=Ex99CEiW9yk)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-temperate
@@ -125,7 +125,7 @@ Additional Names:
 - Name: >-
     緊迫のとき
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=MKBZmviipPk)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:22
 URLs:
 - https://tobyfox.bandcamp.com/track/anticipation-2
@@ -138,7 +138,7 @@ Additional Names:
 - Name: >-
     重要任務…？
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=CxYSALlHTeQ)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:17
 URLs:
 - https://tobyfox.bandcamp.com/track/unnecessary-tension-2
@@ -151,7 +151,7 @@ Additional Names:
 - Name: >-
     ENEMY APPROACHING!
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=nrUNu6TdFWQ)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/enemy-approaching-2
@@ -164,7 +164,7 @@ Additional Names:
 - Name: >-
     ゴースト・ファイト
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=FeuwA9XBV0g)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/ghost-fight-2
@@ -177,7 +177,7 @@ Additional Names:
 - Name: >-
     ケツイ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=xSCwRBDaHw8)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/determination-2
@@ -189,7 +189,7 @@ Main Release: track:home-undertale
 - Name: >-
     ホーム
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=0UkRqMFMZic)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-2
@@ -202,7 +202,7 @@ Additional Names:
 - Name: >-
     ホーム（オルゴール）
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=vC1GAZ62NPg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-music-box-2
@@ -215,7 +215,7 @@ Additional Names:
 - Name: >-
     心の痛み
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=IZvESNW3HjU)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:48
 URLs:
 - https://tobyfox.bandcamp.com/track/heartache-2
@@ -228,7 +228,7 @@ Additional Names:
 - Name: >-
     サンズ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=F3dO5JNEgIk)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:51
 URLs:
 - https://tobyfox.bandcamp.com/track/sans
@@ -241,7 +241,7 @@ Additional Names:
 - Name: >-
     ニャハハ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=GQWuIxIts5A)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/nyeh-heh-heh-2
@@ -254,7 +254,7 @@ Additional Names:
 - Name: >-
     雪景色
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=HVrnz2x8etk)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:44
 URLs:
 - https://tobyfox.bandcamp.com/track/snowy
@@ -267,7 +267,7 @@ Additional Names:
 - Name: >-
     ホリデーシーズンだワン！♫
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=aXczmxc-N8g)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:30
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-holiday
@@ -280,7 +280,7 @@ Additional Names:
 - Name: >-
     ドッグベース
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=Mh44JW2mq8U)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:07
 URLs:
 - https://tobyfox.bandcamp.com/track/dogbass
@@ -293,7 +293,7 @@ Additional Names:
 - Name: >-
     謎めいた場所
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=a8fLyOS4OXU)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/mysterious-place
@@ -306,7 +306,7 @@ Additional Names:
 - Name: >-
     ドッグソング
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=tfO1zcVb4dY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:37
 URLs:
 - https://tobyfox.bandcamp.com/track/dogsong
@@ -319,7 +319,7 @@ Additional Names:
 - Name: >-
     スノーフルのまち
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=nTHMhRgJgP0)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:16
 URLs:
 - https://tobyfox.bandcamp.com/track/snowdin-town
@@ -332,7 +332,7 @@ Additional Names:
 - Name: >-
     いらっしゃいませ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=Txf-qkLVJx8)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/shop
@@ -353,7 +353,7 @@ Additional Names:
 - Name: >-
     DATE START!
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=puwOdeKHAKY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:57
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-start
@@ -366,7 +366,7 @@ Additional Names:
 - Name: >-
     DATE DANGER!
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=1u-RXnYHkCE)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-tense
@@ -379,7 +379,7 @@ Additional Names:
 - Name: >-
     DATE FIGHT!
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=QJmGkzWCI34)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:36
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-fight
@@ -392,7 +392,7 @@ Additional Names:
 - Name: >-
     もしかして…
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=SyFjHBA8Sqo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/premonition
@@ -405,7 +405,7 @@ Additional Names:
 - Name: >-
     キケンのナゾ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=l35q6TPP63c)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/danger-mystery
@@ -418,7 +418,7 @@ Additional Names:
 - Name: >-
     アンダイン
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=M_NW2CVgJCk)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/undyne
@@ -431,7 +431,7 @@ Additional Names:
 - Name: >-
     ウォーターフェル
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=DVUh7caufKU)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:07
 URLs:
 - https://tobyfox.bandcamp.com/track/waterfall
@@ -444,7 +444,7 @@ Additional Names:
 - Name: >-
     逃げろ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=92JtOM-wz4I)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:27
 URLs:
 - https://tobyfox.bandcamp.com/track/run
@@ -457,7 +457,7 @@ Additional Names:
 - Name: >-
     やすらぎの水辺
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=PBEGCIeJ4HQ)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/quiet-water
@@ -470,7 +470,7 @@ Additional Names:
 - Name: >-
     思い出
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=r3uFD8AKmr8)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:15
 URLs:
 - https://tobyfox.bandcamp.com/track/memory
@@ -483,7 +483,7 @@ Additional Names:
 - Name: >-
     びっくりするほど近い距離を飛んで渡らせてくれる鳥
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=__XEopj2hxg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/bird-that-carries-you-over-a-disproportionately-small-gap
@@ -496,7 +496,7 @@ Additional Names:
 - Name: >-
     怒りのマネキン！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=FbtgN-lqRHA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dummy
@@ -509,7 +509,7 @@ Additional Names:
 - Name: >-
     みすぼらしい家
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=D15E0GCJJrc)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:39
 URLs:
 - https://tobyfox.bandcamp.com/track/pathetic-house
@@ -522,7 +522,7 @@ Additional Names:
 - Name: >-
     ブルブルチューン
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=xNSOwI595QY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:24
 URLs:
 - https://tobyfox.bandcamp.com/track/spooktune
@@ -535,7 +535,7 @@ Additional Names:
 - Name: >-
     ブルブルウェーブ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=927DZIW5Zbg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/spookwave
@@ -548,7 +548,7 @@ Additional Names:
 - Name: >-
     グロすマスソング
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=I5bWvTkjBj8)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:13
 URLs:
 - https://tobyfox.bandcamp.com/track/ghouliday
@@ -561,7 +561,7 @@ Additional Names:
 - Name: >-
     まったり
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=IBo1GuVxEe0)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/chill
@@ -574,7 +574,7 @@ Additional Names:
 - Name: >-
     サンダースネイル
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=KuQnII1Wd6I)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:42
 URLs:
 - https://tobyfox.bandcamp.com/track/thundersnail
@@ -587,7 +587,7 @@ Additional Names:
 - Name: >-
     手ミーむら！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=BmMu_GO5UBE)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/temmie-village
@@ -600,7 +600,7 @@ Additional Names:
 - Name: >-
     手ミーみせ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=k7UMwQvXSoo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/tem-shop
@@ -613,7 +613,7 @@ Additional Names:
 - Name: >-
     ぬあああああ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=4BSINiU1xEA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:23
 URLs:
 - https://tobyfox.bandcamp.com/track/ngahhh
@@ -626,7 +626,7 @@ Additional Names:
 - Name: >-
     正義の槍
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=XGzYhJcm-Jw)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:55
 URLs:
 - https://tobyfox.bandcamp.com/track/spear-of-justice
@@ -639,7 +639,7 @@ Additional Names:
 - Name: >-
     Woo
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=7UwlGSgQhTs)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/ooo
@@ -652,7 +652,7 @@ Additional Names:
 - Name: >-
     アルフィー
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=WDujywIOBdA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:26
 URLs:
 - https://tobyfox.bandcamp.com/track/alphys
@@ -665,7 +665,7 @@ Additional Names:
 - Name: >-
     イッツ・ショータイム！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=0OKu3CvY3ZY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/its-showtime
@@ -678,7 +678,7 @@ Additional Names:
 - Name: >-
     メタル・クラッシャー
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=J6brXCuKTHo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/metal-crusher
@@ -699,7 +699,7 @@ Additional Names:
 - Name: >-
     あついワン！♫
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=R1TPMim12yU)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:34
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-heats
@@ -712,7 +712,7 @@ Additional Names:
 - Name: >-
     強敵たち
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=uQU3KBJu1aI)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/stronger-monsters
@@ -725,7 +725,7 @@ Additional Names:
 - Name: >-
     ホテル
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=naLXDko8eUA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:28
 URLs:
 - https://tobyfox.bandcamp.com/track/hotel
@@ -738,7 +738,7 @@ Additional Names:
 - Name: >-
     枕の上にミントチョコレートも置いていない宿泊施設をホテルと呼んでよいものだろうか
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=zWXD1ZJE-HY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:01
 URLs:
 - https://tobyfox.bandcamp.com/track/can-you-really-call-this-a-hotel-i-didnt-receive-a-mint-on-my-pillow-or-anything
@@ -751,7 +751,7 @@ Additional Names:
 - Name: >-
     告白
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=c8xdkxeKKg4)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:43
 URLs:
 - https://tobyfox.bandcamp.com/track/confession
@@ -764,7 +764,7 @@ Additional Names:
 - Name: >-
     現場から中継です
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=m-BeSffEiIA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/live-report
@@ -777,7 +777,7 @@ Additional Names:
 - Name: >-
     絶対絶命レポート
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=BENfoomNhUM)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:47
 URLs:
 - https://tobyfox.bandcamp.com/track/death-report
@@ -790,7 +790,7 @@ Additional Names:
 - Name: >-
     スパイダーダンス
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=OA46s3gww_o)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:46
 URLs:
 - https://tobyfox.bandcamp.com/track/spider-dance
@@ -803,7 +803,7 @@ Additional Names:
 - Name: >-
     おかしな敵
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=fb6kGsixpYg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:59
 URLs:
 - https://tobyfox.bandcamp.com/track/wrong-enemy
@@ -816,7 +816,7 @@ Additional Names:
 - Name: >-
     ああ！運命の人よ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=GOCuKG1o2cM)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:24
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-one-true-love
@@ -829,7 +829,7 @@ Additional Names:
 - Name: >-
     ああ！とらわれの恋人よ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=TPyPCv28fC0)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:33
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-dungeon
@@ -842,7 +842,7 @@ Additional Names:
 - Name: >-
     今日もどこかで雨が降る
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=KtC-pl9P3kE)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:50
 URLs:
 - https://tobyfox.bandcamp.com/track/its-raining-somewhere-else
@@ -855,7 +855,7 @@ Additional Names:
 - Name: >-
     コアへの接近
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=ZkXjF0IIeug)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:12
 URLs:
 - https://tobyfox.bandcamp.com/track/core-approach
@@ -871,7 +871,7 @@ Additional Names:
 - Name: >-
     コア
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=SEOYyM9n9mw)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:46
 URLs:
 - https://tobyfox.bandcamp.com/track/core
@@ -884,7 +884,7 @@ Additional Names:
 - Name: >-
     最終回！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=poDx-ww7H2A)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:08
 URLs:
 - https://tobyfox.bandcamp.com/track/last-episode
@@ -897,7 +897,7 @@ Additional Names:
 - Name: >-
     なんとッ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=FqRdEUsl27I)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-my
@@ -910,7 +910,7 @@ Additional Names:
 - Name: >-
     華麗なる死闘
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=qeDIZCc6Cyo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:15
 URLs:
 - https://tobyfox.bandcamp.com/track/death-by-glamour
@@ -923,7 +923,7 @@ Additional Names:
 - Name: >-
     愛するファンのみんなへ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=_AayQ9tBfxA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:47
 URLs:
 - https://tobyfox.bandcamp.com/track/for-the-fans
@@ -936,7 +936,7 @@ Additional Names:
 - Name: >-
     長～いエレベーター
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=KPsTN7GcEjI)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:20
 URLs:
 - https://tobyfox.bandcamp.com/track/long-elevator
@@ -949,7 +949,7 @@ Additional Names:
 - Name: >-
     UNDERTALE
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=1HIKNbnV8nw)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 6:22
 URLs:
 - https://tobyfox.bandcamp.com/track/undertale
@@ -962,7 +962,7 @@ Additional Names:
 - Name: >-
     サンズとのバトルで流れるかもしれない曲
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=hZaECtu1igk)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/song-that-might-play-when-you-fight-sans
@@ -975,7 +975,7 @@ Additional Names:
 - Name: >-
     決断のとき
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=RWl8o-znLck)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:13
 URLs:
 - https://tobyfox.bandcamp.com/track/the-choice
@@ -988,7 +988,7 @@ Additional Names:
 - Name: >-
     小さな衝撃
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=BZg1BuY1QiY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/small-shock
@@ -1001,7 +1001,7 @@ Additional Names:
 - Name: >-
     バリア
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=XPVq0qXuPLs)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/barrier
@@ -1022,7 +1022,7 @@ Additional Names:
 - Name: >-
     アズゴア
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=42kI2lT0x6U)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:36
 URLs:
 - https://tobyfox.bandcamp.com/track/asgore
@@ -1035,7 +1035,7 @@ Additional Names:
 - Name: >-
     バカだね
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=TRcQImpnW5Q)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:35
 URLs:
 - https://www.youtube.com/watch?v=oJFur9DFkoQ
@@ -1047,7 +1047,7 @@ Additional Names:
 - Name: >-
     最高の悪夢
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=DxxLzJDARbo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 4:00
 URLs:
 - https://www.youtube.com/watch?v=SObWQRaltug
@@ -1059,7 +1059,7 @@ Additional Names:
 - Name: >-
     フィナーレ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=hiioWOkHTp0)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:52
 URLs:
 - https://www.youtube.com/watch?v=5qajT8lS2ok
@@ -1071,7 +1071,7 @@ Additional Names:
 - Name: >-
     ひとつのエンディング
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=9g6V67JzAHY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 3:29
 URLs:
 - https://www.youtube.com/watch?v=gLgUesz8444
@@ -1083,7 +1083,7 @@ Additional Names:
 - Name: >-
     彼女がピアノを弾いている
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=rLKvVTJdYy0)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=41S_VS4dvY8
@@ -1095,7 +1095,7 @@ Additional Names:
 - Name: >-
     真実
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=52olsp3GUqY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:06
 URLs:
 - https://www.youtube.com/watch?v=LS86CPaShI4
@@ -1107,7 +1107,7 @@ Additional Names:
 - Name: >-
     アマルガム
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=DYRHwiyJsBA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:20
 URLs:
 - https://www.youtube.com/watch?v=0T8AROoIh44
@@ -1119,7 +1119,7 @@ Additional Names:
 - Name: >-
     おちてきた子（リプライズ）
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=qG5ZjezxIck)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:31
 URLs:
 - https://www.youtube.com/watch?v=AvDrW4JTjME
@@ -1131,7 +1131,7 @@ Additional Names:
 - Name: >-
     あきらめないで
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=rpYoFaphxqQ)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:02
 URLs:
 - https://www.youtube.com/watch?v=YQlbR-XW0CQ
@@ -1143,7 +1143,7 @@ Additional Names:
 - Name: >-
     夢と希望
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=wbO3p7_Mf30)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 3:01
 URLs:
 - https://www.youtube.com/watch?v=HA3Ks8NLS-Y
@@ -1155,7 +1155,7 @@ Additional Names:
 - Name: >-
     燃え尽きろ！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=kdM6Kl8ooGc)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:21
 URLs:
 - https://www.youtube.com/watch?v=VauL5iv687I
@@ -1174,7 +1174,7 @@ Additional Names:
 - Name: >-
     彼のテーマ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=pMXxxFeZAPg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:05
 URLs:
 - https://www.youtube.com/watch?v=8tf-gVaHdag
@@ -1186,7 +1186,7 @@ Additional Names:
 - Name: >-
     最後の力
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=Df0gorkBD-M)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=9WAKw79WqSQ
@@ -1198,7 +1198,7 @@ Additional Names:
 - Name: >-
     再会
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=VUaeXgFlFFY)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 4:44
 URLs:
 - https://www.youtube.com/watch?v=8K0npQ--ACw
@@ -1210,7 +1210,7 @@ Additional Names:
 - Name: >-
     スタートメニュー（Full Ver.）
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=u2dqBeqbxFg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:32
 URLs:
 - https://www.youtube.com/watch?v=q2IYscs_8uY
@@ -1222,7 +1222,7 @@ Additional Names:
 - Name: >-
     自由
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=ZDC9LWRcY1g)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 1:54
 URLs:
 - https://www.youtube.com/watch?v=USVk9tGQXbo
@@ -1234,7 +1234,7 @@ Additional Names:
 - Name: >-
     全員、集合！
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=qOQz2gfWGaw)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 4:12
 URLs:
 - https://www.youtube.com/watch?v=uxmzr8pNGDU
@@ -1246,7 +1246,7 @@ Additional Names:
 - Name: >-
     これでホントにサヨナラ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=oiaO05_ImsA)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:15
 URLs:
 - https://www.youtube.com/watch?v=EpBQ5m3Ag3Q
@@ -1258,7 +1258,7 @@ Additional Names:
 - Name: >-
     BUT THE EARTH REFUSED TO DIE
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=WBPw2OOfzRM)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:34
 URLs:
 - https://www.youtube.com/watch?v=O6pph2RMoPU
@@ -1270,7 +1270,7 @@ Additional Names:
 - Name: >-
     本物のヒーローとの戦い
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=Bzw9yLkLVJg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 2:37
 URLs:
 - https://www.youtube.com/watch?v=DcERQHg3iy8
@@ -1282,7 +1282,7 @@ Additional Names:
 - Name: >-
     "NEO"の力
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=gXLA6GKdmEg)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=bWUIWTkBiqE
@@ -1301,7 +1301,7 @@ Additional Names:
 - Name: >-
     おやすみなさい
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=a9-7h0NmMn8
@@ -1312,7 +1312,7 @@ Additional Names:
 - Name: >-
     DATE START!（FM Ver.）
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Suffix Directory: false
 Artists:
 - artist:coda
@@ -1329,7 +1329,7 @@ Additional Names:
 - Name: >-
     別れ
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Suffix Directory: false
 Artists:
 - flashygoodness
@@ -1346,7 +1346,7 @@ Additional Names:
 - Name: >-
     DOG DATE
   Annotation: >-
-    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
+    [Japanese release](https://www.fangamer.jp/collections/undertale/products/undertale-ost)
 Suffix Directory: false
 Artists:
 - artist:coda

--- a/album/undertale-soundtrack.yaml
+++ b/album/undertale-soundtrack.yaml
@@ -1192,6 +1192,7 @@ Referenced Tracks:
 - Terezi's Theme
 ---
 Track: Finale
+Additional Names:
 - Name: >-
     フィナーレ
   Annotation: >-
@@ -1208,6 +1209,7 @@ Referenced Tracks:
 - Memory
 ---
 Track: An Ending
+Additional Names:
 - Name: >-
     ひとつのエンディング
   Annotation: >-
@@ -1220,6 +1222,7 @@ Referenced Tracks:
 - Ruins
 ---
 Track: She's Playing Piano
+Additional Names:
 - Name: >-
     彼女がピアノを弾いている
   Annotation: >-
@@ -1232,6 +1235,7 @@ Referenced Tracks:
 - Alphys
 ---
 Track: Here We Are
+Additional Names:
 - Name: >-
     真実
   Annotation: >-
@@ -1244,6 +1248,7 @@ Referenced Tracks:
 - Alphys
 ---
 Track: Amalgam
+Additional Names:
 - Name: >-
     アマルガム
   Annotation: >-
@@ -1256,6 +1261,7 @@ Referenced Tracks:
 - Barrier
 ---
 Track: Fallen Down (Reprise)
+Additional Names:
 - Name: >-
     おちてきた子（リプライズ）
   Annotation: >-
@@ -1269,6 +1275,7 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Don't Give Up
+Additional Names:
 - Name: >-
     あきらめないで
   Annotation: >-
@@ -1281,6 +1288,7 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Hopes and Dreams
+Additional Names:
 - Name: >-
     夢と希望
   Annotation: >-
@@ -1778,6 +1786,7 @@ Referencing Sources:
     <i>Lan:</i> I think it's critical to understanding music in context. I think it's something *we should think about* when considering what the Point of any music even is. But I also think it's super nebulous and speculative, very often, when we don't get a confident and unambiguous word one way or the other from the composer. That makes me hesitant to use it as a deciding factor - on whether to include or exclude a reference. (...But I wonder if it's necessary, sometimes, too.)
 ---
 Track: Burn in Despair!
+Additional Names:
 - Name: >-
     燃え尽きろ！
   Annotation: >-
@@ -1807,6 +1816,7 @@ Referencing Sources:
     Refer to [[Hopes and Dreams]] for a detailed record of discussion about the presence of [[Penumbra Phantasm]] in this track, that one, and [[Last Goodbye]].
 ---
 Track: His Theme
+Additional Names:
 - Name: >-
     彼のテーマ
   Annotation: >-
@@ -1819,6 +1829,7 @@ Referenced Tracks:
 - Memory
 ---
 Track: Final Power
+Additional Names:
 - Name: >-
     最後の力
   Annotation: >-
@@ -1832,6 +1843,7 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Reunited
+Additional Names:
 - Name: >-
     再会
   Annotation: >-
@@ -1846,6 +1858,7 @@ Referenced Tracks:
 - Snowdin Town
 ---
 Track: Menu (Full)
+Additional Names:
 - Name: >-
     スタートメニュー（Full Ver.）
   Annotation: >-
@@ -1859,6 +1872,7 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Respite
+Additional Names:
 - Name: >-
     自由
   Annotation: >-
@@ -1873,6 +1887,7 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Bring It In, Guys!
+Additional Names:
 - Name: >-
     全員、集合！
   Annotation: >-
@@ -1895,6 +1910,7 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Last Goodbye
+Additional Names:
 - Name: >-
     これでホントにサヨナラ
   Annotation: >-
@@ -1916,6 +1932,7 @@ Referencing Sources:
     Refer to [[Hopes and Dreams]] for a detailed record of discussion about the presence of [[Penumbra Phantasm]] in this track, that one, and [[SAVE the World]].
 ---
 Track: But the Earth Refused to Die
+Additional Names:
 - Name: >-
     BUT THE EARTH REFUSED TO DIE
   Annotation: >-
@@ -1928,6 +1945,7 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Battle Against a True Hero
+Additional Names:
 - Name: >-
     本物のヒーローとの戦い
   Annotation: >-
@@ -1940,6 +1958,7 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Power of "NEO"
+Additional Names:
 - Name: >-
     "NEO"の力
   Annotation: >-
@@ -1961,6 +1980,7 @@ Referenced Tracks:
 - track:megalovania-ebhh
 ---
 Track: Good Night
+Additional Names:
 - Name: >-
     おやすみなさい
   Annotation: >-

--- a/album/undertale-soundtrack.yaml
+++ b/album/undertale-soundtrack.yaml
@@ -1,4 +1,9 @@
 Album: UNDERTALE Soundtrack
+Additional Names:
+- Name: >-
+    UNDERTALE サウンドトラック
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/playlist?list=OLAK5uy_mIPOCqUQ9XhAymMmT1vcSPfzdkWZ7zI2k)
 Directory Suffix: undertale
 Artists:
 - Toby Fox
@@ -35,6 +40,11 @@ Additional Files:
 Section: Main album
 ---
 Track: Once Upon a Time
+Additional Names:
+- Name: >-
+    むかしむかし…
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=AFZby8KSCuA)
 Duration: 1:28
 URLs:
 - https://tobyfox.bandcamp.com/track/once-upon-a-time-2
@@ -46,6 +56,11 @@ Commentary: |-
     This song was created as an homage to the title music to [[artist:mother|MOTHER]], eventually released in the US as EarthBound Beginnings. What inspired me most is how emotional and nostalgic it felt, even with just a few long notes and a simple bassline. I wanted to replicate that. You don't need to write something complicated to express a deep feeling. When something is simple, it's easy to capture your pure expression. And so I think this is a sincere song.
 ---
 Track: Start Menu
+Additional Names:
+- Name: >-
+    スタートメニュー
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DopVsY89fBs)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/start-menu
@@ -55,6 +70,11 @@ Referenced Tracks:
 - track:menu-undertale-demo
 ---
 Track: Your Best Friend
+Additional Names:
+- Name: >-
+    キミの親友
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=gv4ai0G5ZUg)
 Duration: 0:23
 URLs:
 - https://tobyfox.bandcamp.com/track/your-best-friend-2
@@ -62,6 +82,11 @@ URLs:
 - https://open.spotify.com/track/6gJTgSwOw2TqAPCnk2gTlk
 ---
 Track: Fallen Down
+Additional Names:
+- Name: >-
+    おちてきた子
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qG5ZjezxIck)
 Suffix Directory: true
 Duration: 0:57
 URLs:
@@ -76,6 +101,11 @@ Commentary: |-
     Someone recently asked me how I create songs that fit the characters and scenarios in the game so perfectly. Well, given the fact that some of them weren't created for UNDERTALE... I actually think I'm just good at using the fact that the human mind loves to make associations. Whatever you hear first in a scenario will be the thing that "fits."
 ---
 Track: Ruins
+Additional Names:
+- Name: >-
+    いせき
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=i0H9zYeplWE)
 Suffix Directory: true
 Duration: 1:32
 URLs:
@@ -84,6 +114,11 @@ URLs:
 - https://open.spotify.com/track/1vuSdk2EGjh3eXCXBbT9Qf
 ---
 Track: Uwa!! So Temperate♫
+Additional Names:
+- Name: >-
+    おだやかだワン！♫
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Ex99CEiW9yk)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-temperate
@@ -91,6 +126,11 @@ URLs:
 - https://open.spotify.com/track/3PV4bPPqezu18K45MIOrVY
 ---
 Track: Anticipation
+Additional Names:
+- Name: >-
+    緊迫のとき
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=MKBZmviipPk)
 Duration: 0:22
 URLs:
 - https://tobyfox.bandcamp.com/track/anticipation-2
@@ -100,6 +140,11 @@ Referenced Tracks:
 - Enemy Approaching
 ---
 Track: Unnecessary Tension
+Additional Names:
+- Name: >-
+    重要任務…？
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=CxYSALlHTeQ)
 Duration: 0:17
 URLs:
 - https://tobyfox.bandcamp.com/track/unnecessary-tension-2
@@ -107,6 +152,11 @@ URLs:
 - https://open.spotify.com/track/184lW8f9jvoShhMV8o6BuW
 ---
 Track: Enemy Approaching
+Additional Names:
+- Name: >-
+    ENEMY APPROACHING!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=nrUNu6TdFWQ)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/enemy-approaching-2
@@ -114,6 +164,11 @@ URLs:
 - https://open.spotify.com/track/5iOTHhi2C3mHSn007Neqcg
 ---
 Track: Ghost Fight
+Additional Names:
+- Name: >-
+    ゴースト・ファイト
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=FeuwA9XBV0g)
 Duration: 0:56
 URLs:
 - https://tobyfox.bandcamp.com/track/ghost-fight-2
@@ -121,6 +176,11 @@ URLs:
 - https://open.spotify.com/track/36AhCvv8NAVPr0eNsv2PrW
 ---
 Track: Determination
+Additional Names:
+- Name: >-
+    ケツイ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=xSCwRBDaHw8)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/determination-2
@@ -128,6 +188,11 @@ URLs:
 - https://open.spotify.com/track/3KHbBpwYdlM6uKJirvCrEA
 ---
 Track: Home
+Additional Names:
+- Name: >-
+    ホーム
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=0UkRqMFMZic)
 Suffix Directory: true
 Duration: 2:03
 URLs:
@@ -138,6 +203,11 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Home (Music Box)
+Additional Names:
+- Name: >-
+    ホーム（オルゴール）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=vC1GAZ62NPg)
 Duration: 2:03
 URLs:
 - https://tobyfox.bandcamp.com/track/home-music-box-2
@@ -148,6 +218,11 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Heartache
+Additional Names:
+- Name: >-
+    心の痛み
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=IZvESNW3HjU)
 Duration: 1:48
 URLs:
 - https://tobyfox.bandcamp.com/track/heartache-2
@@ -157,6 +232,11 @@ Referenced Tracks:
 - Enemy Approaching
 ---
 Track: sans.
+Additional Names:
+- Name: >-
+    サンズ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=F3dO5JNEgIk)
 Duration: 0:50
 URLs:
 - https://tobyfox.bandcamp.com/track/sans
@@ -164,6 +244,11 @@ URLs:
 - https://open.spotify.com/track/26lWYpgbcknITI0Fy1eZDs
 ---
 Track: Nyeh Heh Heh!
+Additional Names:
+- Name: >-
+    ニャハハ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=GQWuIxIts5A)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/nyeh-heh-heh-2
@@ -177,6 +262,11 @@ Commentary: |-
     This song wasn't made for Undertale either. It (and [[Bonetrousle]]) were the main battle themes of [[album:deltarune-ch1-ost|an RPG game I was working on before Undertale, based off of a dream I had.]] However, I didn't plan it very well, so the project fell apart before I accomplished a single room. [["Sans"]] was also a song in the game called "Muscles," and [["Heartache"]] was a song called "Joker Battle." Anyway, I always mess up playing this song on the piano, so if you can't play it, it's not a big deal. Since it's Papyrus, it's OK as long as you try your best.
 ---
 Track: Snowy
+Additional Names:
+- Name: >-
+    雪景色
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=HVrnz2x8etk)
 Duration: 1:44
 URLs:
 - https://tobyfox.bandcamp.com/track/snowy
@@ -184,6 +274,11 @@ URLs:
 - https://open.spotify.com/track/7Af5aQzfpm2VxnCFsy6Tkx
 ---
 Track: Uwa!! So Holiday♫
+Additional Names:
+- Name: >-
+    ホリデーシーズンだワン！♫
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=aXczmxc-N8g)
 Duration: 0:30
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-holiday
@@ -193,6 +288,11 @@ Referenced Tracks:
 - Uwa!! So Temperate♫
 ---
 Track: Dogbass
+Additional Names:
+- Name: >-
+    ドッグベース
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Mh44JW2mq8U)
 Duration: 0:06
 URLs:
 - https://tobyfox.bandcamp.com/track/dogbass
@@ -202,6 +302,11 @@ Referenced Tracks:
 - Ghost Fight
 ---
 Track: Mysterious Place
+Additional Names:
+- Name: >-
+    謎めいた場所
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=a8fLyOS4OXU)
 Duration: 0:44
 URLs:
 - https://tobyfox.bandcamp.com/track/mysterious-place
@@ -209,6 +314,11 @@ URLs:
 - https://open.spotify.com/track/79HBiklNqtQXln5ocHUR3B
 ---
 Track: Dogsong
+Additional Names:
+- Name: >-
+    ドッグソング
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=tfO1zcVb4dY)
 Duration: 0:37
 URLs:
 - https://tobyfox.bandcamp.com/track/dogsong
@@ -218,6 +328,11 @@ Referenced Tracks:
 - Enemy Approaching
 ---
 Track: Snowdin Town
+Additional Names:
+- Name: >-
+    スノーフルのまち
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=nTHMhRgJgP0)
 Duration: 1:16
 URLs:
 - https://tobyfox.bandcamp.com/track/snowdin-town
@@ -234,6 +349,11 @@ Commentary: |-
     I really liked playing this one on the piano. Whenever I played it my mom would get it stuck in her head and whistle it. So I'm quite proud of it.
 ---
 Track: Shop
+Additional Names:
+- Name: >-
+    いらっしゃいませ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Txf-qkLVJx8)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 0:50
@@ -252,6 +372,11 @@ URLs:
 - https://open.spotify.com/track/2AtC6i0b8TjpjhWBZYLprX
 ---
 Track: Dating Start!
+Additional Names:
+- Name: >-
+    DATE START!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=puwOdeKHAKY)
 Duration: 1:56
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-start
@@ -261,6 +386,11 @@ Referenced Tracks:
 - Snowdin Town
 ---
 Track: Dating Tense!
+Additional Names:
+- Name: >-
+    DATE DANGER!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=1u-RXnYHkCE)
 Duration: 0:26
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-tense
@@ -270,6 +400,11 @@ Referenced Tracks:
 - Undyne
 ---
 Track: Dating Fight!
+Additional Names:
+- Name: >-
+    DATE FIGHT!
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=QJmGkzWCI34)
 Duration: 0:35
 URLs:
 - https://tobyfox.bandcamp.com/track/dating-fight
@@ -280,6 +415,11 @@ Referenced Tracks:
 - Snowdin Town
 ---
 Track: Premonition
+Additional Names:
+- Name: >-
+    もしかして…
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=SyFjHBA8Sqo)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 1:01
@@ -291,6 +431,11 @@ Referenced Tracks:
 - Your Best Nightmare
 ---
 Track: Danger Mystery
+Additional Names:
+- Name: >-
+    キケンのナゾ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=l35q6TPP63c)
 Duration: 0:18
 URLs:
 - https://tobyfox.bandcamp.com/track/danger-mystery
@@ -298,6 +443,11 @@ URLs:
 - https://open.spotify.com/track/3577RkKMcLN7NKeqNDjLQw
 ---
 Track: Undyne
+Additional Names:
+- Name: >-
+    アンダイン
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=M_NW2CVgJCk)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/undyne
@@ -305,6 +455,11 @@ URLs:
 - https://open.spotify.com/track/1MoAGaJNyPwaLSB6iTLNg1
 ---
 Track: Waterfall
+Additional Names:
+- Name: >-
+    ウォーターフェル
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DVUh7caufKU)
 Duration: 2:06
 URLs:
 - https://tobyfox.bandcamp.com/track/waterfall
@@ -316,6 +471,11 @@ Referenced Tracks:
 - Ooo
 ---
 Track: Run!
+Additional Names:
+- Name: >-
+    逃げろ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=92JtOM-wz4I)
 Duration: 0:26
 URLs:
 - https://tobyfox.bandcamp.com/track/run
@@ -325,6 +485,11 @@ Referenced Tracks:
 - Undyne
 ---
 Track: Quiet Water
+Additional Names:
+- Name: >-
+    やすらぎの水辺
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=PBEGCIeJ4HQ)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/quiet-water
@@ -334,6 +499,11 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Memory
+Additional Names:
+- Name: >-
+    思い出
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=r3uFD8AKmr8)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 1:15
@@ -355,6 +525,11 @@ Commentary: |-
     [[Don't forget]] that...
 ---
 Track: Bird That Carries You Over A Disproportionately Small Gap
+Additional Names:
+- Name: >-
+    びっくりするほど近い距離を飛んで渡らせてくれる鳥
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=__XEopj2hxg)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/bird-that-carries-you-over-a-disproportionately-small-gap
@@ -364,6 +539,11 @@ Referenced Tracks:
 - Alphys
 ---
 Track: Dummy!
+Additional Names:
+- Name: >-
+    怒りのマネキン！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=FbtgN-lqRHA)
 Duration: 2:25
 URLs:
 - https://tobyfox.bandcamp.com/track/dummy
@@ -373,6 +553,11 @@ Referenced Tracks:
 - Ghost Fight
 ---
 Track: Pathetic House
+Additional Names:
+- Name: >-
+    みすぼらしい家
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=D15E0GCJJrc)
 Duration: 0:38
 URLs:
 - https://tobyfox.bandcamp.com/track/pathetic-house
@@ -382,6 +567,11 @@ Referenced Tracks:
 - Ghost Fight
 ---
 Track: Spooktune
+Additional Names:
+- Name: >-
+    ブルブルチューン
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=xNSOwI595QY)
 Suffix Directory: true
 Duration: 0:23
 URLs:
@@ -390,6 +580,11 @@ URLs:
 - https://open.spotify.com/track/7jxPl7YKBJuLEgG2iuQ86u
 ---
 Track: Spookwave
+Additional Names:
+- Name: >-
+    ブルブルウェーブ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=927DZIW5Zbg)
 Duration: 0:25
 URLs:
 - https://tobyfox.bandcamp.com/track/spookwave
@@ -399,6 +594,11 @@ Referenced Tracks:
 - Spooktune
 ---
 Track: Ghouliday
+Additional Names:
+- Name: >-
+    グロすマスソング
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=I5bWvTkjBj8)
 Duration: 0:12
 URLs:
 - https://tobyfox.bandcamp.com/track/ghouliday
@@ -408,6 +608,11 @@ Referenced Tracks:
 - The One Horse Open Sleigh
 ---
 Track: Chill
+Additional Names:
+- Name: >-
+    まったり
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=IBo1GuVxEe0)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 0:56
@@ -417,6 +622,11 @@ URLs:
 - https://open.spotify.com/track/7aETfVDs6MnQg6uyEhhpro
 ---
 Track: Thundersnail
+Additional Names:
+- Name: >-
+    サンダースネイル
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=KuQnII1Wd6I)
 Duration: 0:42
 URLs:
 - https://tobyfox.bandcamp.com/track/thundersnail
@@ -424,6 +634,11 @@ URLs:
 - https://open.spotify.com/track/47nTwghY7OBlUhnrp0npNp
 ---
 Track: Temmie Village
+Additional Names:
+- Name: >-
+    手ミーむら！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=BmMu_GO5UBE)
 Duration: 0:57
 URLs:
 - https://tobyfox.bandcamp.com/track/temmie-village
@@ -433,6 +648,11 @@ Referenced Tracks:
 - Enemy Approaching
 ---
 Track: Tem Shop
+Additional Names:
+- Name: >-
+    手ミーみせ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=k7UMwQvXSoo)
 Duration: 0:45
 URLs:
 - https://tobyfox.bandcamp.com/track/tem-shop
@@ -442,6 +662,11 @@ Referenced Tracks:
 - Enemy Approaching
 ---
 Track: NGAHHH!!
+Additional Names:
+- Name: >-
+    ぬあああああ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=4BSINiU1xEA)
 Duration: 1:22
 URLs:
 - https://tobyfox.bandcamp.com/track/ngahhh
@@ -452,6 +677,11 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Spear of Justice
+Additional Names:
+- Name: >-
+    正義の槍
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=XGzYhJcm-Jw)
 Duration: 1:55
 URLs:
 - https://tobyfox.bandcamp.com/track/spear-of-justice
@@ -462,6 +692,11 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Ooo
+Additional Names:
+- Name: >-
+    Woo
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=7UwlGSgQhTs)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/ooo
@@ -469,6 +704,11 @@ URLs:
 - https://open.spotify.com/track/6MpL0zLvaHKjWFZQjwBnFB
 ---
 Track: Alphys
+Additional Names:
+- Name: >-
+    アルフィー
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=WDujywIOBdA)
 Duration: 1:25
 URLs:
 - https://tobyfox.bandcamp.com/track/alphys
@@ -476,6 +716,11 @@ URLs:
 - https://open.spotify.com/track/5Prf4wpKlnsqj9HTSW4BjW
 ---
 Track: It's Showtime!
+Additional Names:
+- Name: >-
+    イッツ・ショータイム！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=0OKu3CvY3ZY)
 Duration: 0:46
 URLs:
 - https://tobyfox.bandcamp.com/track/its-showtime
@@ -485,6 +730,11 @@ Referenced Tracks:
 - Hotel
 ---
 Track: Metal Crusher
+Additional Names:
+- Name: >-
+    メタル・クラッシャー
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=J6brXCuKTHo)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/metal-crusher
@@ -503,6 +753,11 @@ Referenced Tracks:
 - Patient
 ---
 Track: Uwa!! So HEATS!!♫
+Additional Names:
+- Name: >-
+    あついワン！♫
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=R1TPMim12yU)
 Duration: 0:33
 URLs:
 - https://tobyfox.bandcamp.com/track/uwa-so-heats
@@ -512,6 +767,11 @@ Referenced Tracks:
 - Uwa!! So Temperate♫
 ---
 Track: Stronger Monsters
+Additional Names:
+- Name: >-
+    強敵たち
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=uQU3KBJu1aI)
 Duration: 1:03
 URLs:
 - https://tobyfox.bandcamp.com/track/stronger-monsters
@@ -521,6 +781,11 @@ Referenced Tracks:
 - Enemy Approaching
 ---
 Track: Hotel
+Additional Names:
+- Name: >-
+    ホテル
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=naLXDko8eUA)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 1:27
@@ -532,6 +797,11 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Can You Really Call This A Hotel, I Didn't Receive A Mint On My Pillow Or Anything
+Additional Names:
+- Name: >-
+    枕の上にミントチョコレートも置いていない宿泊施設をホテルと呼んでよいものだろうか
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=zWXD1ZJE-HY)
 Duration: 1:01
 URLs:
 - https://tobyfox.bandcamp.com/track/can-you-really-call-this-a-hotel-i-didnt-receive-a-mint-on-my-pillow-or-anything
@@ -542,6 +812,11 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Confession
+Additional Names:
+- Name: >-
+    告白
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=c8xdkxeKKg4)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 0:42
@@ -553,6 +828,11 @@ Referenced Tracks:
 - Snowdin Town
 ---
 Track: Live Report
+Additional Names:
+- Name: >-
+    現場から中継です
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=m-BeSffEiIA)
 Duration: 0:17
 URLs:
 - https://tobyfox.bandcamp.com/track/live-report
@@ -562,6 +842,11 @@ Referenced Tracks:
 - It's Showtime!
 ---
 Track: Death Report
+Additional Names:
+- Name: >-
+    絶対絶命レポート
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=BENfoomNhUM)
 Duration: 0:47
 URLs:
 - https://tobyfox.bandcamp.com/track/death-report
@@ -572,6 +857,11 @@ Referenced Tracks:
 - It's Showtime!
 ---
 Track: Spider Dance
+Additional Names:
+- Name: >-
+    スパイダーダンス
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=OA46s3gww_o)
 Duration: 1:46
 URLs:
 - https://tobyfox.bandcamp.com/track/spider-dance
@@ -581,6 +871,11 @@ Referenced Tracks:
 - Ghost Fight
 ---
 Track: Wrong Enemy !?
+Additional Names:
+- Name: >-
+    おかしな敵
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=fb6kGsixpYg)
 Duration: 0:58
 URLs:
 - https://tobyfox.bandcamp.com/track/wrong-enemy
@@ -588,6 +883,11 @@ URLs:
 - https://open.spotify.com/track/5R8oeZeq8AUiJuz5FIPR9m
 ---
 Track: Oh! One True Love
+Additional Names:
+- Name: >-
+    ああ！運命の人よ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=GOCuKG1o2cM)
 Duration: 1:24
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-one-true-love
@@ -619,6 +919,11 @@ Lyrics: |-
     So sad it's happening.
 ---
 Track: Oh! Dungeon
+Additional Names:
+- Name: >-
+    ああ！とらわれの恋人よ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=TPyPCv28fC0)
 Duration: 0:32
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-dungeon
@@ -645,6 +950,11 @@ Lyrics: |-
     Them fry
 ---
 Track: It's Raining Somewhere Else
+Additional Names:
+- Name: >-
+    今日もどこかで雨が降る
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=KtC-pl9P3kE)
 Duration: 2:50
 URLs:
 - https://tobyfox.bandcamp.com/track/its-raining-somewhere-else
@@ -654,6 +964,11 @@ Referenced Tracks:
 - sans.
 ---
 Track: CORE Approach
+Additional Names:
+- Name: >-
+    コアへの接近
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=ZkXjF0IIeug)
 Duration: 0:12
 URLs:
 - https://tobyfox.bandcamp.com/track/core-approach
@@ -663,6 +978,11 @@ Referenced Tracks:
 - Hotel
 ---
 Track: CORE
+Additional Names:
+- Name: >-
+    コア
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=SEOYyM9n9mw)
 Duration: 2:46
 URLs:
 - https://tobyfox.bandcamp.com/track/core
@@ -672,6 +992,11 @@ Referenced Tracks:
 - Another Medium
 ---
 Track: Last Episode!
+Additional Names:
+- Name: >-
+    最終回！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=poDx-ww7H2A)
 Duration: 0:07
 URLs:
 - https://tobyfox.bandcamp.com/track/last-episode
@@ -681,6 +1006,11 @@ Referenced Tracks:
 - Metal Crusher
 ---
 Track: Oh My...
+Additional Names:
+- Name: >-
+    なんとッ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=FqRdEUsl27I)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/oh-my
@@ -688,6 +1018,11 @@ URLs:
 - https://open.spotify.com/track/6CBsGV6sv811sRb4sNBmcl
 ---
 Track: Death by Glamour
+Additional Names:
+- Name: >-
+    華麗なる死闘
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qeDIZCc6Cyo)
 Duration: 2:14
 URLs:
 - https://tobyfox.bandcamp.com/track/death-by-glamour
@@ -700,6 +1035,11 @@ Referenced Tracks:
 - It's Showtime!
 ---
 Track: For the Fans
+Additional Names:
+- Name: >-
+    愛するファンのみんなへ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=_AayQ9tBfxA)
 Duration: 1:47
 URLs:
 - https://tobyfox.bandcamp.com/track/for-the-fans
@@ -709,6 +1049,11 @@ Referenced Tracks:
 - Oh! One True Love
 ---
 Track: Long Elevator
+Additional Names:
+- Name: >-
+    長～いエレベーター
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=KPsTN7GcEjI)
 Duration: 0:20
 URLs:
 - https://tobyfox.bandcamp.com/track/long-elevator
@@ -716,6 +1061,11 @@ URLs:
 - https://open.spotify.com/track/3bmbaQXM98fEAoQotiNu9Q
 ---
 Track: Undertale
+Additional Names:
+- Name: >-
+    UNDERTALE
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=1HIKNbnV8nw)
 Contributors:
 - Stephanie MacIntire (guitar)
 Duration: 6:21
@@ -730,6 +1080,11 @@ Commentary: |-
     It wasn’t until I heard a certain song that I was inspired to completely change the chords and guitar accompaniment. This new guitar accompaniment then served as the basis for [[track:memory-undertale|“Memory,”]] so we have a lot to thank that inspiring song for.
 ---
 Track: Song That Might Play When You Fight Sans
+Additional Names:
+- Name: >-
+    サンズとのバトルで流れるかもしれない曲
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=hZaECtu1igk)
 Duration: 1:02
 URLs:
 - https://tobyfox.bandcamp.com/track/song-that-might-play-when-you-fight-sans
@@ -740,6 +1095,11 @@ Referenced Tracks:
 - Bonetrousle
 ---
 Track: The Choice
+Additional Names:
+- Name: >-
+    決断のとき
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=RWl8o-znLck)
 Duration: 2:12
 URLs:
 - https://tobyfox.bandcamp.com/track/the-choice
@@ -751,6 +1111,11 @@ Sampled Tracks:
 - Undertale
 ---
 Track: Small Shock
+Additional Names:
+- Name: >-
+    小さな衝撃
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=BZg1BuY1QiY)
 Duration: 0:14
 URLs:
 - https://tobyfox.bandcamp.com/track/small-shock
@@ -758,6 +1123,11 @@ URLs:
 - https://open.spotify.com/track/7g2vS40kPg9PVMc8muxzBb
 ---
 Track: Barrier
+Additional Names:
+- Name: >-
+    バリア
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=XPVq0qXuPLs)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 0:31
@@ -774,6 +1144,11 @@ URLs:
 - https://open.spotify.com/track/7txouAZgjqHcIPQQTzojyv
 ---
 Track: ASGORE
+Additional Names:
+- Name: >-
+    アズゴア
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=42kI2lT0x6U)
 Duration: 2:36
 URLs:
 - https://tobyfox.bandcamp.com/track/asgore
@@ -788,6 +1163,11 @@ Referenced Tracks:
 Section: Hidden on Bandcamp
 ---
 Track: You Idiot
+Additional Names:
+- Name: >-
+    バカだね
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=TRcQImpnW5Q)
 Duration: 0:34
 URLs:
 - https://www.youtube.com/watch?v=oJFur9DFkoQ
@@ -796,6 +1176,11 @@ Referenced Tracks:
 - Your Best Nightmare
 ---
 Track: Your Best Nightmare
+Additional Names:
+- Name: >-
+    最高の悪夢
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DxxLzJDARbo)
 Duration: 4:00
 URLs:
 - https://www.youtube.com/watch?v=SObWQRaltug
@@ -807,6 +1192,10 @@ Referenced Tracks:
 - Terezi's Theme
 ---
 Track: Finale
+- Name: >-
+    フィナーレ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=hiioWOkHTp0)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 1:52
@@ -819,6 +1208,10 @@ Referenced Tracks:
 - Memory
 ---
 Track: An Ending
+- Name: >-
+    ひとつのエンディング
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=9g6V67JzAHY)
 Duration: 3:28
 URLs:
 - https://www.youtube.com/watch?v=gLgUesz8444
@@ -827,6 +1220,10 @@ Referenced Tracks:
 - Ruins
 ---
 Track: She's Playing Piano
+- Name: >-
+    彼女がピアノを弾いている
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=rLKvVTJdYy0)
 Duration: 0:18
 URLs:
 - https://www.youtube.com/watch?v=41S_VS4dvY8
@@ -835,6 +1232,10 @@ Referenced Tracks:
 - Alphys
 ---
 Track: Here We Are
+- Name: >-
+    真実
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=52olsp3GUqY)
 Duration: 2:06
 URLs:
 - https://www.youtube.com/watch?v=LS86CPaShI4
@@ -843,6 +1244,10 @@ Referenced Tracks:
 - Alphys
 ---
 Track: Amalgam
+- Name: >-
+    アマルガム
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=DYRHwiyJsBA)
 Duration: 1:20
 URLs:
 - https://www.youtube.com/watch?v=0T8AROoIh44
@@ -851,6 +1256,10 @@ Referenced Tracks:
 - Barrier
 ---
 Track: Fallen Down (Reprise)
+- Name: >-
+    おちてきた子（リプライズ）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qG5ZjezxIck)
 Duration: 2:30
 URLs:
 - https://www.youtube.com/watch?v=AvDrW4JTjME
@@ -860,6 +1269,10 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Don't Give Up
+- Name: >-
+    あきらめないで
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=rpYoFaphxqQ)
 Duration: 2:02
 URLs:
 - https://www.youtube.com/watch?v=YQlbR-XW0CQ
@@ -868,6 +1281,10 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Hopes and Dreams
+- Name: >-
+    夢と希望
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=wbO3p7_Mf30)
 Duration: 3:01
 URLs:
 - https://www.youtube.com/watch?v=HA3Ks8NLS-Y
@@ -1361,6 +1778,10 @@ Referencing Sources:
     <i>Lan:</i> I think it's critical to understanding music in context. I think it's something *we should think about* when considering what the Point of any music even is. But I also think it's super nebulous and speculative, very often, when we don't get a confident and unambiguous word one way or the other from the composer. That makes me hesitant to use it as a deciding factor - on whether to include or exclude a reference. (...But I wonder if it's necessary, sometimes, too.)
 ---
 Track: Burn in Despair!
+- Name: >-
+    燃え尽きろ！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=kdM6Kl8ooGc)
 Duration: 0:21
 URLs:
 - https://www.youtube.com/watch?v=VauL5iv687I
@@ -1386,6 +1807,10 @@ Referencing Sources:
     Refer to [[Hopes and Dreams]] for a detailed record of discussion about the presence of [[Penumbra Phantasm]] in this track, that one, and [[Last Goodbye]].
 ---
 Track: His Theme
+- Name: >-
+    彼のテーマ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=pMXxxFeZAPg)
 Duration: 2:05
 URLs:
 - https://www.youtube.com/watch?v=8tf-gVaHdag
@@ -1394,6 +1819,10 @@ Referenced Tracks:
 - Memory
 ---
 Track: Final Power
+- Name: >-
+    最後の力
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Df0gorkBD-M)
 Duration: 0:19
 URLs:
 - https://www.youtube.com/watch?v=9WAKw79WqSQ
@@ -1403,6 +1832,10 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Reunited
+- Name: >-
+    再会
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=VUaeXgFlFFY)
 Suffix Directory: true
 Duration: 4:44
 URLs:
@@ -1413,6 +1846,10 @@ Referenced Tracks:
 - Snowdin Town
 ---
 Track: Menu (Full)
+- Name: >-
+    スタートメニュー（Full Ver.）
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=u2dqBeqbxFg)
 Duration: 0:32
 URLs:
 - https://www.youtube.com/watch?v=q2IYscs_8uY
@@ -1422,6 +1859,10 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Respite
+- Name: >-
+    自由
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=ZDC9LWRcY1g)
 Suffix Directory: true
 Reference By Directory: outside album
 Duration: 1:54
@@ -1432,6 +1873,10 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Bring It In, Guys!
+- Name: >-
+    全員、集合！
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=qOQz2gfWGaw)
 Duration: 4:12
 URLs:
 - https://www.youtube.com/watch?v=uxmzr8pNGDU
@@ -1450,6 +1895,10 @@ Referenced Tracks:
 - Once Upon a Time
 ---
 Track: Last Goodbye
+- Name: >-
+    これでホントにサヨナラ
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=oiaO05_ImsA)
 Duration: 2:15
 URLs:
 - https://www.youtube.com/watch?v=EpBQ5m3Ag3Q
@@ -1467,6 +1916,10 @@ Referencing Sources:
     Refer to [[Hopes and Dreams]] for a detailed record of discussion about the presence of [[Penumbra Phantasm]] in this track, that one, and [[SAVE the World]].
 ---
 Track: But the Earth Refused to Die
+- Name: >-
+    BUT THE EARTH REFUSED TO DIE
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=WBPw2OOfzRM)
 Duration: 0:34
 URLs:
 - https://www.youtube.com/watch?v=O6pph2RMoPU
@@ -1475,6 +1928,10 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Battle Against a True Hero
+- Name: >-
+    本物のヒーローとの戦い
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=Bzw9yLkLVJg)
 Duration: 2:36
 URLs:
 - https://www.youtube.com/watch?v=DcERQHg3iy8
@@ -1483,6 +1940,10 @@ Referenced Tracks:
 - Ruins
 ---
 Track: Power of "NEO"
+- Name: >-
+    "NEO"の力
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=gXLA6GKdmEg)
 Duration: 0:30
 URLs:
 - https://www.youtube.com/watch?v=bWUIWTkBiqE
@@ -1500,6 +1961,10 @@ Referenced Tracks:
 - track:megalovania-ebhh
 ---
 Track: Good Night
+- Name: >-
+    おやすみなさい
+  Annotation: >-
+    [Japanese release](https://music.youtube.com/watch?v=2NvL8Z0lpCo)
 Duration: 0:31
 URLs:
 - https://www.youtube.com/watch?v=a9-7h0NmMn8

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -294,6 +294,7 @@ Content: |-
     <!-- art tag additions -->
     - added character tags: [[tag:ethan-adminstuck]], [[tag:jackson-adminstuck]], [[tag:jane-dave-janestuck]], [[tag:jane-jade-janestuck]], [[tag:jane-john-janestuck]], [[tag:jane-rose-janestuck]], [[tag:jane-roxy-janestuck]], [[tag:jordan-adminstuck]], [[tag:matt-adminstuck]] (thanks, Lan, Lilith!)
     <!-- additional name additions -->
+    - added Japanese-release additional names across [[group:undertale-and-deltarune]] as well as [[artist:pokemon]] album releases (thanks, ruby!)
     - added additional names to tracks: (thanks, Lan, Jackie, Whisper, Lilith!)
         - across [[album:cookiefonsters-2016-famitracker-covers]] (Bandcamp, YouTube, SoundCloud)
         - [[track:squiddle-march]] and [[track:dord-waltz]] (SoundCloud)


### PR DESCRIPTION
adds Additional Names for UNDERTALE, DELTARUNE, and Pokémon soundtrack albums.

for UTDR: Japanese Additional Names have only been added to albums with a distinct Japanese release. for the main game soundtracks this means that UNDERTALE Soundtrack, and the individual DELTARUNE Chapter OSTs have JP titles, as the Steam "DELTARUNE Soundtrack" does not have a Japanese version released. this also adds the *actual* titles for the Nintendo Dream enclosure CDs instead of the "translated" ones, as Additional Names.

for Pokémon: as it stands, the titles are based on the Nintendo Music localizations (and based on Pokémon localization standards for the few that aren't), with the Japanese titles being shared across the physical CD releases and the Japanese version of Nintendo Music,