### PR TITLE
Add URLs for Paul Dochney/dril

### DIFF
--- a/artists.yaml
+++ b/artists.yaml
@@ -11287,6 +11287,8 @@ Artist: Patti LuPone
 Artist: Patty Hill
 ---
 Artist: Paul Dochney
+Aliases:
+- dril
 URLs:
 - https://bsky.app/profile/dril.bsky.social
 - https://twitter.com/dril

--- a/artists.yaml
+++ b/artists.yaml
@@ -11287,6 +11287,10 @@ Artist: Patti LuPone
 Artist: Patty Hill
 ---
 Artist: Paul Dochney
+URLs:
+- https://bsky.app/profile/dril.bsky.social
+- https://twitter.com/dril
+- https://linktr.ee/drilreal
 ---
 Artist: Paul Francis Webster
 ---


### PR DESCRIPTION
This link was made by the fandom back in 2017 and was controversial to the point of getting /r/homestuck linked in a mainstream publication, but he has publicly acknowledged it and seems to dislike people avoiding the subject (["Maybe people need to grow up. Just accept that I’m not like Santa Claus. I’m not a magic elf who posts."](https://www.theringer.com/2023/04/12/tech/dril-twitter-interview-profile-identity)).