### PR TITLE
RBH: move sonic electronic from music from video games to other music originating outside homestuck

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -9418,70 +9418,6 @@ URLs:
 - https://m.nintendo.com/shared/US/tracks/037c8a8a-3510-47b9-9dae-e085d5a8be4c
 - https://www.youtube.com/watch?v=m86VCw2JqOE
 ---
-Track: Sonic Electronic
-# This is from officially licensed album of Sonic-themed music from Germany, none of which is related to actual in-game music in any way.
-# Official release:
-#   Sonic The Hedgehog
-# Reference
-#   https://vgmdb.net/album/2054
-Artists:
-- Sonic the Hedgehog
-- Emerald Hill
-- Spike Shellcracker
-- Oscar Oberheim
-Duration: 3:07
-URLs:
-- https://www.youtube.com/watch?v=MkdbN7xDkAM
-Lyrics: |-
-    Ding, ding, ding
-    Get the ring, ring, ring
-    I'm the Sonic Electronic and I'm gonna be the king
-    To the ring, ring, ring
-    Take a ding, ding, ding
-    When you really score me high, set me free and we will fly
-
-    La la la
-    Lala la la la
-    Lala la la lalalala lalalalala
-    Lala la la la
-    Lala la la la
-    Lala la la lalalala lalalalala
-
-    Ding, ding, ding
-    Get the ring, ring, ring
-    I'm the Sonic Electronic and I'm gonna be the king
-    To the ring, ring, ring
-    Take a ding, ding, ding
-    When you really score me high, set me free and we will fly
-
-    Ding, ding, ding
-    Get the ring, ring, ring
-    I'm the Sonic Electronic and I'm gonna be the king
-    To the ring, ring, ring
-    Take a ding, ding, ding
-    When you really score me high, we will take another try
-
-    La la la
-    Lala la la la
-    Lala la la lalalala lalalalala
-    Lala la la la
-    Lala la la la
-    Lala la la lalalala lalalalala
-
-    Ding, ding, ding
-    Get the ring, ring, ring
-    I'm the Sonic Electronic and I'm gonna be the king
-    To the ring, ring, ring
-    Take a ding, ding, ding
-    When you really score me high, set me free and we will fly
-
-    La la la
-    Lala la la la
-    Lala la la lalalala lalalalala
-    Lala la la la
-    Lala la la la
-    Lala la la lalalala lalalalala
----
 Track: Soul 0 System
 # JP: Soul 0 System～回歴スル追約ノ忘レ貝
 # Official release:
@@ -44147,6 +44083,70 @@ Lyrics: |-
     05768
     394338
     75021...
+---
+Track: Sonic Electronic
+# This is from officially licensed album of Sonic-themed music from Germany, none of which is related to actual in-game music in any way.
+# Official release:
+#   Sonic The Hedgehog
+# Reference
+#   https://vgmdb.net/album/2054
+Artists:
+- Sonic the Hedgehog
+- Emerald Hill
+- Spike Shellcracker
+- Oscar Oberheim
+Duration: 3:07
+URLs:
+- https://www.youtube.com/watch?v=MkdbN7xDkAM
+Lyrics: |-
+    Ding, ding, ding
+    Get the ring, ring, ring
+    I'm the Sonic Electronic and I'm gonna be the king
+    To the ring, ring, ring
+    Take a ding, ding, ding
+    When you really score me high, set me free and we will fly
+
+    La la la
+    Lala la la la
+    Lala la la lalalala lalalalala
+    Lala la la la
+    Lala la la la
+    Lala la la lalalala lalalalala
+
+    Ding, ding, ding
+    Get the ring, ring, ring
+    I'm the Sonic Electronic and I'm gonna be the king
+    To the ring, ring, ring
+    Take a ding, ding, ding
+    When you really score me high, set me free and we will fly
+
+    Ding, ding, ding
+    Get the ring, ring, ring
+    I'm the Sonic Electronic and I'm gonna be the king
+    To the ring, ring, ring
+    Take a ding, ding, ding
+    When you really score me high, we will take another try
+
+    La la la
+    Lala la la la
+    Lala la la lalalala lalalalala
+    Lala la la la
+    Lala la la la
+    Lala la la lalalala lalalalala
+
+    Ding, ding, ding
+    Get the ring, ring, ring
+    I'm the Sonic Electronic and I'm gonna be the king
+    To the ring, ring, ring
+    Take a ding, ding, ding
+    When you really score me high, set me free and we will fly
+
+    La la la
+    Lala la la la
+    Lala la la lalalala lalalalala
+    Lala la la la
+    Lala la la la
+    Lala la la lalalala lalalalala
 ---
 Track: Sorrow In a Pacifist Pillbox
 Artists:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -576,6 +576,7 @@ Content: |-
     - moved [[track:falling-for-ghosts]] and [[track:fruity-pebbles-jingle]] from "Miscellany by Homestuck musicians" to "Other music originating outside Homestuck" (thanks, cookiefonster, Lavender!)
     - moved [[track:bad-apple-lovelight]] (feat. [[artist:nomico]]) from "Music from video games" to "Other music originating outside Homestuck" (thanks, Lan, bit!)
     - moved [[track:yomitsu-hirasaka-corruption]] from "Other music originating outside Homestuck" to "Music from video games" (thanks, Lilith, ruby, Lan!)
+    - moved [[track:sonic-electronic]] from "Music from video games" to "Other music originating outside Homestuck" (thanks, ruby, Lilith!)
     <!-- general removals -->
     - removed [[album:references-beyond-homestuck]] track "Settings (Wii Fit)" since it's part of [[track:main-menu-wii-fit]] (thanks, ruby!)
     - removed "(…) - Single" additional names automatically enforced on Apple Music and iTunes platforms, affecting [[track:black-richaadeb]], [[track:heir-of-grief-richaadeb]], [[track:dance-of-thorns-richaadeb]], [[track:oppa-toby-style]] (all [[artist:richaadeb]]), and [[album:dreamers-diarchy]] (thanks, Whisper, ruby!)


### PR DESCRIPTION
moves sonic electronic from music from video games to other music originating outside homestuck.

thanks, ruby!