### PR TITLE
section change, for 黄泉津比良坂CORRUPTION (no longer name fix)

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -11893,6 +11893,29 @@ Lyrics: |-
     And in your reality, if I don't know how to love you
     I'll leave you be
 ---
+Track: 黄泉津比良坂CORRUPTION
+# uh oh god there's two of them, official releases i mean
+# so it was first released on Enri Edo (厭離穢土), predating its usage in Umineko When They Cry chiru in 2010
+# but the more well-known release is the compilation album, Amrita (アムリタ)
+# i know it probably doesn't make sense to have two official release references on here, but i mean considering these are comments, we might as well
+# Official release A:
+#   Enri Edo
+#   厭離穢土
+# Reference A:
+#   https://vgmdb.net/album/89397
+# Official release B:
+#   Amrita
+#   アムリタ
+# Reference B:
+#   https://vgmdb.net/album/14778
+Directory: yomitsu-hirasaka-corruption
+Artists:
+- Umineko When They Cry
+- '-45'
+Duration: 4:49
+URLs:
+- https://www.youtube.com/watch?v=rKfmGqlp8D4
+---
 Section: Music composed for movies, television, and other visual arts
 ---
 Track: $64,000 Question
@@ -51491,14 +51514,6 @@ Lyrics: |-
 Commentary: |-
     <i>Niklink:</i> (wiki editor, 11/19/2022)
     Track name translates to "Lisa Frank 420 / Modern Computing" ("Risa Furanku 420 / Gendai no Konpyū").
----
-Track: 黄泉津比良坂CORRUPTION
-Directory: yomitsu-hirasaka-corruption
-Artists:
-- '-45'
-Duration: 4:49
-URLs:
-- https://www.youtube.com/watch?v=rKfmGqlp8D4
 ---
 Section: Other works originating outside of Homestuck
 Color: '#8ccaf1'

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -566,6 +566,7 @@ Content: |-
     - moved [[track:lets-read-a-webcomic]] from [[album:references-beyond-homestuck]] to [[album:more-homestuck-fandom]] (thanks, Lan!)
     - moved [[track:falling-for-ghosts]] and [[track:fruity-pebbles-jingle]] from "Miscellany by Homestuck musicians" to "Other music originating outside Homestuck" (thanks, cookiefonster, Lavender!)
     - moved [[track:bad-apple-lovelight]] (feat. [[artist:nomico]]) from "Music from video games" to "Other music originating outside Homestuck" (thanks, Lan, bit!)
+    - moved [[track:yomitsu-hirasaka-corruption]] from "Other music originating outside Homestuck" to "Music from video games" (thanks, Lilith, ruby, Lan!)
     <!-- general removals -->
     - removed [[album:references-beyond-homestuck]] track "Settings (Wii Fit)" since it's part of [[track:main-menu-wii-fit]] (thanks, ruby!)
     - removed "(…) - Single" additional names automatically enforced on Apple Music and iTunes platforms, affecting [[track:black-richaadeb]], [[track:heir-of-grief-richaadeb]], [[track:dance-of-thorns-richaadeb]], [[track:oppa-toby-style]] (all [[artist:richaadeb]]), and [[album:dreamers-diarchy]] (thanks, Whisper, ruby!)


### PR DESCRIPTION
Moves -45's 黄泉津比良坂CORRUPTION ~~(was going to be renamed Yomitsu Hirasawa CORRUPTION; with the JP name moved to additional names)~~ from "Other music originating outside Homestuck" to "Music from video games", and adds the "Umineko When They Cry" (franchise) artist to the track as well.

Thanks, ruby, and Lan!