### PR TITLE
track fixes for Mother series (Sanctuary Guardian references Battle Theme 3, Smiles and Tears ref. both Eight Melodies, Choose a File references Twinkle Elementary School

### DIFF
--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -10034,9 +10034,30 @@ Referenced Tracks:
 - Eight Melodies (EarthBound)
 - Eight Melodies (EarthBound Beginnings)
 Lyrics: |-
-    I miss you...
-Commentary: |-
-    @@ ([Full lyrics!](https://web.archive.org/web/20221206064929/https:/earthboundcentral.com/2009/01/smiles-tears-lyrics/))
+    @@ [Itoi's lyrics](https://web.archive.org/web/20221206064929/https:/earthboundcentral.com/2009/01/smiles-tears-lyrics/)
+
+    Otonatachi no hanbun mo ikitewa inai keredo
+    omoide no kazu naraba ryukku ni ippai sa
+    o ki ni iri no besubooru kyappu kakato tsubureta suniikaa
+    poketto no oku ni aru yo surihetta gitaa pikku
+    namida ga chigireru kurai kanashii koto mo atta kedo
+    itsudemo kimi ga boku no soba ni itekureta
+    tomodachi no mama iru to futari zutto omotteta
+    kizukanai mama tabun kimi o ai shiteta
+
+    warai attari asondari kizu tsukinagara aruku
+    chikamichi mawari michi mo mayoinagara oboeta
+    shinjirareru hito dake iru wake nai to shitemo
+    shinjiru haato dake wa suterarenai to shitta
+    ari no mama no kimi dake ga boku o tsuyoku shitekureta
+    itsudemo kimi ga boku o tsuyoku shitekureta
+    yasashii kaze ga fuku yoo ni kusa o nadeteiku yoo ni
+    itsudemo kimi wa egao misete aruiteta
+
+    soo namida to egao kawarugawaru ni
+    miseatta futari wa...
+    I miss you
+    tooku ni hanarete
 ---
 Track: Snake Eater
 # Reference:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -3150,7 +3150,8 @@ Duration: 2:04
 URLs:
 - https://www.youtube.com/watch?v=2jxRBxUSvCo
 ---
-Track: Battle Theme 3 (EarthBound Beginnings)
+Track: Battle Theme 3
+Name Detail: EarthBound Beginnings
 # Reference:
 #   https://vgmdb.net/album/106653
 Artists:
@@ -5077,7 +5078,8 @@ URLs:
 Referenced Tracks:
 - Fist Bump
 ---
-Track: Eight Melodies (EarthBound)
+Track: Eight Melodies
+Name Detail: EarthBound
 # no official standalone release
 Artists:
 - Mother
@@ -5086,7 +5088,8 @@ Artists:
 URLs:
 - https://www.youtube.com/watch?v=W8WSZwX2xhg
 ---
-Track: Eight Melodies (EarthBound Beginnings)
+Track: Eight Melodies
+Name Detail: EarthBound Beginnings
 # Reference
 #   https://vgmdb.net/album/106653
 Artists:

--- a/album/references-beyond-homestuck.yaml
+++ b/album/references-beyond-homestuck.yaml
@@ -3150,6 +3150,16 @@ Duration: 2:04
 URLs:
 - https://www.youtube.com/watch?v=2jxRBxUSvCo
 ---
+Track: Battle Theme 3 (EarthBound Beginnings)
+# Reference:
+#   https://vgmdb.net/album/106653
+Artists:
+- Mother
+- Hirokazu Tanaka
+Duration: 1:50
+URLs:
+- https://www.youtube.com/watch?v=avPBaQ7vWw8
+---
 Track: Battle Theme (Yūyūki)
 Directory: battle-theme-yuyuki
 # Reference:
@@ -3931,6 +3941,8 @@ Artists:
 Duration: 1:10
 URLs:
 - https://www.youtube.com/watch?v=CYzTLzhnMLM
+Referenced Tracks:
+- Twinkle Elementary School
 ---
 Track: Chrono Cross ~Scars of Time~
 # (See Corridors of Time for info on soundtrack/YouTube differences)
@@ -5065,7 +5077,16 @@ URLs:
 Referenced Tracks:
 - Fist Bump
 ---
-Track: Eight Melodies
+Track: Eight Melodies (EarthBound)
+# no official standalone release
+Artists:
+- Mother
+- Keiichi Suzuki
+- Hirokazu Tanaka
+URLs:
+- https://www.youtube.com/watch?v=W8WSZwX2xhg
+---
+Track: Eight Melodies (EarthBound Beginnings)
 # Reference
 #   https://vgmdb.net/album/106653
 Artists:
@@ -5074,7 +5095,7 @@ Artists:
 - Hirokazu Tanaka
 Duration: 1:17
 URLs:
-- https://www.youtube.com/watch?v=W8WSZwX2xhg
+- https://www.youtube.com/watch?v=-OaWAEhWZ28
 ---
 Track: The End (Chapter 1)
 Artists:
@@ -5901,7 +5922,7 @@ URLs:
 - https://nigoro.bandcamp.com/track/giants-cry-2
 ---
 Track: Giygas Disintegrates
-# (See Eight Melodies, no official soundtrack release)
+# (See Eight Melodies (EarthBound), no official soundtrack release)
 Artists:
 - Mother
 - Keiichi Suzuki
@@ -8279,7 +8300,7 @@ URLs:
 - https://www.youtube.com/watch?v=ql8K3KJyWgY
 ---
 Track: One Fateful Night
-# (See Eight Melodies, no official soundtrack release)
+# (See Eight Melodies (EarthBound), no official soundtrack release)
 Artists:
 - Mother
 - Keiichi Suzuki
@@ -9620,6 +9641,8 @@ Artists:
 Duration: 2:11
 URLs:
 - https://www.youtube.com/watch?v=A_Gj-RJeeng
+Referenced Tracks:
+- Battle Theme 3 (EarthBound Beginnings)
 ---
 Track: Sand Ocean
 # Reference:
@@ -9997,18 +10020,20 @@ URLs:
 - https://www.youtube.com/watch?v=2p9aPeTnXeI
 ---
 Track: Smiles and Tears
-# (See Eight Melodies, no official soundtrack release)
+# (See Eight Melodies (EarthBound), no official soundtrack release)
 Artists:
 - Mother
 - Keiichi Suzuki
 - Hirokazu Tanaka
 URLs:
 - https://www.youtube.com/watch?v=vkAmD8A3CRk
+Referenced Tracks:
+- Eight Melodies (EarthBound)
+- Eight Melodies (EarthBound Beginnings)
 Lyrics: |-
     I miss you...
 Commentary: |-
-    <i>Mother:</i>
-    ([Full lyrics!](https://earthboundcentral.com/2009/01/smiles-tears-lyrics/))
+    @@ ([Full lyrics!](https://web.archive.org/web/20221206064929/https:/earthboundcentral.com/2009/01/smiles-tears-lyrics/))
 ---
 Track: Snake Eater
 # Reference:
@@ -10443,7 +10468,7 @@ URLs:
 - https://www.youtube.com/watch?v=oLOyVDP_ckQ
 ---
 Track: Super Dry Dance
-# (See Eight Melodies, no official soundtrack release)
+# (See Eight Melodies (EarthBound), no official soundtrack release)
 Artists:
 - Mother
 - Keiichi Suzuki
@@ -11609,7 +11634,7 @@ URLs:
 - https://www.youtube.com/watch?v=_K9-SwNBMSY
 ---
 Track: What a Great Picture!
-# (See Eight Melodies, no official soundtrack release)
+# (See Eight Melodies (EarthBound), no official soundtrack release)
 Artists:
 - Mother
 - Keiichi Suzuki
@@ -11841,7 +11866,7 @@ URLs:
 - https://www.youtube.com/watch?v=zWNkD4YWt_c
 ---
 Track: You Gained a Level!
-# (See Eight Melodies, no official soundtrack release)
+# (See Eight Melodies (EarthBound), no official soundtrack release)
 Artists:
 - Mother
 - Keiichi Suzuki

--- a/album/super-smash-bros-ultimate.yaml
+++ b/album/super-smash-bros-ultimate.yaml
@@ -895,7 +895,7 @@ Artists:
 Duration: 2:31
 Referenced Tracks:
 - track:fourside
-- Eight Melodies
+- track:eight-melodies-earthbound
 ---
 Section: Fire Emblem
 Color: '#adadad'

--- a/album/unreleased-tracks.yaml
+++ b/album/unreleased-tracks.yaml
@@ -222,7 +222,7 @@ URLs:
 - https://www.youtube.com/watch?v=fy6SMhEBSBk
 Referenced Tracks:
 - You Gained a Level!
-- Eight Melodies
+- track:eight-melodies-earthbound
 ---
 Track: Nic Cage Romance
 Additional Names:

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -747,8 +747,11 @@ Content: |-
     - fixed [[track:sburban-cartdown]] not sampling [[track:sburban-countdown]] in addition to referencing it (thanks, Lavender!)
     - fixed [[track:findher]] not referencing [[track:lost-girl]] (thanks, vriska, ruby!)
     - fixed [[track:radiation-is-now-on-youtube]] referencing [[track:bro-hop]] instead of sampling it (thanks, Lilith, Jackie!)
+    - fixed [[track:choose-a-file]] not referencing [[track:twinkle-elementary-school]] (thanks, Lilith!)
     - fixed [[track:destiny-ablaze]] not referencing [[track:destiny-fire-emblem-awakening]] (thanks, ruby!)
     - fixed [[track:prelude-ablaze]] not referencing [[track:prelude-fire-emblem-awakening]] (thanks, ruby!)
+    - fixed [[track:sanctuary-guardian]] not referencing [[track:battle-theme-3-earthbound-beginnings]] (thanks, Lilith!)
+    - fixed [[track:smiles-and-tears]] not referencing [[track:eight-melodies-earthbound]] and [[track:eight-melodies-earthbound-beginnings]] (thanks, FF, Lilith!)
     - fixed [[track:cobalt-corsair]] artwork not referencing [[track:teal-hunter]] artwork (thanks, Lan!)
     - fixed [[track:old-secret]] artwork ([[album:hiveswap-friendsim]]) not referencing [[album:hiveswap-act-1-ost]] album cover (thanks, Jackie!)
     - fixed [[track:damaras-bees-fatalism-beemix]] artwork not referencing [[track:fatalism]] (thanks, Lan!)
@@ -1067,6 +1070,7 @@ Content: |-
     - fixed broken image embed in [[track:aaaaaaaaaaaaa-post-canon-version]] (for "In the Court of the Crimson King")
     - made a handful of formatting or transcription tweaks across YouTube video commentary for [[album:of-troles-and-chiptumes]] (thanks, cookiefonster!)
     - fixed Bandcamp link in booklet commentary for [[track:dwelling-among-the-dream-bubbles]] (was to a functioning, but outdated, "the-divide-ep" URL; thanks, Lilith!)
+    - replaced dead EarthBound Central link in commentary for [[track:smiles-and-tears]] with archived link (thanks, FF, Lavender, Lilith!)
     <!-- link fixes -->
     - fixed YouTube listening link for [[track:side-1-the-nobles]] ([[album:the-nobles]], was to [[track:determination-of-a-hero]]; thanks, Vi, Lan!)
     - fixed wiki archive listening link for [[track:obligatory-drum-loop]] (was typed incorrectly, "%" instead of "%20"; thanks, Lan!)
@@ -1110,6 +1114,7 @@ Content: |-
     - changed directory of [[track:forever-now-unbeatable-demo-tapes]] from `forever-now` to `forever-now-unbeatable-demo-tapes`
     - changed directory of [[track:boutique-pokemon-sword-shield]] from `boutique` to `boutique-pokemon-sword-shield`
     - changed directory of [[track:obtained-an-item-pokemon-scarlet-violet]] from `obtained-an-item` to `obtained-an-item-pokemon-scarlet-violet`
+    - changed directory of [[track:eight-melodies-earthbound]] from `eight-melodies` to `eight-melodies-earthbound`
     - changed directory of [[track:future-people-single]] from `future-people` to `future-people-single`
     - changed directory of [[track:sleeping-in-single]] from `sleeping-in` to `sleeping-in-single`
     - changed directory of [[track:do-the-homestuck-demo]] from `do-the-homestuck` to `do-the-homestuck-demo`

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -398,6 +398,7 @@ Content: |-
     - added Bandcamp and SoundCloud lyrics to [[track:indomitable-vast-error]] (thanks, Lilith, Lan!)
     - added artist's lyrics across [[album:your-majesty]] (thanks, Lan, Whisper!)
     - added in-game lyrics to [[track:oh-one-true-love]] and [[track:oh-dungeon]] (thanks, ruby!)
+    - added Itoi's lyrics to [[track:smiles-and-tears]] (thanks, FF, Lavender, Lilith, Lan!)
     - added lyrics to [[track:the-smile-song]] (thanks, Lilith, Lan!)
     <!-- link additions -->
     - added official Bandcamp listening links for solo albums [[album:mobius-trip-and-hadron-kaleido]], [[album:sburb]], [[album:prospit-and-derse]], [[album:song-of-skaia]], [[album:one-year-older]], and [[album:genesis-frog]] (thanks, Lan!)
@@ -1070,7 +1071,6 @@ Content: |-
     - fixed broken image embed in [[track:aaaaaaaaaaaaa-post-canon-version]] (for "In the Court of the Crimson King")
     - made a handful of formatting or transcription tweaks across YouTube video commentary for [[album:of-troles-and-chiptumes]] (thanks, cookiefonster!)
     - fixed Bandcamp link in booklet commentary for [[track:dwelling-among-the-dream-bubbles]] (was to a functioning, but outdated, "the-divide-ep" URL; thanks, Lilith!)
-    - replaced dead EarthBound Central link in commentary for [[track:smiles-and-tears]] with archived link (thanks, FF, Lavender, Lilith!)
     <!-- link fixes -->
     - fixed YouTube listening link for [[track:side-1-the-nobles]] ([[album:the-nobles]], was to [[track:determination-of-a-hero]]; thanks, Vi, Lan!)
     - fixed wiki archive listening link for [[track:obligatory-drum-loop]] (was typed incorrectly, "%" instead of "%20"; thanks, Lan!)

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -1114,7 +1114,6 @@ Content: |-
     - changed directory of [[track:forever-now-unbeatable-demo-tapes]] from `forever-now` to `forever-now-unbeatable-demo-tapes`
     - changed directory of [[track:boutique-pokemon-sword-shield]] from `boutique` to `boutique-pokemon-sword-shield`
     - changed directory of [[track:obtained-an-item-pokemon-scarlet-violet]] from `obtained-an-item` to `obtained-an-item-pokemon-scarlet-violet`
-    - changed directory of [[track:eight-melodies-earthbound]] from `eight-melodies` to `eight-melodies-earthbound`
     - changed directory of [[track:future-people-single]] from `future-people` to `future-people-single`
     - changed directory of [[track:sleeping-in-single]] from `sleeping-in` to `sleeping-in-single`
     - changed directory of [[track:do-the-homestuck-demo]] from `do-the-homestuck` to `do-the-homestuck-demo`
@@ -1123,6 +1122,7 @@ Content: |-
     - changed directory of [[track:battle-rival-pokemon-black2-white2]] from `battle-rival-b2w2` to `battle-rival-pokemon-black2-white2`
     - changed directory of [[track:battle-frontier-brain-hoenn-version]] from `battle-frontier-brainhoenn-version` to `battle-frontier-brain-hoenn-version`
     - changed directory of [[track:battle-frontier-brain-hoenn-version]] from `battle-frontier-brainsinnoh-version` to `battle-frontier-brain-sinnoh-version`
+    - changed directory of [[track:eight-melodies-earthbound]] from `eight-melodies` to `eight-melodies-earthbound`
     - changed directory of [[track:bad-apple-lovelight]] from `bad-apple-feat-nomico` to `bad-apple-lovelight`
     - changed directory of [[artist:akira-series]] from `akira` to `akira-series`
     </details>


### PR DESCRIPTION
fixes Sanctuary Guardian not referencing Battle Theme 3 (from EarthBound Beginnings), Smiles and Tears not referencing both Eight Melodies tracks (thanks, FF!), adds the (EarthBound) subtitle to the preexisting Eight Melodies so it won't collide with the one from EarthBound Beginnings, and rescues the broken EarthBound Central link in Smiles and Tears' commentary (thanks, FF, and Lavender!); and also makes it artistless.

(and also adjusts Fourside and Hero's Growth's referenced tracks to point to EarthBound's Eight Melodies)

This was split from https://github.com/hsmusic/hsmusic-data/pull/875.