### PR TITLE
replace YouTube URLs for Skaia Voyages and Mother (Malcolm Brown) with standalone uploads

### DIFF
--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -1163,7 +1163,7 @@ Artists:
 - Malcolm Brown
 Duration: 2:09
 URLs:
-- https://youtu.be/4AILbcNRy-k?t=2086
+- https://www.youtube.com/watch?v=zJXTl8eWmIk
 Referenced Tracks:
 - Black Rose / Green Sun
 - Aggrieve
@@ -1623,7 +1623,7 @@ Artists:
 - Seth Peelle
 Duration: 1:12
 URLs:
-- https://youtu.be/gbiS4WkCOVo?t=18066
+- https://www.youtube.com/watch?v=iacW0L8-DRw
 - https://media.hsmusic.wiki/misc/archive/Skaia%20Voyages.mp3
 Referenced Tracks:
 - Sburban Jungle

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -362,6 +362,7 @@ Content: |-
     - added Apple Music and Spotify listening links to [[track:pushing-onwards]] (thanks, Lilith!)
     - replaced YouTube listening link for [[track:orange-hat]] with artist's upload (thanks, Lilith, Lan!)
     - replaced YouTube listening links for [[track:solar-voyage]] and [[track:renewed-return]] with artist's uploads (thanks, wertercatt, Lan!)
+    - replaced YouTube listening links for [[track:mother-malcolm-brown]] and [[track:skaia-voyages]] with standalone uploads (thanks, Makin, Lilith!)
     - replaced Spotify listening links for [[track:celestial]], [[album:rakka-wake-01-opening-me]], and [[album:rakka-sp1-outside-2]] with link to single, rather than track (thanks, Lan, Whisper!)
     - replaced YouTube listening link for [[track:danger-on-the-dance-floor-mid-boss]] with official upload (thanks, ruby!)
     - added wiki archive listening links to [[track:do-the-homestuck-demo]] and [[track:lets-read-a-webcomic]] (thanks, Lan!)


### PR DESCRIPTION
replaces the YouTube URLs for Skaia Voyages and Mother (Malcolm Brown) with standalone YouTube uploads; thanks, [blanked]!