### PR TITLE
fix Harmonize (CANMT) referencing Ruins (With Strings) instead of Ruins (UNDERTALE)

### DIFF
--- a/album/cool-and-new-volume-s-x.yaml
+++ b/album/cool-and-new-volume-s-x.yaml
@@ -2156,7 +2156,7 @@ Referenced Tracks:
 - CONTACT
 - Descend
 - track:dr-pepper
-- Ruins (With Strings)
+- track:ruins-undertale
 - 'Deaf Injustice: Ignoration!!'
 - Oppa Toby Style
 - Madame Controversielle

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -498,6 +498,7 @@ Content: |-
     - fixed [[track:rise-of-the-denizens]] not sampling [[track:upward-movement-dave-owns]] in addition to referencing it, and referencing [[track:cascade]] instead of sampling [[track:savior-of-the-dreaming-dead-cascade-cut]] (thanks, Makin, Lan!)
     - fixed [[track:the-metamorphosis-of-rose-lalonde]] not referencing individual movement tracks ([[track:the-metamorphosis-treading-the-line]], [[track:the-metamorphosis-harbinger-of-the-outer-gods]], [[track:the-metamorphosis-the-solar-ascendancy]]; thanks, Lilith!)
     - fixed [[track:dream-around]] not referencing [[track:english]] (thanks, Lan!)
+    - fixed [[track:harmonize-canmt]] referencing [[track:ruins-with-strings]] instead of [[track:ruins-undertale]] (thanks, Makin, Lilith!)
     - fixed [[track:bowstutzlogic]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:lore-2-the-revengning]] and [[track:savior-of-a-lot-of-money]] not sampling [[track:your-bed]] (thanks, Lilith!)
     - fixed [[track:secretz-barz]] not sampling [[track:your-bed]] (thanks, Lilith!)


### PR DESCRIPTION
Fixes [Harmonize (CANMT)](https://preview.hsmusic.wiki/track/harmonize-canmt/) referencing [Ruins (With Strings)](https://preview.hsmusic.wiki/track/ruins-with-strings/) instead of [Ruins](https://preview.hsmusic.wiki/track/ruins-undertale/) (from UNDERTALE); thanks, Makin!