### PR TITLE
Face Yourself [Beta] url fix

### DIFF
--- a/album/reminders-of-you-beta.yaml
+++ b/album/reminders-of-you-beta.yaml
@@ -51,4 +51,4 @@ Referenced Tracks:
 # - Dialogue from Hazbin Hotel
 # - Mortal Kombat SFX
 URLs:
-- https://vasterror.bandcamp.com/track/side-1-who-you-were-beta
+- https://vasterror.bandcamp.com/track/face-yourself-beta

--- a/static-page/changelog.yaml
+++ b/static-page/changelog.yaml
@@ -1084,6 +1084,7 @@ Content: |-
     - fixed Bandcamp link in booklet commentary for [[track:dwelling-among-the-dream-bubbles]] (was to a functioning, but outdated, "the-divide-ep" URL; thanks, Lilith!)
     <!-- link fixes -->
     - fixed YouTube listening link for [[track:side-1-the-nobles]] ([[album:the-nobles]], was to [[track:determination-of-a-hero]]; thanks, Vi, Lan!)
+    - fixed Bandcamp listening link for [[track:face-yourself-beta]] (was to [[track:side-1-who-you-were-beta]]; thanks, Lilith!)
     - fixed wiki archive listening link for [[track:obligatory-drum-loop]] (was typed incorrectly, "%" instead of "%20"; thanks, Lan!)
     - fixed YouTube listening link for [[track:advanced-step]] (was to [CD track](https://www.youtube.com/watch?v=OW-lJdk3CY4) instead of in-game track; thanks, ruby!)
     - fixed YouTube listening link for [[track:rhythm-boxing-expert]] (was to [beginner/advanced track](https://www.youtube.com/watch?v=QdJPe21VBc0); thanks, ruby, Lavender!)


### PR DESCRIPTION
Fixes [Face Yourself [Beta]'s](https://preview.hsmusic.wiki/track/face-yourself-beta/) listening link linking to [Side 1: Who You Were [Beta]](https://preview.hsmusic.wiki/track/side-1-who-you-were-beta/).