### PR TITLE
Referencing fixes: English not referencing Expiration Date

### DIFF
--- a/album/more-homestuck-fandom.yaml
+++ b/album/more-homestuck-fandom.yaml
@@ -548,6 +548,29 @@ Lyrics: |-
 
     Oh, Nick Smalley guitar solo
 ---
+Track: Expiration Date
+Artists:
+- Toby Fox
+Duration: 1:33
+URLs:
+- https://www.tumblr.com/pieckestucasa/663790996736393216/fwugradiation-i-wrote-this-during-the-first
+- https://www.youtube.com/watch?v=GWb9Envv8oo
+- https://media.hsmusic.wiki/misc/archive/Expiration%20Date.mp3
+Referenced Tracks:
+- Toccata and Fugue in D minor
+Commentary: |-
+    <i>Toby Fox:</i> ([Tumblr](https://www.tumblr.com/pieckestucasa/663790996736393216/fwugradiation-i-wrote-this-during-the-first), 11/8/2011)
+
+    I wrote this during the first Homestuck Intermission as a theme for Lord English. I called it “Expiration Date.” I’m certain there will be another song called “Expiration Date” at some point, just because it’s the most badass time-related name.
+
+    Mostly I’m posting this here for trivia’s sake (look how long ago [[English|these melodies can incubate]]), and also because wow I’ve gotten a lot better in 2 years, huh.
+Referencing Sources: |-
+    <i>Lilithtreasure:</i> (wiki editor, 5/2/2026)
+
+    So reversing the track at 1:02-1:13 reveals that [[Toccata and Fugue in D minor]] is in this, albeit in a sort of scrambled fashion.
+
+    <audio src="media/misc/expiration-date-reversed-snippet.mp3" inline></audio>
+---
 Track: Exploring the Depths of Sburb
 Artists:
 - Thomas Ferkol

--- a/album/the-felt.yaml
+++ b/album/the-felt.yaml
@@ -498,6 +498,10 @@ Referencing Sources: |-
     <i>Erase:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1471209163878043769), 2/11/2026)
 
     shouldnt english have [[Expiration Date|expiration date]] as a reference cuz toby said he made it back during the intermission
+
+    <i>Toby Fox:</i> ([Tumblr](https://www.tumblr.com/pieckestucasa/663790996736393216/fwugradiation-i-wrote-this-during-the-first) re: [[Expiration Date]], 11/8/2011)
+
+    I wrote this during the first Homestuck Intermission as a theme for Lord English. I called it “Expiration Date.” [...] Mostly I’m posting this here for trivia’s sake (look how long ago these melodies can incubate), and also because wow I’ve gotten a lot better in 2 years, huh.
 ---
 Track: Variations
 Artists:

--- a/album/the-felt.yaml
+++ b/album/the-felt.yaml
@@ -484,6 +484,8 @@ Duration: 3:30
 URLs:
 - https://homestuck.bandcamp.com/track/english
 - https://www.youtube.com/watch?v=6zMnNCDaKuE
+Referenced Tracks:
+- Expiration Date
 Sheet Music Files:
 - Title: Piano score by almostsix
   Files:
@@ -492,6 +494,10 @@ MIDI Project Files:
 - Title: MIDI by seekercat
   Files:
   - 'English - seekercat.mid'
+Referencing Sources: |-
+    <i>Erase:</i> ([HSMusic Discord](https://discord.com/channels/749042497610842152/1353743089164095548/1471209163878043769), 2/11/2026)
+
+    shouldnt english have [[Expiration Date|expiration date]] as a reference cuz toby said he made it back during the intermission
 ---
 Track: Variations
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -398,6 +398,7 @@ Content: |-
     <!-- referencing source additions -->
     - added MSPA news post referencing source to [[track:black]] (thanks, Lilith!)
     - added various referencing sources to [[track:dissension-remix]], [[track:white]], [[track:octoroon-rangoon]], [[track:clockwork-sorrow]], [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] (thanks, Lan!)
+    - added Discord referencing sources to [[track:english]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:good-old-hornless-jerryatric]] and [[track:the-worlds-heel]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:teleports-behind-you]] (thanks, Lan!)
     - added Discord referencing sources to [[track:twice-as-bright]], [[track:flyfish]], [[track:in-it-to-win-it]], and [[track:spiritstriker]] (thanks, Lilith!)
@@ -540,6 +541,7 @@ Content: |-
     - fixed [[track:white]] not referencing [[track:skies-of-skaia]] (thanks, HunZhen!)
     - fixed [[track:versus]] not referencing [[track:sunsetter]] (thanks, Erase, Lilith, Lan, plus Rainy, Pascal, Jebb!)
     - fixed [[track:sunsetter]] not referencing [[track:hawkeye]] (was the other way around; thanks, Erase, Lan!)
+    - fixed [[track:english]] not referencing [[track:expiration-date]] (thanks, Erase, Lilith!)
     - fixed [[track:earthsea-borealis]] not referencing [[track:double-midnight]] (thanks, Grace, Interrobang, Lilith!)
     - fixed [[track:frog-hunt]] not referencing [[track:homestuck-anthem]] (thanks, Bowman, Celeste, Lilith!)
     - fixed [[track:additional-mayhem-universe-a]] ([[album:coloUrs-and-mayhem-universe-a]]) not referencing [[track:non-compos-mentis]] (thanks, Erase, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -398,7 +398,7 @@ Content: |-
     <!-- referencing source additions -->
     - added MSPA news post referencing source to [[track:black]] (thanks, Lilith!)
     - added various referencing sources to [[track:dissension-remix]], [[track:white]], [[track:octoroon-rangoon]], [[track:clockwork-sorrow]], [[track:hopes-and-dreams]], [[track:save-the-world]], and [[track:last-goodbye]] (thanks, Lan!)
-    - added Discord referencing sources to [[track:english]] (thanks, Lilith!)
+    - added Discord and Tumblr referencing sources to [[track:english]] (thanks, Erase, Lilith, Lan!)
     - added Discord referencing sources to [[track:good-old-hornless-jerryatric]] and [[track:the-worlds-heel]] (thanks, Lilith!)
     - added Discord referencing sources to [[track:teleports-behind-you]] (thanks, Lan!)
     - added Discord referencing sources to [[track:twice-as-bright]], [[track:flyfish]], [[track:in-it-to-win-it]], and [[track:spiritstriker]] (thanks, Lilith!)


### PR DESCRIPTION
Fixes English not referencing Expiration Date; thanks, Erase!

Merge with: [hsmusic-media#201 archive additions: Expiration Date
](https://github.com/hsmusic/hsmusic-media/pull/201)