### PR TITLE
Flash addition: [S] Antebellum: Recite. from Vast Error

### DIFF
--- a/flashes.yaml
+++ b/flashes.yaml
@@ -5063,6 +5063,16 @@ Crediting Sources: |-
     [[artist:silentneptune]], [[artist:gast]],<br>
     [[artist:apsinthos]] and [[artist:diz]].
 ---
+Flash: '[S] Antebellum: Recite.'
+Directory: antebellum-recite
+Date: May 3, 2026
+Cover Art File Extension: png
+Featured Tracks:
+- track:the-stars-speak-back
+URLs:
+- https://www.deconreconstruction.com/vasterror/2496
+- https://www.youtube.com/watch?v=JCbgRe87Yc8
+---
 Act: More fan adventures
 Color: '#ff7093'
 Directory: more-fan-adventures

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -244,11 +244,11 @@ Content: |-
         - added [[album:deltarune-ch2-rejected-tracks]]!
     <h3>other additions</h3>
     <!-- flash additions -->
+    - added [[flash-act:vast-error]] flashes (thanks, Lilith!)
     - added [[flash:6943]] (thanks, Meulanie, Lavender!)
     - added [[flash:7823]] (thanks, AirPrime, Lilith!)
     - added [[flash:darkcage]] and [[flash:darkcage2]] secret pages (thanks, Tangle!)
     - added [[flash:combustion]] and [[flash:body-mind-soul]] flashes from [[group:desynced]] (thanks, Jebb!)
-    - added [[flash:antebellum-recite]] to [[flash-act:vast-error]] flashes (thanks, Lilith!)
     - added [[flash:street-strifer-op-movie]] (thanks, ruby, Makin, Lan!)
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
     <!-- track additions -->
@@ -1962,7 +1962,6 @@ Content: |-
     <!-- flashes -->
     - added [[flash:plink-strife]] to [[flash-act:loftlocked]] flashes (thanks, Lilith!)
     - added [[flash-act:freeroam]] flashes (thanks, Lilith!)
-    - added [[flash-act:vast-error]] flashes (thanks, Lilith!)
     - added [[flash-act:snowbound-blood]] game (thanks, Lilith, Lavender, wertercatt!)
     - added [[flash:cascade-reanimated]] and [[flash:the-man-in-the-cairo-overcoat]] animations (thanks, Jebb!)
     <!-- tracks -->

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -248,6 +248,7 @@ Content: |-
     - added [[flash:7823]] (thanks, AirPrime, Lilith!)
     - added [[flash:darkcage]] and [[flash:darkcage2]] secret pages (thanks, Tangle!)
     - added [[flash:combustion]] and [[flash:body-mind-soul]] flashes from [[group:desynced]] (thanks, Jebb!)
+    - added [[flash:antebellum-recite]] to [[flash-act:vast-error]] flashes (thanks, Lilith!)
     - added [[flash:street-strifer-op-movie]] (thanks, ruby, Makin, Lan!)
     - added [[flash:sweet-rave-party2]] art collab (thanks, Lan!)
     <!-- track additions -->


### PR DESCRIPTION
Adds the newly released [[S] Antebellum: Recite.](https://www.deconreconstruction.com/vasterror/2496) from Vast Error to HSMusic's collection of Vast Error flashes!

Merge with: https://github.com/hsmusic/hsmusic-media/pull/202